### PR TITLE
Add location parameters management

### DIFF
--- a/src/Route/routingdata.tsx
+++ b/src/Route/routingdata.tsx
@@ -337,6 +337,11 @@ const TrackCrud = lazy(
   () => import("../components/common/academic/educational_structure/track/crud")
 );
 
+const CountryParameters = lazy(() => import("../components/common/country_parameters/index"));
+const CountryCrud = lazy(() => import("../components/common/country_parameters/country/crud"));
+const CityCrud = lazy(() => import("../components/common/country_parameters/city/crud"));
+const CountyCrud = lazy(() => import("../components/common/country_parameters/county/crud"));
+const DistrictCrud = lazy(() => import("../components/common/country_parameters/district/crud"));
 const Questionlabeling = lazy(
   () => import("../components/common/questionlabeling/table")
 );
@@ -2027,6 +2032,11 @@ export const Routedata = [
     path: `${import.meta.env.BASE_URL}pollingManagement/idareİndex`,
     element: <AdministrativeSupportTeamPage />,
   },
+  { id: 9001, path: `${import.meta.env.BASE_URL}parameters/country`, element: <CountryParameters /> },
+  { id: 9002, path: `${import.meta.env.BASE_URL}parameters/country-crud/:id?`, element: <CountryCrud /> },
+  { id: 9003, path: `${import.meta.env.BASE_URL}parameters/city-crud/:id?`, element: <CityCrud /> },
+  { id: 9004, path: `${import.meta.env.BASE_URL}parameters/county-crud/:id?`, element: <CountyCrud /> },
+  { id: 9005, path: `${import.meta.env.BASE_URL}parameters/district-crud/:id?`, element: <DistrictCrud /> },
 
 
 

--- a/src/components/common/country_parameters/city/crud.tsx
+++ b/src/components/common/country_parameters/city/crud.tsx
@@ -1,0 +1,59 @@
+import { FormikHelpers, FormikValues } from "formik";
+import { useEffect, useState } from "react";
+import { useNavigate, useParams, useLocation } from "react-router-dom";
+import ReusableModalForm, { FieldDefinition } from "../../ReusableModalForm";
+import { addCity } from "../../../../slices/cities/add/thunk";
+import { updateCity } from "../../../../slices/cities/update/thunk";
+import { showCity } from "../../../../slices/cities/show/thunk";
+import { useDispatch } from "react-redux";
+import { AppDispatch } from "../../../store";
+
+interface FormData extends FormikValues {
+  name: string;
+}
+
+export default function CityCrud() {
+  const { id } = useParams<{ id?: string }>();
+  const navigate = useNavigate();
+  const location = useLocation() as { state?: { country_id?: number } };
+  const dispatch = useDispatch<AppDispatch>();
+  const mode = id ? "update" : "add";
+  const [initialValues, setInitialValues] = useState<FormData>({ name: "" });
+
+  const getFields = (): FieldDefinition[] => [
+    { name: "name", label: "Şehir Adı", type: "text", required: true },
+  ];
+
+  useEffect(() => {
+    if (mode === "update" && id) {
+      dispatch(showCity(Number(id))).then((res: any) => {
+        if (showCity.fulfilled.match(res)) {
+          setInitialValues({ name: res.payload.cityName });
+        }
+      });
+    }
+  }, [mode, id, dispatch]);
+
+  const handleSubmit = async (values: FormData, _helpers: FormikHelpers<FormData>) => {
+    if (mode === "add") {
+      await dispatch(addCity({ ...values, country_id: location.state?.country_id || 0 }));
+    } else if (id) {
+      await dispatch(updateCity({ cityId: Number(id), payload: values }));
+    }
+    navigate("/parameters/country", { state: { country_id: location.state?.country_id } });
+  };
+
+  return (
+    <ReusableModalForm<FormData>
+      show={true}
+      title={mode === "add" ? "Şehir Ekle" : "Şehir Güncelle"}
+      fields={getFields}
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      confirmButtonLabel={mode === "add" ? "Ekle" : "Güncelle"}
+      cancelButtonLabel="Vazgeç"
+      onClose={() => navigate("/parameters/country")}
+      autoGoBackOnModalClose
+    />
+  );
+}

--- a/src/components/common/country_parameters/city/table.tsx
+++ b/src/components/common/country_parameters/city/table.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useCityTable } from "../../../hooks/city/useList";
+import { City } from "../../../../types/city/list";
+import ReusableTable, { ColumnDefinition, useDebounce } from "../../ReusableTable";
+import { deleteCity } from "../../../../slices/cities/delete/thunk";
+import { useUpdateQueryParamsFromFilters } from "../../../hooks/utilshooks/useUpdateQueryParamsFromFilters";
+
+interface CityTableProps {
+  countryId?: number;
+  enabled?: boolean;
+  onSelectCity?: (city: City) => void;
+}
+
+type QueryParams = { [x: string]: any; name: string; pageSize: number; page: number };
+
+export default function CityTable({ countryId, enabled, onSelectCity }: CityTableProps) {
+  const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState<number>(10);
+  const [inputName, setInputName] = useState("");
+  const debouncedName = useDebounce<string>(inputName, 500);
+  const [name, setName] = useState("");
+  const [filtersEnabled, setFiltersEnabled] = useState({ name: false });
+
+  const handleFilterChange = (key: string, value: any) => {
+    setFiltersEnabled((prev) => ({ ...prev, [key]: true }));
+    if (key === "name") setInputName(value);
+  };
+
+  useEffect(() => {
+    setName(debouncedName);
+  }, [debouncedName]);
+
+  const filterState = useMemo(
+    () => ({ name: name, page: 1, pageSize }),
+    [name, pageSize]
+  );
+
+  const updateQueryParams = (params: QueryParams) => {
+    const query = new URLSearchParams();
+    if (params.name) query.set("city_name", params.name);
+    navigate(`?${query.toString()}`);
+  };
+  useUpdateQueryParamsFromFilters<QueryParams>(filterState, updateQueryParams);
+
+  const params = useMemo(
+    () => ({
+      enabled: enabled,
+      paginate: pageSize,
+      page: page,
+      per_page: pageSize,
+      name: name,
+      country_id: countryId,
+    }),
+    [pageSize, page, name, countryId, enabled]
+  );
+
+  const {
+    cityData,
+    loading,
+    error,
+    setPage: updatePage,
+    setPageSize: updatePageSize,
+    data,
+  } = useCityTable(params);
+
+  const filters = useMemo(
+    () => [
+      {
+        key: "name",
+        value: inputName,
+        placeholder: "Şehir...",
+        type: "text" as const,
+        onChange: (val: string) => handleFilterChange("name", val),
+        isEnabled: filtersEnabled.name,
+      },
+    ],
+    [inputName]
+  );
+
+  const columns: ColumnDefinition<City>[] = useMemo(
+    () => [
+      { key: "name", label: "Name", render: (row) => row.name },
+      {
+        key: "actions",
+        label: "İşlemler",
+        render: (row, openDeleteModal) => (
+          <div className="flex gap-2">
+            <button
+              onClick={() => navigate(`/parameters/city-crud/${row.id}`)}
+              className="btn btn-icon btn-sm btn-info-light rounded-pill"
+            >
+              <i className="ti ti-pencil" />
+            </button>
+            <button
+              onClick={() => openDeleteModal && openDeleteModal(row)}
+              className="btn btn-icon btn-sm btn-danger-light rounded-pill"
+              style={{ marginLeft: "10px" }}
+            >
+              <i className="ti ti-trash" />
+            </button>
+            {onSelectCity && (
+              <button
+                onClick={() => onSelectCity(row)}
+                className="btn btn-icon btn-sm btn-primary-light rounded-pill"
+                style={{ marginLeft: "10px" }}
+              >
+                <i className="ti ti-check" />
+              </button>
+            )}
+          </div>
+        ),
+      },
+    ],
+    [navigate, onSelectCity]
+  );
+
+  return (
+    <ReusableTable<City>
+      columns={columns}
+      data={cityData}
+      loading={loading}
+      error={error}
+      tableMode="multi"
+      currentPage={page}
+      filters={filters}
+      onAdd={() => navigate("/parameters/city-crud/", { state: { country_id: countryId } })}
+      onDeleteRow={(row) => deleteCity(row.id)}
+      onPageChange={(newPage) => {
+        setPage(newPage);
+        updatePage(newPage);
+      }}
+      onPageSizeChange={(newSize) => {
+        setPageSize(newSize);
+        updatePageSize(newSize);
+        setPage(1);
+        updatePage(1);
+      }}
+      exportFileName="cities"
+      showExportButtons={true}
+    />
+  );
+}

--- a/src/components/common/country_parameters/country/crud.tsx
+++ b/src/components/common/country_parameters/country/crud.tsx
@@ -1,0 +1,59 @@
+import { FormikHelpers, FormikValues } from "formik";
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import ReusableModalForm, { FieldDefinition } from "../../ReusableModalForm";
+import { addCountry } from "../../../../slices/countries/add/thunk";
+import { updateCountry } from "../../../../slices/countries/update/thunk";
+import { fetchCountry } from "../../../../slices/countries/show/thunk";
+import { useDispatch } from "react-redux";
+import { AppDispatch } from "../../../store";
+
+interface FormData extends FormikValues {
+  name: string;
+}
+
+export default function CountryCrud() {
+  const { id } = useParams<{ id?: string }>();
+  const navigate = useNavigate();
+  const dispatch = useDispatch<AppDispatch>();
+  const mode = id ? "update" : "add";
+
+  const [initialValues, setInitialValues] = useState<FormData>({ name: "" });
+
+  const getFields = (): FieldDefinition[] => [
+    { name: "name", label: "Ülke Adı", type: "text", required: true },
+  ];
+
+  useEffect(() => {
+    if (mode === "update" && id) {
+      dispatch(fetchCountry(Number(id))).then((res: any) => {
+        if (fetchCountry.fulfilled.match(res)) {
+          setInitialValues({ name: res.payload.name });
+        }
+      });
+    }
+  }, [mode, id, dispatch]);
+
+  const handleSubmit = async (values: FormData, _helpers: FormikHelpers<FormData>) => {
+    if (mode === "add") {
+      await dispatch(addCountry(values));
+    } else if (id) {
+      await dispatch(updateCountry({ countryId: Number(id), payload: values }));
+    }
+    navigate("/parameters/country");
+  };
+
+  return (
+    <ReusableModalForm<FormData>
+      show={true}
+      title={mode === "add" ? "Ülke Ekle" : "Ülke Güncelle"}
+      fields={getFields}
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      confirmButtonLabel={mode === "add" ? "Ekle" : "Güncelle"}
+      cancelButtonLabel="Vazgeç"
+      onClose={() => navigate("/parameters/country")}
+      autoGoBackOnModalClose
+    />
+  );
+}

--- a/src/components/common/country_parameters/country/table.tsx
+++ b/src/components/common/country_parameters/country/table.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useCountriesList } from "../../../hooks/countries/useCountriesList";
+import { ICountry } from "../../../../types/countries/list";
+import ReusableTable, { ColumnDefinition, useDebounce } from "../../ReusableTable";
+import { deleteCountry } from "../../../../slices/countries/delete/thunk";
+import { useUpdateQueryParamsFromFilters } from "../../../hooks/utilshooks/useUpdateQueryParamsFromFilters";
+
+interface CountryTableProps {
+  onSelectCountry?: (country: ICountry) => void;
+}
+
+type QueryParams = {
+  [x: string]: any;
+  name: string;
+  pageSize: number;
+  page: number;
+};
+
+export default function CountryTable({ onSelectCountry }: CountryTableProps) {
+  const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState<number>(10);
+  const [inputName, setInputName] = useState("");
+  const debouncedName = useDebounce<string>(inputName, 500);
+  const [name, setName] = useState("");
+  const [filtersEnabled, setFiltersEnabled] = useState({ name: false });
+
+  const handleFilterChange = (key: string, value: any) => {
+    setFiltersEnabled((prev) => ({ ...prev, [key]: true }));
+    if (key === "name") setInputName(value);
+  };
+
+  useEffect(() => {
+    setName(debouncedName);
+  }, [debouncedName]);
+
+  const filterState = useMemo(
+    () => ({ name: name, page: 1, pageSize }),
+    [name, pageSize]
+  );
+  const updateQueryParams = (params: QueryParams) => {
+    const query = new URLSearchParams();
+    if (params.name) query.set("country_name", params.name);
+    navigate(`?${query.toString()}`);
+  };
+  useUpdateQueryParamsFromFilters<QueryParams>(filterState, updateQueryParams);
+
+  const params = useMemo(
+    () => ({
+      enabled: true,
+      paginate: pageSize,
+      page: page,
+      per_page: pageSize,
+      name: name,
+    }),
+    [pageSize, page, name]
+  );
+
+  const {
+    countriesData,
+    loading,
+    error,
+    totalPages,
+    totalItems,
+    setPage: updatePage,
+    setPageSize: updateTablePageSize,
+  } = useCountriesList(params);
+
+  const filters = useMemo(
+    () => [
+      {
+        key: "name",
+        value: inputName,
+        placeholder: "Ülke...",
+        type: "text" as const,
+        onChange: (val: string) => {
+          handleFilterChange("name", val);
+        },
+        isEnabled: filtersEnabled.name,
+      },
+    ],
+    [inputName]
+  );
+
+  const columns: ColumnDefinition<ICountry>[] = useMemo(
+    () => [
+      { key: "name", label: "Name", render: (row) => row.name },
+      {
+        key: "actions",
+        label: "İşlemler",
+        render: (row, openDeleteModal) => (
+          <div className="flex gap-2">
+            <button
+              onClick={() => {
+                navigate(`/parameters/country-crud/${row.id}`);
+              }}
+              className="btn btn-icon btn-sm btn-info-light rounded-pill"
+            >
+              <i className="ti ti-pencil" />
+            </button>
+            <button
+              onClick={() => openDeleteModal && openDeleteModal(row)}
+              className="btn btn-icon btn-sm btn-danger-light rounded-pill"
+              style={{ marginLeft: "10px" }}
+            >
+              <i className="ti ti-trash" />
+            </button>
+            {onSelectCountry && (
+              <button
+                onClick={() => onSelectCountry(row)}
+                className="btn btn-icon btn-sm btn-primary-light rounded-pill"
+                style={{ marginLeft: "10px" }}
+              >
+                <i className="ti ti-check" />
+              </button>
+            )}
+          </div>
+        ),
+      },
+    ],
+    [navigate, onSelectCountry]
+  );
+
+  return (
+    <>
+      <ReusableTable<ICountry>
+        columns={columns}
+        data={countriesData}
+        loading={loading}
+        error={error}
+        showModal={false}
+        tableMode="multi"
+        currentPage={page}
+        filters={filters}
+        totalPages={totalPages}
+        totalItems={totalItems}
+        onAdd={() => {
+          navigate("/parameters/country-crud/", { state: {} });
+        }}
+        onDeleteRow={(row) => {
+          deleteCountry(row.id);
+        }}
+        onPageChange={(newPage) => {
+          setPage(newPage);
+          updatePage(newPage);
+        }}
+        onPageSizeChange={(newSize) => {
+          setPageSize(newSize);
+          updateTablePageSize(newSize);
+          setPage(1);
+          updatePage(1);
+        }}
+        exportFileName="countries"
+        showExportButtons={true}
+      />
+    </>
+  );
+}

--- a/src/components/common/country_parameters/county/crud.tsx
+++ b/src/components/common/country_parameters/county/crud.tsx
@@ -1,0 +1,59 @@
+import { FormikHelpers, FormikValues } from "formik";
+import { useEffect, useState } from "react";
+import { useNavigate, useParams, useLocation } from "react-router-dom";
+import ReusableModalForm, { FieldDefinition } from "../../ReusableModalForm";
+import { addCounty } from "../../../../slices/counties/add/thunk";
+import { updateCounty } from "../../../../slices/counties/update/thunk";
+import { showCounty } from "../../../../slices/counties/show/thunk";
+import { useDispatch } from "react-redux";
+import { AppDispatch } from "../../../store";
+
+interface FormData extends FormikValues {
+  name: string;
+}
+
+export default function CountyCrud() {
+  const { id } = useParams<{ id?: string }>();
+  const navigate = useNavigate();
+  const location = useLocation() as { state?: { city_id?: number } };
+  const dispatch = useDispatch<AppDispatch>();
+  const mode = id ? "update" : "add";
+  const [initialValues, setInitialValues] = useState<FormData>({ name: "" });
+
+  const getFields = (): FieldDefinition[] => [
+    { name: "name", label: "İlçe Adı", type: "text", required: true },
+  ];
+
+  useEffect(() => {
+    if (mode === "update" && id) {
+      dispatch(showCounty(Number(id))).then((res: any) => {
+        if (showCounty.fulfilled.match(res)) {
+          setInitialValues({ name: res.payload.name });
+        }
+      });
+    }
+  }, [mode, id, dispatch]);
+
+  const handleSubmit = async (values: FormData, _helpers: FormikHelpers<FormData>) => {
+    if (mode === "add") {
+      await dispatch(addCounty({ ...values, city_id: location.state?.city_id || 0 }));
+    } else if (id) {
+      await dispatch(updateCounty({ countyId: Number(id), payload: values }));
+    }
+    navigate("/parameters/country", { state: { city_id: location.state?.city_id } });
+  };
+
+  return (
+    <ReusableModalForm<FormData>
+      show={true}
+      title={mode === "add" ? "İlçe Ekle" : "İlçe Güncelle"}
+      fields={getFields}
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      confirmButtonLabel={mode === "add" ? "Ekle" : "Güncelle"}
+      cancelButtonLabel="Vazgeç"
+      onClose={() => navigate("/parameters/country")}
+      autoGoBackOnModalClose
+    />
+  );
+}

--- a/src/components/common/country_parameters/county/table.tsx
+++ b/src/components/common/country_parameters/county/table.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useListCounties } from "../../../hooks/county/useCountyList";
+import { County } from "../../../../types/counties/list";
+import ReusableTable, { ColumnDefinition, useDebounce } from "../../ReusableTable";
+import { deleteCounty } from "../../../../slices/counties/delete/thunk";
+
+interface CountyTableProps {
+  cityId?: number;
+  enabled?: boolean;
+  onSelectCounty?: (county: County) => void;
+}
+
+type QueryParams = { [x: string]: any; name: string; pageSize: number; page: number };
+
+export default function CountyTable({ cityId, enabled, onSelectCounty }: CountyTableProps) {
+  const navigate = useNavigate();
+  const [page] = useState(1);
+  const [pageSize] = useState<number>(10);
+  const [inputName, setInputName] = useState("");
+  const debouncedName = useDebounce<string>(inputName, 500);
+  const [name, setName] = useState("");
+  const [filtersEnabled, setFiltersEnabled] = useState({ name: false });
+
+  const handleFilterChange = (key: string, value: any) => {
+    setFiltersEnabled((prev) => ({ ...prev, [key]: true }));
+    if (key === "name") setInputName(value);
+  };
+
+  useEffect(() => {
+    setName(debouncedName);
+  }, [debouncedName]);
+
+  const params = useMemo(
+    () => ({
+      enabled: enabled,
+      page: page,
+      pageSize: pageSize,
+      name: name,
+      city_id: cityId,
+    }),
+    [enabled, page, pageSize, name, cityId]
+  );
+
+  const { Countriesdata: countiesData, status, error } = useListCounties(params);
+  const loading = status === "LOADING";
+
+  const filters = useMemo(
+    () => [
+      {
+        key: "name",
+        value: inputName,
+        placeholder: "İlçe...",
+        type: "text" as const,
+        onChange: (val: string) => handleFilterChange("name", val),
+        isEnabled: filtersEnabled.name,
+      },
+    ],
+    [inputName]
+  );
+
+  const columns: ColumnDefinition<County>[] = useMemo(
+    () => [
+      { key: "name", label: "Name", render: (row) => row.name },
+      {
+        key: "actions",
+        label: "İşlemler",
+        render: (row, openDeleteModal) => (
+          <div className="flex gap-2">
+            <button
+              onClick={() => navigate(`/parameters/county-crud/${row.id}`)}
+              className="btn btn-icon btn-sm btn-info-light rounded-pill"
+            >
+              <i className="ti ti-pencil" />
+            </button>
+            <button
+              onClick={() => openDeleteModal && openDeleteModal(row)}
+              className="btn btn-icon btn-sm btn-danger-light rounded-pill"
+              style={{ marginLeft: "10px" }}
+            >
+              <i className="ti ti-trash" />
+            </button>
+            {onSelectCounty && (
+              <button
+                onClick={() => onSelectCounty(row)}
+                className="btn btn-icon btn-sm btn-primary-light rounded-pill"
+                style={{ marginLeft: "10px" }}
+              >
+                <i className="ti ti-check" />
+              </button>
+            )}
+          </div>
+        ),
+      },
+    ],
+    [navigate, onSelectCounty]
+  );
+
+  return (
+    <ReusableTable<County>
+      columns={columns}
+      data={Array.isArray(countiesData) ? countiesData : []}
+      loading={loading}
+      error={error}
+      tableMode="multi"
+      currentPage={page}
+      filters={filters}
+      onAdd={() => navigate("/parameters/county-crud/", { state: { city_id: cityId } })}
+      onDeleteRow={(row) => deleteCounty(row.id)}
+      exportFileName="counties"
+      showExportButtons={true}
+    />
+  );
+}

--- a/src/components/common/country_parameters/district/crud.tsx
+++ b/src/components/common/country_parameters/district/crud.tsx
@@ -1,0 +1,59 @@
+import { FormikHelpers, FormikValues } from "formik";
+import { useEffect, useState } from "react";
+import { useNavigate, useParams, useLocation } from "react-router-dom";
+import ReusableModalForm, { FieldDefinition } from "../../ReusableModalForm";
+import { addDistrict } from "../../../../slices/districts/add/thunk";
+import { updateDistrict } from "../../../../slices/districts/update/thunk";
+import { showDistrict } from "../../../../slices/districts/show/thunk";
+import { useDispatch } from "react-redux";
+import { AppDispatch } from "../../../store";
+
+interface FormData extends FormikValues {
+  name: string;
+}
+
+export default function DistrictCrud() {
+  const { id } = useParams<{ id?: string }>();
+  const navigate = useNavigate();
+  const location = useLocation() as { state?: { county_id?: number } };
+  const dispatch = useDispatch<AppDispatch>();
+  const mode = id ? "update" : "add";
+  const [initialValues, setInitialValues] = useState<FormData>({ name: "" });
+
+  const getFields = (): FieldDefinition[] => [
+    { name: "name", label: "Mahalle Adı", type: "text", required: true },
+  ];
+
+  useEffect(() => {
+    if (mode === "update" && id) {
+      dispatch(showDistrict(Number(id))).then((res: any) => {
+        if (showDistrict.fulfilled.match(res)) {
+          setInitialValues({ name: res.payload.name });
+        }
+      });
+    }
+  }, [mode, id, dispatch]);
+
+  const handleSubmit = async (values: FormData, _helpers: FormikHelpers<FormData>) => {
+    if (mode === "add") {
+      await dispatch(addDistrict({ ...values, county_id: location.state?.county_id || 0 }));
+    } else if (id) {
+      await dispatch(updateDistrict({ districtId: Number(id), payload: values }));
+    }
+    navigate("/parameters/country", { state: { county_id: location.state?.county_id } });
+  };
+
+  return (
+    <ReusableModalForm<FormData>
+      show={true}
+      title={mode === "add" ? "Mahalle Ekle" : "Mahalle Güncelle"}
+      fields={getFields}
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      confirmButtonLabel={mode === "add" ? "Ekle" : "Güncelle"}
+      cancelButtonLabel="Vazgeç"
+      onClose={() => navigate("/parameters/country")}
+      autoGoBackOnModalClose
+    />
+  );
+}

--- a/src/components/common/country_parameters/district/table.tsx
+++ b/src/components/common/country_parameters/district/table.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useDiscrictTable } from "../../../hooks/districts/useList";
+import { IDistrict } from "../../../../types/districts/list";
+import ReusableTable, { ColumnDefinition, useDebounce } from "../../ReusableTable";
+import { deleteDistrict } from "../../../../slices/districts/delete/thunk";
+
+interface DistrictTableProps {
+  countyId?: number;
+  enabled?: boolean;
+}
+
+type QueryParams = { [x: string]: any; name: string; pageSize: number; page: number };
+
+export default function DistrictTable({ countyId, enabled }: DistrictTableProps) {
+  const navigate = useNavigate();
+  const [page] = useState(1);
+  const [pageSize] = useState<number>(10);
+  const [inputName, setInputName] = useState("");
+  const debouncedName = useDebounce<string>(inputName, 500);
+  const [name, setName] = useState("");
+  const [filtersEnabled, setFiltersEnabled] = useState({ name: false });
+
+  const handleFilterChange = (key: string, value: any) => {
+    setFiltersEnabled((prev) => ({ ...prev, [key]: true }));
+    if (key === "name") setInputName(value);
+  };
+
+  useEffect(() => {
+    setName(debouncedName);
+  }, [debouncedName]);
+
+  const params = useMemo(
+    () => ({
+      enabled: enabled,
+      page: page,
+      pageSize: pageSize,
+      name: name,
+      county_id: countyId,
+    }),
+    [enabled, page, pageSize, name, countyId]
+  );
+
+  const { discrictData: districtData, status, error } = useDiscrictTable(params);
+  const loading = status === "LOADING";
+
+  const filters = useMemo(
+    () => [
+      {
+        key: "name",
+        value: inputName,
+        placeholder: "Mahalle...",
+        type: "text" as const,
+        onChange: (val: string) => handleFilterChange("name", val),
+        isEnabled: filtersEnabled.name,
+      },
+    ],
+    [inputName]
+  );
+
+  const columns: ColumnDefinition<IDistrict>[] = useMemo(
+    () => [
+      { key: "name", label: "Name", render: (row) => row.name },
+      {
+        key: "actions",
+        label: "İşlemler",
+        render: (row, openDeleteModal) => (
+          <div className="flex gap-2">
+            <button
+              onClick={() => navigate(`/parameters/district-crud/${row.id}`)}
+              className="btn btn-icon btn-sm btn-info-light rounded-pill"
+            >
+              <i className="ti ti-pencil" />
+            </button>
+            <button
+              onClick={() => openDeleteModal && openDeleteModal(row)}
+              className="btn btn-icon btn-sm btn-danger-light rounded-pill"
+              style={{ marginLeft: "10px" }}
+            >
+              <i className="ti ti-trash" />
+            </button>
+          </div>
+        ),
+      },
+    ],
+    [navigate]
+  );
+
+  return (
+    <ReusableTable<IDistrict>
+      columns={columns}
+      data={Array.isArray(districtData) ? districtData : []}
+      loading={loading}
+      error={error}
+      tableMode="multi"
+      currentPage={page}
+      filters={filters}
+      onAdd={() => navigate("/parameters/district-crud/", { state: { county_id: countyId } })}
+      onDeleteRow={(row) => deleteDistrict(row.id)}
+      exportFileName="districts"
+      showExportButtons={true}
+    />
+  );
+}

--- a/src/components/common/country_parameters/index.tsx
+++ b/src/components/common/country_parameters/index.tsx
@@ -1,0 +1,62 @@
+import { Row, Col, Card } from "react-bootstrap";
+import CountryTable from "./country/table";
+import CityTable from "./city/table";
+import CountyTable from "./county/table";
+import DistrictTable from "./district/table";
+import { useState } from "react";
+
+export default function CombinedPage() {
+  const [selectedCountryId, setSelectedCountryId] = useState<number>();
+  const [selectedCityId, setSelectedCityId] = useState<number>();
+  const [selectedCountyId, setSelectedCountyId] = useState<number>();
+  const [enabled, setEnabled] = useState(false);
+  return (
+    <div>
+      <Row>
+        <Col md={3}>
+          <Card>
+            <h5>Ülkeler</h5>
+            <CountryTable
+              onSelectCountry={(country) => {
+                setSelectedCountryId(country.id);
+                setEnabled(true);
+              }}
+            />
+          </Card>
+        </Col>
+        <Col md={3}>
+          <Card>
+            <h5>Şehirler</h5>
+            <CityTable
+              countryId={selectedCountryId}
+              enabled={enabled}
+              onSelectCity={(city) => {
+                setSelectedCityId(city.id);
+                setEnabled(true);
+              }}
+            />
+          </Card>
+        </Col>
+        <Col md={3}>
+          <Card>
+            <h5>İlçeler</h5>
+            <CountyTable
+              cityId={selectedCityId}
+              enabled={enabled}
+              onSelectCounty={(county) => {
+                setSelectedCountyId(county.id);
+                setEnabled(true);
+              }}
+            />
+          </Card>
+        </Col>
+        <Col md={3}>
+          <Card>
+            <h5>Mahalleler</h5>
+            <DistrictTable countyId={selectedCountyId} enabled={enabled} />
+          </Card>
+        </Col>
+      </Row>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `country_parameters` section with tables and CRUD modals for Countries, Cities, Counties and Districts
- hook new routes under `/parameters/country`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_683d9cf69cc8832ca3da7c81164ee5ac