### PR TITLE
Implement address management page

### DIFF
--- a/src/Route/routingdata.tsx
+++ b/src/Route/routingdata.tsx
@@ -88,6 +88,9 @@ const DiscountStudent = lazy(
 const EducationalStructure = lazy(
   () => import("../components/common/academic/educational_structure/index")
 );
+const AddressStructurePage = lazy(
+  () => import("../components/common/parameters/address_structure/index")
+);
 const DiscountStudentDetail = lazy(
   () => import("../components/common/discountStudent/detail")
 );
@@ -335,6 +338,19 @@ const ClassLevelCrud = lazy(
 // Educational Structure Track Crud
 const TrackCrud = lazy(
   () => import("../components/common/academic/educational_structure/track/crud")
+);
+
+const CountryModal = lazy(
+  () => import("../components/common/parameters/address_structure/country/crud")
+);
+const CityModal = lazy(
+  () => import("../components/common/parameters/address_structure/city/crud")
+);
+const CountyModal = lazy(
+  () => import("../components/common/parameters/address_structure/county/crud")
+);
+const DistrictModal = lazy(
+  () => import("../components/common/parameters/address_structure/district/crud")
 );
 
 const Questionlabeling = lazy(
@@ -1154,6 +1170,75 @@ export const Routedata = [
     path: `${import.meta.env.BASE_URL}educational-structure/track-crud/:id?`,
     element: (
       <TrackCrud
+        show={true}
+        token={""}
+        onClose={function (): void {
+          throw new Error("Function not implemented.");
+        }}
+        onRefresh={function (): void {
+          throw new Error("Function not implemented.");
+        }}
+      />
+    ),
+  },
+  {
+    id: 330,
+    path: `${import.meta.env.BASE_URL}parameters/country`,
+    element: <AddressStructurePage />,
+  },
+  {
+    id: 331,
+    path: `${import.meta.env.BASE_URL}parameters/country/country-crud/:id?`,
+    element: (
+      <CountryModal
+        show={true}
+        token={""}
+        onClose={function (): void {
+          throw new Error("Function not implemented.");
+        }}
+        onRefresh={function (): void {
+          throw new Error("Function not implemented.");
+        }}
+      />
+    ),
+  },
+  {
+    id: 332,
+    path: `${import.meta.env.BASE_URL}parameters/country/city-crud/:id?`,
+    element: (
+      <CityModal
+        show={true}
+        token={""}
+        onClose={function (): void {
+          throw new Error("Function not implemented.");
+        }}
+        onRefresh={function (): void {
+          throw new Error("Function not implemented.");
+        }}
+      />
+    ),
+  },
+  {
+    id: 333,
+    path: `${import.meta.env.BASE_URL}parameters/country/county-crud/:id?`,
+    element: (
+      <CountyModal
+        show={true}
+        token={""}
+        onClose={function (): void {
+          throw new Error("Function not implemented.");
+        }}
+        onRefresh={function (): void {
+          throw new Error("Function not implemented.");
+        }}
+      />
+    ),
+  },
+  {
+    id: 334,
+    path: `${import.meta.env.BASE_URL}parameters/country/district-crud/:id?`,
+    element: (
+      <DistrictModal
         show={true}
         token={""}
         onClose={function (): void {

--- a/src/components/common/parameters/address_structure/city/crud.tsx
+++ b/src/components/common/parameters/address_structure/city/crud.tsx
@@ -1,0 +1,108 @@
+import { FormikHelpers, FormikValues } from "formik";
+import ReusableModalForm, { FieldDefinition } from "../../ReusableModalForm";
+import { useNavigate, useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useCourseAdd } from "../../../hooks/city/useAdd";
+import { useCourseUpdate } from "../../../hooks/city/useUpdate";
+import { useCourseShow } from "../../../hooks/city/useDetail";
+
+interface CityFormData extends FormikValues {
+  name: string;
+}
+
+interface CityModalProps {
+  show: boolean;
+  token: string;
+  onClose: () => void;
+  onRefresh: () => void;
+}
+
+const CityModal: React.FC<CityModalProps> = ({}) => {
+  const { id } = useParams<{ id?: string }>();
+  const navigate = useNavigate();
+  const mode = id ? "update" : "add";
+
+  const [initialValues, setInitialValues] = useState<CityFormData>({
+    name: "",
+  });
+
+  const getFields = (): FieldDefinition[] => {
+    return [
+      {
+        name: "name",
+        label: "Şehir Adı",
+        type: "text",
+        required: true,
+      },
+    ];
+  };
+
+  const { addNewCourse, status: addStatus, error: addError } = useCourseAdd();
+
+  const {
+    updateExistingCourse,
+    status: updateStatus,
+    error: updateError,
+  } = useCourseUpdate();
+
+  const {
+    course: fetchedCity,
+    status: showStatus,
+    error: showError,
+    getCourse,
+  } = useCourseShow();
+
+  useEffect(() => {
+    if (mode === "update" && id) {
+      getCourse(Number(id));
+    }
+  }, [mode, id, getCourse]);
+
+  useEffect(() => {
+    if (mode === "update" && fetchedCity) {
+      setInitialValues({
+        name: fetchedCity.name,
+      });
+    }
+  }, [mode, fetchedCity]);
+
+  const isLoading =
+    (mode === "add" && addStatus === "LOADING") ||
+    (mode === "update" && (updateStatus === "LOADING" || showStatus === "LOADING"));
+  const combinedError =
+    mode === "add" ? addError : mode === "update" ? updateError || showError : null;
+
+  async function handleSubmit(
+    values: CityFormData,
+    _helpers: FormikHelpers<CityFormData>
+  ) {
+    try {
+      if (mode === "add") {
+        await addNewCourse(values);
+      } else if (mode === "update" && id) {
+        await updateExistingCourse({ courseId: Number(id), payload: values });
+      }
+      navigate("/parameters/country");
+    } catch (error) {
+      console.error("Error saving city:", error);
+    }
+  }
+
+  return (
+    <ReusableModalForm<CityFormData>
+      show={true}
+      title={mode === "add" ? "Şehir Ekle" : "Şehir Güncelle"}
+      fields={getFields}
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      confirmButtonLabel={mode === "add" ? "Ekle" : "Güncelle"}
+      cancelButtonLabel="Vazgeç"
+      isLoading={isLoading}
+      error={combinedError || null}
+      onClose={() => navigate("/parameters/country")}
+      autoGoBackOnModalClose
+    />
+  );
+};
+
+export default CityModal;

--- a/src/components/common/parameters/address_structure/city/table.tsx
+++ b/src/components/common/parameters/address_structure/city/table.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useCityTable } from "../../../hooks/city/useList";
+import ReusableTable, { ColumnDefinition, useDebounce } from "../../ReusableTable";
+import { City } from "../../../types/city/list";
+import { deleteCity } from "../../../slices/cities/delete/thunk";
+import { Button } from "react-bootstrap";
+import sec_buton from "../../../assets/images/media/sec-buton.svg";
+
+interface CityTableProps {
+  onSelectCity?: (city: City) => void;
+  countryId?: number;
+  enabled?: boolean;
+}
+
+export default function CityTable({ countryId, onSelectCity, enabled }: CityTableProps) {
+  const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState<number>(10);
+  const [inputName, setInputName] = useState("");
+  const debouncedName = useDebounce<string>(inputName, 500);
+  const [name, setName] = useState("");
+  const [filtersEnabled, setFiltersEnabled] = useState({ name: false });
+
+  useEffect(() => {
+    setName(debouncedName);
+  }, [debouncedName]);
+
+  const cityParams = useMemo(
+    () => ({
+      enabled: enabled,
+      page: page,
+      pageSize,
+      name: name,
+      country_id: countryId,
+    }),
+    [enabled, page, pageSize, name, countryId]
+  );
+
+  const {
+    cityData,
+    loading,
+    error,
+    setPage: updatePage,
+    setPageSize: updatePageSize,
+  } = useCityTable(cityParams);
+
+  const filters = useMemo(() => {
+    return [
+      {
+        key: "name",
+        value: inputName,
+        placeholder: "Şehir...",
+        type: "text" as const,
+        onChange: (val: string) => {
+          setFiltersEnabled((prev) => ({ ...prev, name: true }));
+          setInputName(val);
+        },
+        isEnabled: filtersEnabled.name,
+      },
+    ];
+  }, [inputName]);
+
+  const columns: ColumnDefinition<City>[] = useMemo(
+    () => [
+      {
+        key: "name",
+        label: "Name",
+        render: (row) => row.name,
+      },
+      {
+        key: "actions",
+        label: "İşlemler",
+        render: (row, openDeleteModal) => (
+          <div className="flex gap-2">
+            <button
+              onClick={() => {
+                navigate(`/parameters/country/city-crud/${row.id}`);
+              }}
+              className="btn btn-icon btn-sm btn-info-light rounded-pill"
+            >
+              <i className="ti ti-pencil" />
+            </button>
+            <button
+              onClick={() => openDeleteModal && openDeleteModal(row)}
+              className="btn btn-icon btn-sm btn-danger-light rounded-pill"
+              style={{ marginLeft: "10px" }}
+            >
+              <i className="ti ti-trash" />
+            </button>
+            <Button
+              onClick={() => {
+                if (onSelectCity) {
+                  onSelectCity(row);
+                } else {
+                  navigate("/parameters/country", {
+                    state: { city_id: row.id, enabled: true },
+                  });
+                }
+              }}
+              variant=""
+              size="sm"
+            >
+              <img
+                src={sec_buton}
+                alt="Seç"
+                style={{ width: "28px", height: "28px" }}
+                onMouseEnter={(e) =>
+                  (e.currentTarget.src =
+                    "/src/assets/images/media/sec-buton-hover.svg")
+                }
+                onMouseLeave={(e) =>
+                  (e.currentTarget.src =
+                    "/src/assets/images/media/sec-buton.svg")
+                }
+              />
+            </Button>{" "}
+          </div>
+        ),
+      },
+    ],
+    [navigate, onSelectCity]
+  );
+
+  return (
+    <>
+      <ReusableTable<City>
+        columns={columns}
+        data={cityData}
+        loading={loading}
+        error={error}
+        showModal={false}
+        tableMode="multi"
+        currentPage={page}
+        filters={filters}
+        onAdd={() => {
+          if (enabled) {
+            navigate("/parameters/country/city-crud/");
+          }
+        }}
+        onDeleteRow={(row) => {
+          deleteCity(row.id);
+        }}
+        onPageChange={(newPage) => {
+          setPage(newPage);
+          updatePage(newPage);
+        }}
+        onPageSizeChange={(newSize) => {
+          setPageSize(newSize);
+          updatePageSize(newSize);
+          setPage(1);
+          updatePage(1);
+        }}
+        exportFileName="cities"
+        showExportButtons={true}
+      />
+    </>
+  );
+}

--- a/src/components/common/parameters/address_structure/country/crud.tsx
+++ b/src/components/common/parameters/address_structure/country/crud.tsx
@@ -1,0 +1,108 @@
+import { FormikHelpers, FormikValues } from "formik";
+import ReusableModalForm, { FieldDefinition } from "../../ReusableModalForm";
+import { useNavigate, useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useCountriesAdd } from "../../../hooks/countries/useCountriesAdd";
+import { useCountriesUpdate } from "../../../hooks/countries/useCountriesUpdate";
+import { useCountriesShow } from "../../../hooks/countries/useCountriesShow";
+
+interface CountryFormData extends FormikValues {
+  name: string;
+}
+
+interface CountryModalProps {
+  show: boolean;
+  token: string;
+  onClose: () => void;
+  onRefresh: () => void;
+}
+
+const CountryModal: React.FC<CountryModalProps> = ({}) => {
+  const { id } = useParams<{ id?: string }>();
+  const navigate = useNavigate();
+  const mode = id ? "update" : "add";
+
+  const [initialValues, setInitialValues] = useState<CountryFormData>({
+    name: "",
+  });
+
+  const getFields = (): FieldDefinition[] => {
+    return [
+      {
+        name: "name",
+        label: "Ülke Adı",
+        type: "text",
+        required: true,
+      },
+    ];
+  };
+
+  const { addNewCountry, status: addStatus, error: addError } = useCountriesAdd();
+
+  const {
+    updateExistingCountry,
+    status: updateStatus,
+    error: updateError,
+  } = useCountriesUpdate();
+
+  const {
+    school: fetchedCountry,
+    status: showStatus,
+    error: showError,
+    getSchool,
+  } = useCountriesShow();
+
+  useEffect(() => {
+    if (mode === "update" && id) {
+      getSchool(Number(id));
+    }
+  }, [mode, id, getSchool]);
+
+  useEffect(() => {
+    if (mode === "update" && fetchedCountry) {
+      setInitialValues({
+        name: fetchedCountry.name,
+      });
+    }
+  }, [mode, fetchedCountry]);
+
+  const isLoading =
+    (mode === "add" && addStatus === "LOADING") ||
+    (mode === "update" && (updateStatus === "LOADING" || showStatus === "LOADING"));
+  const combinedError =
+    mode === "add" ? addError : mode === "update" ? updateError || showError : null;
+
+  async function handleSubmit(
+    values: CountryFormData,
+    _helpers: FormikHelpers<CountryFormData>
+  ) {
+    try {
+      if (mode === "add") {
+        await addNewCountry(values);
+      } else if (mode === "update" && id) {
+        await updateExistingCountry({ countryId: Number(id), payload: values });
+      }
+      navigate("/parameters/country");
+    } catch (error) {
+      console.error("Error saving country:", error);
+    }
+  }
+
+  return (
+    <ReusableModalForm<CountryFormData>
+      show={true}
+      title={mode === "add" ? "Ülke Ekle" : "Ülke Güncelle"}
+      fields={getFields}
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      confirmButtonLabel={mode === "add" ? "Ekle" : "Güncelle"}
+      cancelButtonLabel="Vazgeç"
+      isLoading={isLoading}
+      error={combinedError || null}
+      onClose={() => navigate("/parameters/country")}
+      autoGoBackOnModalClose
+    />
+  );
+};
+
+export default CountryModal;

--- a/src/components/common/parameters/address_structure/country/table.tsx
+++ b/src/components/common/parameters/address_structure/country/table.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useCountriesList } from "../../../hooks/countries/useCountriesList";
+import ReusableTable, { ColumnDefinition, useDebounce } from "../../ReusableTable";
+import { ICountry } from "../../../types/countries/list";
+import { deleteCountry } from "../../../slices/countries/delete/thunk";
+import { Button } from "react-bootstrap";
+import sec_buton from "../../../assets/images/media/sec-buton.svg";
+
+interface CountryTableProps {
+  onSelectCountry?: (country: ICountry) => void;
+}
+
+export default function CountryTable({ onSelectCountry }: CountryTableProps) {
+  const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState<number>(10);
+  const [inputName, setInputName] = useState("");
+  const debouncedName = useDebounce<string>(inputName, 500);
+  const [name, setName] = useState("");
+  const [filtersEnabled, setFiltersEnabled] = useState({ name: false });
+
+  useEffect(() => {
+    setName(debouncedName);
+  }, [debouncedName]);
+
+  const filterState = useMemo(
+    () => ({
+      name: name,
+      page: 1,
+      pageSize,
+    }),
+    [name, pageSize]
+  );
+
+  const countryParams = useMemo(
+    () => ({
+      enabled: true,
+      page: page,
+      pageSize,
+      name: name,
+    }),
+    [page, pageSize, name]
+  );
+
+  const {
+    countriesData,
+    loading,
+    error,
+    setPage: updatePage,
+    setPageSize: updatePageSize,
+    totalPages,
+    totalItems,
+  } = useCountriesList(countryParams);
+
+  const filters = useMemo(() => {
+    return [
+      {
+        key: "name",
+        value: inputName,
+        placeholder: "Ülke...",
+        type: "text" as const,
+        onChange: (val: string) => {
+          setFiltersEnabled((prev) => ({ ...prev, name: true }));
+          setInputName(val);
+        },
+        isEnabled: filtersEnabled.name,
+      },
+    ];
+  }, [inputName]);
+
+  const columns: ColumnDefinition<ICountry>[] = useMemo(
+    () => [
+      {
+        key: "name",
+        label: "Name",
+        render: (row) => row.name,
+      },
+      {
+        key: "actions",
+        label: "İşlemler",
+        render: (row, openDeleteModal) => (
+          <div className="flex gap-2">
+            <button
+              onClick={() => {
+                navigate(`/parameters/country/country-crud/${row.id}`);
+              }}
+              className="btn btn-icon btn-sm btn-info-light rounded-pill"
+            >
+              <i className="ti ti-pencil" />
+            </button>
+            <button
+              onClick={() => openDeleteModal && openDeleteModal(row)}
+              className="btn btn-icon btn-sm btn-danger-light rounded-pill"
+              style={{ marginLeft: "10px" }}
+            >
+              <i className="ti ti-trash" />
+            </button>
+            <Button
+              onClick={() => {
+                if (onSelectCountry) {
+                  onSelectCountry(row);
+                } else {
+                  navigate("/parameters/country", {
+                    state: { country_id: row.id, enabled: true },
+                  });
+                }
+              }}
+              variant=""
+              size="sm"
+            >
+              <img
+                src={sec_buton}
+                alt="Seç"
+                style={{ width: "28px", height: "28px" }}
+                onMouseEnter={(e) =>
+                  (e.currentTarget.src =
+                    "/src/assets/images/media/sec-buton-hover.svg")
+                }
+                onMouseLeave={(e) =>
+                  (e.currentTarget.src =
+                    "/src/assets/images/media/sec-buton.svg")
+                }
+              />
+            </Button>{" "}
+          </div>
+        ),
+      },
+    ],
+    [navigate, onSelectCountry]
+  );
+
+  return (
+    <>
+      <ReusableTable<ICountry>
+        columns={columns}
+        data={countriesData}
+        loading={loading}
+        error={error}
+        showModal={false}
+        tableMode="multi"
+        currentPage={page}
+        filters={filters}
+        totalPages={totalPages}
+        totalItems={totalItems}
+        onAdd={() => {
+          navigate("/parameters/country/country-crud/");
+        }}
+        onPageChange={(newPage) => {
+          setPage(newPage);
+          updatePage(newPage);
+        }}
+        onPageSizeChange={(newSize) => {
+          setPageSize(newSize);
+          updatePageSize(newSize);
+          setPage(1);
+          updatePage(1);
+        }}
+        onDeleteRow={(row) => {
+          deleteCountry(row.id);
+        }}
+        exportFileName="countries"
+        showExportButtons={true}
+      />
+    </>
+  );
+}

--- a/src/components/common/parameters/address_structure/county/crud.tsx
+++ b/src/components/common/parameters/address_structure/county/crud.tsx
@@ -1,0 +1,109 @@
+import { FormikHelpers, FormikValues } from "formik";
+import ReusableModalForm, { FieldDefinition } from "../../ReusableModalForm";
+import { useNavigate, useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useProgramAdd } from "../../../hooks/districts/useAdd";
+import { useProgramUpdate } from "../../../hooks/districts/useUpdate";
+import { useProgramDetail } from "../../../hooks/districts/useDetail";
+
+interface CountyFormData extends FormikValues {
+  name: string;
+}
+
+interface CountyModalProps {
+  show: boolean;
+  token: string;
+  onClose: () => void;
+  onRefresh: () => void;
+}
+
+const CountyModal: React.FC<CountyModalProps> = ({}) => {
+  const { id } = useParams<{ id?: string }>();
+  const navigate = useNavigate();
+  const mode = id ? "update" : "add";
+
+  const [initialValues, setInitialValues] = useState<CountyFormData>({
+    name: "",
+  });
+
+  const getFields = (): FieldDefinition[] => {
+    return [
+      {
+        name: "name",
+        label: "İlçe Adı",
+        type: "text",
+        required: true,
+      },
+    ];
+  };
+
+  const { addedProgram, status: addStatus, error: addError, addNewProgram } = useProgramAdd();
+
+  const {
+    updatedProgram,
+    status: updateStatus,
+    error: updateError,
+    updateProgramDetails,
+  } = useProgramUpdate();
+
+  const {
+    programDetail,
+    status: showStatus,
+    error: showError,
+    getProgramDetail,
+  } = useProgramDetail();
+
+  useEffect(() => {
+    if (mode === "update" && id) {
+      getProgramDetail(Number(id));
+    }
+  }, [mode, id, getProgramDetail]);
+
+  useEffect(() => {
+    if (mode === "update" && programDetail) {
+      setInitialValues({
+        name: programDetail.name,
+      });
+    }
+  }, [mode, programDetail]);
+
+  const isLoading =
+    (mode === "add" && addStatus === "LOADING") ||
+    (mode === "update" && (updateStatus === "LOADING" || showStatus === "LOADING"));
+  const combinedError =
+    mode === "add" ? addError : mode === "update" ? updateError || showError : null;
+
+  async function handleSubmit(
+    values: CountyFormData,
+    _helpers: FormikHelpers<CountyFormData>
+  ) {
+    try {
+      if (mode === "add") {
+        await addNewProgram({ name: values.name });
+      } else if (mode === "update" && id) {
+        await updateProgramDetails({ programId: Number(id), payload: { name: values.name } });
+      }
+      navigate("/parameters/country");
+    } catch (error) {
+      console.error("Error saving county:", error);
+    }
+  }
+
+  return (
+    <ReusableModalForm<CountyFormData>
+      show={true}
+      title={mode === "add" ? "İlçe Ekle" : "İlçe Güncelle"}
+      fields={getFields}
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      confirmButtonLabel={mode === "add" ? "Ekle" : "Güncelle"}
+      cancelButtonLabel="Vazgeç"
+      isLoading={isLoading}
+      error={combinedError || null}
+      onClose={() => navigate("/parameters/country")}
+      autoGoBackOnModalClose
+    />
+  );
+};
+
+export default CountyModal;

--- a/src/components/common/parameters/address_structure/county/table.tsx
+++ b/src/components/common/parameters/address_structure/county/table.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useListCounties } from "../../../hooks/county/useCountyList";
+import ReusableTable, { ColumnDefinition, useDebounce } from "../../ReusableTable";
+import { County } from "../../../types/counties/list";
+import { deleteCounty } from "../../../slices/counties/delete/thunk";
+import { Button } from "react-bootstrap";
+import sec_buton from "../../../assets/images/media/sec-buton.svg";
+
+interface CountyTableProps {
+  onSelectCounty?: (county: County) => void;
+  cityId?: number;
+  enabled?: boolean;
+}
+
+export default function CountyTable({ cityId, onSelectCounty, enabled }: CountyTableProps) {
+  const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState<number>(10);
+  const [inputName, setInputName] = useState("");
+  const debouncedName = useDebounce<string>(inputName, 500);
+  const [name, setName] = useState("");
+  const [filtersEnabled, setFiltersEnabled] = useState({ name: false });
+
+  useEffect(() => {
+    setName(debouncedName);
+  }, [debouncedName]);
+
+  const countyParams = useMemo(
+    () => ({
+      enabled: enabled,
+      page: page,
+      pageSize,
+      name: name,
+      city_id: cityId,
+    }),
+    [enabled, page, pageSize, name, cityId]
+  );
+
+  const {
+    Countriesdata,
+    status,
+    error,
+    data,
+  } = useListCounties(countyParams);
+
+  const countyData: County[] = Array.isArray(Countriesdata)
+    ? Countriesdata
+    : Array.isArray(data)
+    ? data
+    : [];
+
+  const filters = useMemo(() => {
+    return [
+      {
+        key: "name",
+        value: inputName,
+        placeholder: "İlçe...",
+        type: "text" as const,
+        onChange: (val: string) => {
+          setFiltersEnabled((prev) => ({ ...prev, name: true }));
+          setInputName(val);
+        },
+        isEnabled: filtersEnabled.name,
+      },
+    ];
+  }, [inputName]);
+
+  const columns: ColumnDefinition<County>[] = useMemo(
+    () => [
+      {
+        key: "name",
+        label: "Name",
+        render: (row) => row.name,
+      },
+      {
+        key: "actions",
+        label: "İşlemler",
+        render: (row, openDeleteModal) => (
+          <div className="flex gap-2">
+            <button
+              onClick={() => {
+                navigate(`/parameters/country/county-crud/${row.id}`);
+              }}
+              className="btn btn-icon btn-sm btn-info-light rounded-pill"
+            >
+              <i className="ti ti-pencil" />
+            </button>
+            <button
+              onClick={() => openDeleteModal && openDeleteModal(row)}
+              className="btn btn-icon btn-sm btn-danger-light rounded-pill"
+              style={{ marginLeft: "10px" }}
+            >
+              <i className="ti ti-trash" />
+            </button>
+            <Button
+              onClick={() => {
+                if (onSelectCounty) {
+                  onSelectCounty(row);
+                } else {
+                  navigate("/parameters/country", {
+                    state: { county_id: row.id, enabled: true },
+                  });
+                }
+              }}
+              variant=""
+              size="sm"
+            >
+              <img
+                src={sec_buton}
+                alt="Seç"
+                style={{ width: "28px", height: "28px" }}
+                onMouseEnter={(e) =>
+                  (e.currentTarget.src =
+                    "/src/assets/images/media/sec-buton-hover.svg")
+                }
+                onMouseLeave={(e) =>
+                  (e.currentTarget.src =
+                    "/src/assets/images/media/sec-buton.svg")
+                }
+              />
+            </Button>{" "}
+          </div>
+        ),
+      },
+    ],
+    [navigate, onSelectCounty]
+  );
+
+  return (
+    <>
+      <ReusableTable<County>
+        columns={columns}
+        data={countyData}
+        loading={status === "LOADING"}
+        error={error}
+        showModal={false}
+        tableMode="multi"
+        currentPage={page}
+        filters={filters}
+        onAdd={() => {
+          if (enabled) {
+            navigate("/parameters/country/county-crud/");
+          }
+        }}
+        onDeleteRow={(row) => {
+          deleteCounty(row.id);
+        }}
+        onPageChange={(newPage) => {
+          setPage(newPage);
+        }}
+        onPageSizeChange={(newSize) => {
+          setPageSize(newSize);
+          setPage(1);
+        }}
+        exportFileName="counties"
+        showExportButtons={true}
+      />
+    </>
+  );
+}

--- a/src/components/common/parameters/address_structure/district/crud.tsx
+++ b/src/components/common/parameters/address_structure/district/crud.tsx
@@ -1,0 +1,109 @@
+import { FormikHelpers, FormikValues } from "formik";
+import ReusableModalForm, { FieldDefinition } from "../../ReusableModalForm";
+import { useNavigate, useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useProgramAdd } from "../../../hooks/districts/useAdd";
+import { useProgramUpdate } from "../../../hooks/districts/useUpdate";
+import { useProgramDetail } from "../../../hooks/districts/useDetail";
+
+interface DistrictFormData extends FormikValues {
+  name: string;
+}
+
+interface DistrictModalProps {
+  show: boolean;
+  token: string;
+  onClose: () => void;
+  onRefresh: () => void;
+}
+
+const DistrictModal: React.FC<DistrictModalProps> = ({}) => {
+  const { id } = useParams<{ id?: string }>();
+  const navigate = useNavigate();
+  const mode = id ? "update" : "add";
+
+  const [initialValues, setInitialValues] = useState<DistrictFormData>({
+    name: "",
+  });
+
+  const getFields = (): FieldDefinition[] => {
+    return [
+      {
+        name: "name",
+        label: "Mahalle Adı",
+        type: "text",
+        required: true,
+      },
+    ];
+  };
+
+  const { addedProgram, status: addStatus, error: addError, addNewProgram } = useProgramAdd();
+
+  const {
+    updatedProgram,
+    status: updateStatus,
+    error: updateError,
+    updateProgramDetails,
+  } = useProgramUpdate();
+
+  const {
+    programDetail,
+    status: showStatus,
+    error: showError,
+    getProgramDetail,
+  } = useProgramDetail();
+
+  useEffect(() => {
+    if (mode === "update" && id) {
+      getProgramDetail(Number(id));
+    }
+  }, [mode, id, getProgramDetail]);
+
+  useEffect(() => {
+    if (mode === "update" && programDetail) {
+      setInitialValues({
+        name: programDetail.name,
+      });
+    }
+  }, [mode, programDetail]);
+
+  const isLoading =
+    (mode === "add" && addStatus === "LOADING") ||
+    (mode === "update" && (updateStatus === "LOADING" || showStatus === "LOADING"));
+  const combinedError =
+    mode === "add" ? addError : mode === "update" ? updateError || showError : null;
+
+  async function handleSubmit(
+    values: DistrictFormData,
+    _helpers: FormikHelpers<DistrictFormData>
+  ) {
+    try {
+      if (mode === "add") {
+        await addNewProgram({ name: values.name });
+      } else if (mode === "update" && id) {
+        await updateProgramDetails({ programId: Number(id), payload: { name: values.name } });
+      }
+      navigate("/parameters/country");
+    } catch (error) {
+      console.error("Error saving district:", error);
+    }
+  }
+
+  return (
+    <ReusableModalForm<DistrictFormData>
+      show={true}
+      title={mode === "add" ? "Mahalle Ekle" : "Mahalle Güncelle"}
+      fields={getFields}
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      confirmButtonLabel={mode === "add" ? "Ekle" : "Güncelle"}
+      cancelButtonLabel="Vazgeç"
+      isLoading={isLoading}
+      error={combinedError || null}
+      onClose={() => navigate("/parameters/country")}
+      autoGoBackOnModalClose
+    />
+  );
+};
+
+export default DistrictModal;

--- a/src/components/common/parameters/address_structure/district/table.tsx
+++ b/src/components/common/parameters/address_structure/district/table.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useDiscrictTable } from "../../../hooks/districts/useList";
+import ReusableTable, { ColumnDefinition, useDebounce } from "../../ReusableTable";
+import { IDistrict } from "../../../types/districts/list";
+import { deleteProgram } from "../../../slices/programs/delete/thunk";
+
+interface DistrictTableProps {
+  countyId?: number;
+  enabled?: boolean;
+}
+
+export default function DistrictTable({ countyId, enabled }: DistrictTableProps) {
+  const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState<number>(10);
+  const [inputName, setInputName] = useState("");
+  const debouncedName = useDebounce<string>(inputName, 500);
+  const [name, setName] = useState("");
+
+  useEffect(() => {
+    setName(debouncedName);
+  }, [debouncedName]);
+
+  const districtParams = useMemo(
+    () => ({
+      enabled: enabled,
+      page: page,
+      pageSize,
+      name: name,
+      county_id: countyId,
+    }),
+    [enabled, page, pageSize, name, countyId]
+  );
+
+  const { discrictData, loading, error } = useDiscrictTable(districtParams);
+
+  const columns: ColumnDefinition<IDistrict>[] = useMemo(
+    () => [
+      {
+        key: "name",
+        label: "Name",
+        render: (row) => row.name,
+      },
+      {
+        key: "actions",
+        label: "İşlemler",
+        render: (row, openDeleteModal) => (
+          <div className="flex gap-2">
+            <button
+              onClick={() => {
+                navigate(`/parameters/country/district-crud/${row.id}`);
+              }}
+              className="btn btn-icon btn-sm btn-info-light rounded-pill"
+            >
+              <i className="ti ti-pencil" />
+            </button>
+            <button
+              onClick={() => openDeleteModal && openDeleteModal(row)}
+              className="btn btn-icon btn-sm btn-danger-light rounded-pill"
+              style={{ marginLeft: "10px" }}
+            >
+              <i className="ti ti-trash" />
+            </button>
+          </div>
+        ),
+      },
+    ],
+    [navigate]
+  );
+
+  return (
+    <>
+      <ReusableTable<IDistrict>
+        columns={columns}
+        data={discrictData || []}
+        loading={loading}
+        error={error}
+        showModal={false}
+        tableMode="multi"
+        currentPage={page}
+        filters={[]}
+        onAdd={() => {
+          if (enabled) {
+            navigate("/parameters/country/district-crud/");
+          }
+        }}
+        onDeleteRow={(row) => {
+          deleteProgram(row.id);
+        }}
+        onPageChange={(newPage) => {
+          setPage(newPage);
+        }}
+        onPageSizeChange={(newSize) => {
+          setPageSize(newSize);
+          setPage(1);
+        }}
+        exportFileName="districts"
+        showExportButtons={true}
+      />
+    </>
+  );
+}

--- a/src/components/common/parameters/address_structure/index.tsx
+++ b/src/components/common/parameters/address_structure/index.tsx
@@ -1,0 +1,63 @@
+import { Row, Col, Card } from "react-bootstrap";
+import CountryTable from "./country/table";
+import CityTable from "./city/table";
+import CountyTable from "./county/table";
+import DistrictTable from "./district/table";
+import { useState } from "react";
+
+export default function AddressStructurePage() {
+  const [selectedCountryId, setSelectedCountryId] = useState<number>();
+  const [selectedCityId, setSelectedCityId] = useState<number>();
+  const [selectedCountyId, setSelectedCountyId] = useState<number>();
+  const [enabled, setEnabled] = useState(false);
+
+  return (
+    <div>
+      <Row>
+        <Col md={3}>
+          <Card>
+            <h5>Ülkeler</h5>
+            <CountryTable
+              onSelectCountry={(country) => {
+                setSelectedCountryId(country.id);
+                setEnabled(true);
+              }}
+            />
+          </Card>
+        </Col>
+        <Col md={3}>
+          <Card>
+            <h5>Şehirler</h5>
+            <CityTable
+              countryId={selectedCountryId}
+              enabled={enabled}
+              onSelectCity={(city) => {
+                setSelectedCityId(city.id);
+                setEnabled(true);
+              }}
+            />
+          </Card>
+        </Col>
+        <Col md={3}>
+          <Card>
+            <h5>İlçeler</h5>
+            <CountyTable
+              cityId={selectedCityId}
+              enabled={enabled}
+              onSelectCounty={(county) => {
+                setSelectedCountyId(county.id);
+                setEnabled(true);
+              }}
+            />
+          </Card>
+        </Col>
+        <Col md={3}>
+          <Card>
+            <h5>Mahalleler</h5>
+            <DistrictTable countyId={selectedCountyId} enabled={enabled} />
+          </Card>
+        </Col>
+      </Row>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add AddressStructurePage with Country, City, County and District tables
- implement CRUD modals for each address level
- register new page and modals in routing

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_683eba68ed5c832c8f06cca803b4df86