### PR TITLE
Fix address selection tables

### DIFF
--- a/src/components/common/parameters/address_structure/index.tsx
+++ b/src/components/common/parameters/address_structure/index.tsx
@@ -9,7 +9,10 @@ export default function AddressStructurePage() {
   const [selectedCountryId, setSelectedCountryId] = useState<number>();
   const [selectedCityId, setSelectedCityId] = useState<number>();
   const [selectedCountyId, setSelectedCountyId] = useState<number>();
-  const [enabled, setEnabled] = useState(false);
+
+  const [cityEnabled, setCityEnabled] = useState(false);
+  const [countyEnabled, setCountyEnabled] = useState(false);
+  const [districtEnabled, setDistrictEnabled] = useState(false);
 
   return (
     <div>
@@ -20,7 +23,11 @@ export default function AddressStructurePage() {
             <CountryTable
               onSelectCountry={(country) => {
                 setSelectedCountryId(country.id);
-                setEnabled(true);
+                setCityEnabled(true);
+                setCountyEnabled(false);
+                setDistrictEnabled(false);
+                setSelectedCityId(undefined);
+                setSelectedCountyId(undefined);
               }}
             />
           </Card>
@@ -30,10 +37,12 @@ export default function AddressStructurePage() {
             <h5>Şehirler</h5>
             <CityTable
               countryId={selectedCountryId}
-              enabled={enabled}
+              enabled={cityEnabled}
               onSelectCity={(city) => {
                 setSelectedCityId(city.id);
-                setEnabled(true);
+                setCountyEnabled(true);
+                setDistrictEnabled(false);
+                setSelectedCountyId(undefined);
               }}
             />
           </Card>
@@ -43,10 +52,10 @@ export default function AddressStructurePage() {
             <h5>İlçeler</h5>
             <CountyTable
               cityId={selectedCityId}
-              enabled={enabled}
+              enabled={countyEnabled}
               onSelectCounty={(county) => {
                 setSelectedCountyId(county.id);
-                setEnabled(true);
+                setDistrictEnabled(true);
               }}
             />
           </Card>
@@ -54,7 +63,7 @@ export default function AddressStructurePage() {
         <Col md={3}>
           <Card>
             <h5>Mahalleler</h5>
-            <DistrictTable countyId={selectedCountyId} enabled={enabled} />
+            <DistrictTable countyId={selectedCountyId} enabled={districtEnabled} />
           </Card>
         </Col>
       </Row>

--- a/src/components/hooks/city/useList.tsx
+++ b/src/components/hooks/city/useList.tsx
@@ -22,12 +22,11 @@ export function useCityTable(params: CityLListArg) {
 
     dispatch(
       fetchCities({
-        enabled,
         ...otherParams,
         filter,
       })
     );
-  }, [enabled, filter, dispatch]);
+  }, [enabled, filter, dispatch, JSON.stringify(otherParams)]);
   const loading = status === CityListStatus.LOADING;
   const cityData: City[] = data || [];
 

--- a/src/components/hooks/county/useCountyList.tsx
+++ b/src/components/hooks/county/useCountyList.tsx
@@ -19,7 +19,7 @@ export function useListCounties(params :CountyLListArg) {
   useEffect(() => {
     if (!enabled) return;
     dispatch(fetchCounties({ ...otherParams, filter }));
-  }, [enabled, filter, dispatch]);
+  }, [enabled, filter, dispatch, JSON.stringify(otherParams)]);
 
 
   const Countriesdata = data || [];

--- a/src/components/hooks/districts/useList.tsx
+++ b/src/components/hooks/districts/useList.tsx
@@ -27,7 +27,7 @@ export function useDiscrictTable(params: DistrictListArg) {
         filter,
       })
     );
-  }, [enabled, filter, dispatch]);
+  }, [enabled, filter, dispatch, JSON.stringify(otherParams)]);
 
   const loading = status === DistrictsListStatus.LOADING;
   const discrictData: IDistrict[] | null = Array.isArray(data) ? data : data ? [data] : null;

--- a/src/slices/cities/list/reducer.tsx
+++ b/src/slices/cities/list/reducer.tsx
@@ -20,7 +20,7 @@ const cityListSlice = createSlice({
     });
     builder.addCase(fetchCities.fulfilled, (state, action: PayloadAction<any>) => {
       state.status = CityListStatus.SUCCEEDED;
-      state.data = [action.payload];
+      state.data = action.payload.data;
     });
     builder.addCase(fetchCities.rejected, (state, action) => {
       state.status = CityListStatus.FAILED;

--- a/src/slices/cities/list/thunk.tsx
+++ b/src/slices/cities/list/thunk.tsx
@@ -1,9 +1,9 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import axiosInstance from '../../../services/axiosClient';
 import { CITIES } from '../../../helpers/url_helper';
-import { City, CityLListArg } from '../../../types/city/list';
+import { CityListResponse, CityLListArg } from '../../../types/city/list';
 
-export const fetchCities = createAsyncThunk<City, CityLListArg>(
+export const fetchCities = createAsyncThunk<CityListResponse, CityLListArg>(
   'address/fetchCities',
   async (queryParams, { rejectWithValue }) => {
     try {
@@ -17,7 +17,7 @@ export const fetchCities = createAsyncThunk<City, CityLListArg>(
       const queryString = query.toString();
       const response = await axiosInstance.get(`${CITIES}?${queryString}`);
 
-      return response.data as City;
+      return response.data as CityListResponse;
     } catch (err: any) {
       return rejectWithValue(err.response?.data?.message || 'Fetch Cities failed');
     }

--- a/src/slices/counties/list/reducer.tsx
+++ b/src/slices/counties/list/reducer.tsx
@@ -21,7 +21,7 @@ const countyListSlice = createSlice({
     });
     builder.addCase(fetchCounties.fulfilled, (state, action: PayloadAction<any>) => {
       state.status = CountyListStatus.SUCCEEDED;
-      state.data = action.payload;
+      state.data = action.payload.data;
     });
     builder.addCase(fetchCounties.rejected, (state, action) => {
       state.status = CountyListStatus.FAILED;

--- a/src/types/city/list.tsx
+++ b/src/types/city/list.tsx
@@ -15,6 +15,12 @@ export interface CityListState {
   status: CityListStatus;
   error: string | null;
 }
+
+export interface CityListResponse {
+  data: City[];
+  links?: any;
+  meta?: any;
+}
 export interface CityLListArg {
   enabled?: boolean;
   [key: string]: any;


### PR DESCRIPTION
## Summary
- refine city list thunk and reducer
- update county reducer for list response
- track fetch params in address structure hooks
- control table enable flags per selection
- add `CityListResponse` type

## Testing
- `npm run build` *(fails: Cannot find module 'vite' or its types)*

------
https://chatgpt.com/codex/tasks/task_e_683eca3f4490832cadd4f0109297ce17