### PR TITLE
Fix payload types in address CRUD components

### DIFF
--- a/src/components/common/country_parameters/city/crud.tsx
+++ b/src/components/common/country_parameters/city/crud.tsx
@@ -7,10 +7,9 @@ import { updateCity } from "../../../../slices/cities/update/thunk";
 import { showCity } from "../../../../slices/cities/show/thunk";
 import { useDispatch } from "react-redux";
 import { AppDispatch } from "../../../store";
+import { AddCityPayload } from "../../../../types/city/add";
 
-interface FormData extends FormikValues {
-  name: string;
-}
+interface FormData extends FormikValues, AddCityPayload {}
 
 export default function CityCrud() {
   const { id } = useParams<{ id?: string }>();
@@ -18,7 +17,10 @@ export default function CityCrud() {
   const location = useLocation() as { state?: { country_id?: number } };
   const dispatch = useDispatch<AppDispatch>();
   const mode = id ? "update" : "add";
-  const [initialValues, setInitialValues] = useState<FormData>({ name: "" });
+  const [initialValues, setInitialValues] = useState<FormData>({
+    name: "",
+    country_id: location.state?.country_id ?? 0,
+  });
 
   const getFields = (): FieldDefinition[] => [
     { name: "name", label: "Şehir Adı", type: "text", required: true },
@@ -28,7 +30,10 @@ export default function CityCrud() {
     if (mode === "update" && id) {
       dispatch(showCity(Number(id))).then((res: any) => {
         if (showCity.fulfilled.match(res)) {
-          setInitialValues({ name: res.payload.cityName });
+          setInitialValues({
+            name: res.payload.cityName,
+            country_id: res.payload.countryId,
+          });
         }
       });
     }
@@ -36,7 +41,7 @@ export default function CityCrud() {
 
   const handleSubmit = async (values: FormData, _helpers: FormikHelpers<FormData>) => {
     if (mode === "add") {
-      await dispatch(addCity({ ...values, country_id: location.state?.country_id || 0 }));
+      await dispatch(addCity(values));
     } else if (id) {
       await dispatch(updateCity({ cityId: Number(id), payload: values }));
     }

--- a/src/components/common/country_parameters/county/crud.tsx
+++ b/src/components/common/country_parameters/county/crud.tsx
@@ -7,10 +7,9 @@ import { updateCounty } from "../../../../slices/counties/update/thunk";
 import { showCounty } from "../../../../slices/counties/show/thunk";
 import { useDispatch } from "react-redux";
 import { AppDispatch } from "../../../store";
+import { AddCountyPayload } from "../../../../types/counties/add";
 
-interface FormData extends FormikValues {
-  name: string;
-}
+interface FormData extends FormikValues, AddCountyPayload {}
 
 export default function CountyCrud() {
   const { id } = useParams<{ id?: string }>();
@@ -18,7 +17,10 @@ export default function CountyCrud() {
   const location = useLocation() as { state?: { city_id?: number } };
   const dispatch = useDispatch<AppDispatch>();
   const mode = id ? "update" : "add";
-  const [initialValues, setInitialValues] = useState<FormData>({ name: "" });
+  const [initialValues, setInitialValues] = useState<FormData>({
+    name: "",
+    city_id: location.state?.city_id ?? 0,
+  });
 
   const getFields = (): FieldDefinition[] => [
     { name: "name", label: "İlçe Adı", type: "text", required: true },
@@ -28,7 +30,10 @@ export default function CountyCrud() {
     if (mode === "update" && id) {
       dispatch(showCounty(Number(id))).then((res: any) => {
         if (showCounty.fulfilled.match(res)) {
-          setInitialValues({ name: res.payload.name });
+          setInitialValues({
+            name: res.payload.name,
+            city_id: res.payload.city_id,
+          });
         }
       });
     }
@@ -36,7 +41,7 @@ export default function CountyCrud() {
 
   const handleSubmit = async (values: FormData, _helpers: FormikHelpers<FormData>) => {
     if (mode === "add") {
-      await dispatch(addCounty({ ...values, city_id: location.state?.city_id || 0 }));
+      await dispatch(addCounty(values));
     } else if (id) {
       await dispatch(updateCounty({ countyId: Number(id), payload: values }));
     }

--- a/src/components/common/country_parameters/district/crud.tsx
+++ b/src/components/common/country_parameters/district/crud.tsx
@@ -7,10 +7,9 @@ import { updateDistrict } from "../../../../slices/districts/update/thunk";
 import { showDistrict } from "../../../../slices/districts/show/thunk";
 import { useDispatch } from "react-redux";
 import { AppDispatch } from "../../../store";
+import { AddDistrictPayload } from "../../../../types/districts/add";
 
-interface FormData extends FormikValues {
-  name: string;
-}
+interface FormData extends FormikValues, AddDistrictPayload {}
 
 export default function DistrictCrud() {
   const { id } = useParams<{ id?: string }>();
@@ -18,7 +17,10 @@ export default function DistrictCrud() {
   const location = useLocation() as { state?: { county_id?: number } };
   const dispatch = useDispatch<AppDispatch>();
   const mode = id ? "update" : "add";
-  const [initialValues, setInitialValues] = useState<FormData>({ name: "" });
+  const [initialValues, setInitialValues] = useState<FormData>({
+    name: "",
+    county_id: location.state?.county_id ?? 0,
+  });
 
   const getFields = (): FieldDefinition[] => [
     { name: "name", label: "Mahalle Adı", type: "text", required: true },
@@ -28,7 +30,10 @@ export default function DistrictCrud() {
     if (mode === "update" && id) {
       dispatch(showDistrict(Number(id))).then((res: any) => {
         if (showDistrict.fulfilled.match(res)) {
-          setInitialValues({ name: res.payload.name });
+          setInitialValues({
+            name: res.payload.name,
+            county_id: res.payload.data?.county_id ?? res.payload.county_id,
+          });
         }
       });
     }
@@ -36,7 +41,7 @@ export default function DistrictCrud() {
 
   const handleSubmit = async (values: FormData, _helpers: FormikHelpers<FormData>) => {
     if (mode === "add") {
-      await dispatch(addDistrict({ ...values, county_id: location.state?.county_id || 0 }));
+      await dispatch(addDistrict(values));
     } else if (id) {
       await dispatch(updateDistrict({ districtId: Number(id), payload: values }));
     }


### PR DESCRIPTION
## Summary
- include foreign key IDs in form data for city, county and district CRUD
- update fetch effects and submit handlers accordingly

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: missing modules/types)*

------
https://chatgpt.com/codex/tasks/task_e_683ed0364c0c832caa4d7aa110fa1274