### PR TITLE
Adjust homework pages filter layout

### DIFF
--- a/src/components/common/homework/pages/assignmentsCheck/table.tsx
+++ b/src/components/common/homework/pages/assignmentsCheck/table.tsx
@@ -5,6 +5,7 @@ import ReusableTable, {
     ColumnDefinition,
     FilterDefinition,
 } from '../../../ReusableTable';
+import FilterGroup from '../../components/organisms/SearchFilters';
 
 import { useAssignmentStudentsList } from '../../../../hooks/assignmentStudents/useList';
 import { AssignmentStudentData as AssignmentRow } from '../../../../../types/assignmentStudents/list';
@@ -218,22 +219,29 @@ export default function AssignmentsCheckTable() {
 
 
     return (
-        <ReusableTable<AssignmentRow>
-            columns={columns}
-            data={assignmentStudentsData}
-            loading={loading}
-            error={error}
-            filters={filters}
-            showModal={false}
-            showExportButtons
-            tableMode="single"
-            currentPage={page}
-            totalPages={totalPages}
-            totalItems={totalItems}
-            pageSize={pageSize}
-            onPageChange={setPage}
-            onPageSizeChange={size => { setPageSize(size); setPage(1); }}
-            exportFileName="student_assignment_list"
-        />
+        <>
+            <FilterGroup
+                filters={filters}
+                columnsPerRow={4}
+                navigate={navigate}
+            />
+
+            <ReusableTable<AssignmentRow>
+                columns={columns}
+                data={assignmentStudentsData}
+                loading={loading}
+                error={error}
+                showModal={false}
+                showExportButtons
+                tableMode="single"
+                currentPage={page}
+                totalPages={totalPages}
+                totalItems={totalItems}
+                pageSize={pageSize}
+                onPageChange={setPage}
+                onPageSizeChange={size => { setPageSize(size); setPage(1); }}
+                exportFileName="student_assignment_list"
+            />
+        </>
     );
 }

--- a/src/components/common/homework/pages/assignmentsCount/assigned/table.tsx
+++ b/src/components/common/homework/pages/assignmentsCount/assigned/table.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import ReusableTable, { ColumnDefinition, FilterDefinition, } from '../../../../ReusableTable';
+import FilterGroup from '../../components/organisms/SearchFilters';
 import { useAssignmentStudentsList } from '../../../../../hooks/assignmentStudents/useList';
 import { AssignmentStudentData as AssignmentRow } from '../../../../../../types/assignmentStudents/list';
 
@@ -197,6 +198,11 @@ export default function GivenHomeworkCount() {
 
     return (
         <div>
+            <FilterGroup
+                filters={filters}
+                columnsPerRow={4}
+                navigate={navigate}
+            />
             <ReusableTable<AssignmentRow>
                 columns={columns}
                 data={assignmentStudentsData}
@@ -205,7 +211,6 @@ export default function GivenHomeworkCount() {
                 showExportButtons={true}
                 tableMode="single"
                 error={error}
-                filters={filters}
                 currentPage={page}
                 totalPages={totalPages}
                 totalItems={totalItems}

--- a/src/components/common/homework/pages/assignmentsCount/planned/table.tsx
+++ b/src/components/common/homework/pages/assignmentsCount/planned/table.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import ReusableTable, { ColumnDefinition, FilterDefinition, } from '../../../../ReusableTable';
+import FilterGroup from '../../components/organisms/SearchFilters';
 import { useAssignmentStudentsList } from '../../../../../hooks/assignmentStudents/useList';
 import { AssignmentStudentData as AssignmentRow } from '../../../../../../types/assignmentStudents/list';
 
@@ -204,6 +205,11 @@ export default function PlannedHomeworkCount() {
 
     return (
         <div>
+            <FilterGroup
+                filters={filters}
+                columnsPerRow={4}
+                navigate={navigate}
+            />
             <ReusableTable<AssignmentRow>
                 columns={columns}
                 data={assignmentStudentsData}
@@ -212,7 +218,6 @@ export default function PlannedHomeworkCount() {
                 showExportButtons={true}
                 tableMode="single"
                 error={error}
-                filters={filters}
                 currentPage={page}
                 totalPages={totalPages}
                 totalItems={totalItems}

--- a/src/components/common/homework/pages/assignmentsCount/resolved/table.tsx
+++ b/src/components/common/homework/pages/assignmentsCount/resolved/table.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import ReusableTable, { ColumnDefinition, FilterDefinition, } from '../../../../ReusableTable';
+import FilterGroup from '../../components/organisms/SearchFilters';
 import { useAssignmentStudentsList } from '../../../../../hooks/assignmentStudents/useList';
 import { AssignmentStudentData as AssignmentRow } from '../../../../../../types/assignmentStudents/list';
 
@@ -188,6 +189,11 @@ export default function CompletedHomeworkCount() {
 
     return (
         <div>
+            <FilterGroup
+                filters={filters}
+                columnsPerRow={4}
+                navigate={navigate}
+            />
             <ReusableTable<AssignmentRow>
                 columns={columns}
                 data={assignmentStudentsData}
@@ -196,7 +202,6 @@ export default function CompletedHomeworkCount() {
                 showExportButtons={true}
                 tableMode="single"
                 error={error}
-                filters={filters}
                 currentPage={page}
                 totalPages={totalPages}
                 totalItems={totalItems}

--- a/src/components/common/homework/pages/assignmentsDefinition/table.tsx
+++ b/src/components/common/homework/pages/assignmentsDefinition/table.tsx
@@ -7,6 +7,7 @@ import ReusableTable, {
     ColumnDefinition,
     FilterDefinition,
 } from "../../../ReusableTable";
+import FilterGroup from "../../components/organisms/SearchFilters";
 
 import { useAssignmentStudentsList } from "../../../../hooks/assignmentStudents/useList";
 import { useAssignmentStudentDelete } from "../../../../hooks/assignmentStudents/useDelete";
@@ -244,23 +245,30 @@ export default function DefiningHomeworkPage() {
 
 
     return (
-        <ReusableTable<AssignmentRow>
-            columns={columns}
-            data={assignmentStudentsData}
-            loading={loading}
-            error={error}
-            filters={filters}
-            showModal={false}
-            showExportButtons
-            tableMode="single"
-            currentPage={page}
-            totalPages={totalPages}
-            totalItems={totalItems}
-            pageSize={pageSize}
-            onPageChange={setPage}
-            onPageSizeChange={size => { setPageSize(size); setPage(1); }}
-            exportFileName="defining-homework"
-            onAdd={() => navigate('/homework/definingHomework/crud')}
-        />
+        <>
+            <FilterGroup
+                filters={filters}
+                columnsPerRow={4}
+                navigate={navigate}
+            />
+
+            <ReusableTable<AssignmentRow>
+                columns={columns}
+                data={assignmentStudentsData}
+                loading={loading}
+                error={error}
+                showModal={false}
+                showExportButtons
+                tableMode="single"
+                currentPage={page}
+                totalPages={totalPages}
+                totalItems={totalItems}
+                pageSize={pageSize}
+                onPageChange={setPage}
+                onPageSizeChange={size => { setPageSize(size); setPage(1); }}
+                exportFileName="defining-homework"
+                onAdd={() => navigate('/homework/definingHomework/crud')}
+            />
+        </>
     );
 }

--- a/src/components/common/homework/pages/assignmentsList/table.tsx
+++ b/src/components/common/homework/pages/assignmentsList/table.tsx
@@ -6,6 +6,7 @@ import ReusableTable, {
     ColumnDefinition,
     FilterDefinition,
 } from '../../../ReusableTable';
+import FilterGroup from '../../components/organisms/SearchFilters';
 
 import { useAssignmentStudentsList } from '../../../../hooks/assignmentStudents/useList';
 import { useAssignmentStudentDelete } from '../../../../hooks/assignmentStudents/useDelete';
@@ -258,26 +259,33 @@ export default function AssignmentsListTable() {
 
     /* ----------------------------------- UI ----------------------------------- */
     return (
-        <ReusableTable<AssignmentRow>
+        <>
+            <FilterGroup
+                filters={filters}
+                columnsPerRow={4}
+                navigate={navigate}
+            />
 
-            columns={columns}
-            data={assignmentStudentsData}
-            loading={loading}
-            showModal={false}
-            showExportButtons
-            tableMode="single"
-            error={error}
-            filters={filters}
-            currentPage={page}
-            totalPages={totalPages}
-            totalItems={totalItems}
-            pageSize={pageSize}
-            onPageChange={(p) => setPage(p)}
-            onPageSizeChange={(size) => {
-                setPageSize(size);
-                setPage(1);
-            }}
-            exportFileName="student_assignment_list"
-        />
+            <ReusableTable<AssignmentRow>
+
+                columns={columns}
+                data={assignmentStudentsData}
+                loading={loading}
+                showModal={false}
+                showExportButtons
+                tableMode="single"
+                error={error}
+                currentPage={page}
+                totalPages={totalPages}
+                totalItems={totalItems}
+                pageSize={pageSize}
+                onPageChange={(p) => setPage(p)}
+                onPageSizeChange={(size) => {
+                    setPageSize(size);
+                    setPage(1);
+                }}
+                exportFileName="student_assignment_list"
+            />
+        </>
     );
 }

--- a/src/components/common/homework/pages/plannedAssignments/table.tsx
+++ b/src/components/common/homework/pages/plannedAssignments/table.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import ReusableTable, {
     ColumnDefinition,
 } from '../../../ReusableTable';
+import FilterGroup from '../../components/organisms/SearchFilters';
 
 import { useAssignmentsList } from '../../../../hooks/assignments/useList';
 import { useAssignmentDelete } from '../../../../hooks/assignments/useDelete';
@@ -297,26 +298,33 @@ export default function PlannedAssignmentsTable() {
 
     /* ---------------- render ---------------- */
     return (
-        <ReusableTable<AssignmentData>
-            onAdd={() => navigate('/plannedhomework/crud')}
-            tableMode="single"
-            columns={columns}
-            data={assignmentsData}
-            loading={loading}
-            error={error}
-            filters={filters}
-            showModal={false}
-            showExportButtons
-            currentPage={page}
-            totalPages={totalPages}
-            totalItems={totalItems}
-            pageSize={pageSize}
-            onPageChange={setPage}
-            onPageSizeChange={(s) => {
-                setPageSize(s);
-                setPage(1);
-            }}
-            exportFileName="student_assignment_list"
-        />
+        <>
+            <FilterGroup
+                filters={filters}
+                columnsPerRow={4}
+                navigate={navigate}
+            />
+
+            <ReusableTable<AssignmentData>
+                onAdd={() => navigate('/plannedhomework/crud')}
+                tableMode="single"
+                columns={columns}
+                data={assignmentsData}
+                loading={loading}
+                error={error}
+                showModal={false}
+                showExportButtons
+                currentPage={page}
+                totalPages={totalPages}
+                totalItems={totalItems}
+                pageSize={pageSize}
+                onPageChange={setPage}
+                onPageSizeChange={(s) => {
+                    setPageSize(s);
+                    setPage(1);
+                }}
+                exportFileName="student_assignment_list"
+            />
+        </>
     );
 }


### PR DESCRIPTION
## Summary
- show homework filters using `FilterGroup` to match other modules
- pass `columnsPerRow={4}` so four filters display per row

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: missing modules/types)*

------
https://chatgpt.com/codex/tasks/task_e_683ef26ce97c832c8c94e312b121ed3b