### PR TITLE
Use Pageheader in polling management modules

### DIFF
--- a/src/components/common/pollingManagement/administrativeSupportTeam/index.tsx
+++ b/src/components/common/pollingManagement/administrativeSupportTeam/index.tsx
@@ -9,6 +9,7 @@ import TabsContainer from './component/organisms/TabsContainer';
 
 /* Sayfa içerikleri                                                          */
 import AdministrativeRequestTable from './pages/request/table';
+import Pageheader from '../../../page-header/pageheader';
 
 /* ========================================================================== */
 const AdministrativeSupportTeamPage: React.FC = () => {
@@ -22,7 +23,7 @@ const AdministrativeSupportTeamPage: React.FC = () => {
 
     return (
         <div className="px-4">
-            <h5>Okul-İdare Ve Destek Kadrosu</h5>
+            <Pageheader title="Yoklama Yönetimi" currentpage="Okul-İdare Ve Destek Kadrosu" />
 
             <TabsContainer
                 tabs={tabsConfig}

--- a/src/components/common/pollingManagement/class-course/index.tsx
+++ b/src/components/common/pollingManagement/class-course/index.tsx
@@ -6,6 +6,7 @@ import TabsContainer from './component/organisms/TabsContainer';
 import ExecutiveStatusTable from './pages/executiveStatus/table';
 import PollingListTable from './pages/pollingList/table';
 import PollingCountsTable from './pages/pollingCounts/table';
+import Pageheader from '../../../page-header/pageheader';
 
 
 
@@ -44,7 +45,7 @@ const PollingManagementPage: React.FC = () => {
 
     return (
         <div className="px-4">
-            <h5>Sınıf &amp; Ders</h5>
+            <Pageheader title="Yoklama Yönetimi" currentpage="Sınıf & Ders" />
 
             <TabsContainer
                 tabs={tabsConfig}

--- a/src/components/common/pollingManagement/clupPolling/index.tsx
+++ b/src/components/common/pollingManagement/clupPolling/index.tsx
@@ -7,6 +7,7 @@ import ClubGroupPlanTable from './pages/clupPlan/table';
 import ClubProgramTable from './pages/clupProgram/table';
 import ClubPollingTable from './pages/clupPolling/table';
 import ClubCountTable from './pages/clupCount/table';
+import Pageheader from "../../../page-header/pageheader";
 
 /* -------------------------------------------------------------- */
 const ClupPollingManagementPage: React.FC = () => {
@@ -23,7 +24,7 @@ const ClupPollingManagementPage: React.FC = () => {
 
     return (
         <div className="px-4">
-            <h5>Kulüp Yoklama</h5>
+            <Pageheader title="Yoklama Yönetimi" currentpage="Kulüp Yoklama" />
 
             <TabsContainer
                 tabs={tabs}

--- a/src/components/common/pollingManagement/foodPolling/index.tsx
+++ b/src/components/common/pollingManagement/foodPolling/index.tsx
@@ -7,6 +7,7 @@ import FoodAttendanceTable from './pages/foodPolling/table';
 import FoodGroupPlanTable from './pages/groupPlan/table';
 import FoodOfficerListTable from './pages/officerList/table';
 import FoodPollingCountsTable from './pages/pollingCount/table';
+import Pageheader from "../../../page-header/pageheader";
 
 /* -------------------------------------------------------------- */
 const ClupPollingManagementPage: React.FC = () => {
@@ -23,7 +24,7 @@ const ClupPollingManagementPage: React.FC = () => {
 
     return (
         <div className="px-4">
-            <h5>Yemek Yoklama</h5>
+            <Pageheader title="Yoklama Yönetimi" currentpage="Yemek Yoklama" />
 
             <TabsContainer
                 tabs={tabs}

--- a/src/components/common/pollingManagement/oneToOne/index.tsx
+++ b/src/components/common/pollingManagement/oneToOne/index.tsx
@@ -10,6 +10,7 @@ import StudentPlanTable from './pages/plan/table';             // Birebir Planla
 import OneToOnePollingTable from './pages/polling/table';          // Birebir Yoklama
 import CountTeacherTable from './pages/countTeacher/table';     // Öğretmen Birebir Sayıları
 import CountStudentTable from './pages/countStudent/table';     // Öğrenci Birebir Sayıları
+import Pageheader from "../../../page-header/pageheader";
 
 /* -------------------------------------------------------------------- */
 const OneToOneManagementPage: React.FC = () => {
@@ -27,7 +28,7 @@ const OneToOneManagementPage: React.FC = () => {
 
   return (
     <div className="px-4">
-      <h5>Birebir Yoklama</h5>
+      <Pageheader title="Yoklama Yönetimi" currentpage="Birebir Yoklama" />
 
       <TabsContainer
         tabs={tabs}

--- a/src/components/common/pollingManagement/parent/parentindex.tsx
+++ b/src/components/common/pollingManagement/parent/parentindex.tsx
@@ -2,6 +2,7 @@ import { useState, FC } from 'react';
 import TabsContainer from '../class-course/component/organisms/TabsContainer';
 
 import ParentRequestEntryTable from './pages/requestEntry/table';
+import Pageheader from "../../../page-header/pageheader";
 
 
 const ParentIndexPage: FC = () => {
@@ -13,7 +14,7 @@ const ParentIndexPage: FC = () => {
 
     return (
         <div className="px-4">
-            <h5>Veli Talep Girişi</h5>
+            <Pageheader title="Yoklama Yönetimi" currentpage="Veli Talep Girişi" />
 
             <TabsContainer
                 tabs={tabs}

--- a/src/components/common/pollingManagement/personel-teachers/index.tsx
+++ b/src/components/common/pollingManagement/personel-teachers/index.tsx
@@ -11,6 +11,7 @@ import TabsContainer from './component/organisms/TabsContainer';
 import DemandManagementTable from './pages/demandManagement/table';
 import DailyPollingTable from './pages/daily/table';
 import PollingCountsTable from './pages/count/table';
+import Pageheader from "../../../page-header/pageheader";
 
 /* ========================================================================== */
 const StaffPollingManagementPage: React.FC = () => {
@@ -26,7 +27,7 @@ const StaffPollingManagementPage: React.FC = () => {
 
     return (
         <div className="px-4">
-            <h5>Personel / Öğretmen Yoklama</h5>
+            <Pageheader title="Yoklama Yönetimi" currentpage="Personel / Öğretmen Yoklama" />
 
             <TabsContainer
                 tabs={tabsConfig}

--- a/src/components/common/pollingManagement/studyPolling/index.tsx
+++ b/src/components/common/pollingManagement/studyPolling/index.tsx
@@ -8,6 +8,7 @@ import StudyPlanTable from './pages/studyPlan/table';
 import StudyProgramTable from './pages/studyProgram/table';
 import StudyPollingTable from './pages/studyPolling/table';
 import PollingCountTable from './pages/pollingCount/table';
+import Pageheader from "../../../page-header/pageheader";
 
 const StudyPollingPage: React.FC = () => {
     /* active-tab state */
@@ -23,7 +24,7 @@ const StudyPollingPage: React.FC = () => {
 
     return (
         <div className="px-4">
-            <h5>Etüt Yoklama</h5>
+            <Pageheader title="Yoklama Yönetimi" currentpage="Etüt Yoklama" />
 
             <TabsContainer
                 tabs={tabsConfig}

--- a/src/components/common/pollingManagement/teachers/teacherIndex.tsx
+++ b/src/components/common/pollingManagement/teachers/teacherIndex.tsx
@@ -5,6 +5,7 @@ import TabsContainer from './component/organisms/TabsContainer';
 import TeachersTable from './pages/teachers/table';
 import TeachersPollingTable from './pages/teachersPolling/table';
 import LessonPollingTable from './pages/lesson/table';
+import Pageheader from "../../../page-header/pageheader";
 
 
 
@@ -21,7 +22,7 @@ const TeacherPollingManagementPage: React.FC = () => {
 
     return (
         <div className="px-4">
-            <h5>Öğretmen Yoklama</h5>
+            <Pageheader title="Yoklama Yönetimi" currentpage="Öğretmen Yoklama" />
 
             <TabsContainer
                 tabs={tabsConfig}


### PR DESCRIPTION
## Summary
- switch polling management module headers from h5 tags to the shared `Pageheader` component

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_683efd10594c832cb40f7300597441ed