### PR TITLE
Align polling management tabs with guidance style

### DIFF
--- a/src/components/common/pollingManagement/administrativeSupportTeam/index.tsx
+++ b/src/components/common/pollingManagement/administrativeSupportTeam/index.tsx
@@ -18,7 +18,14 @@ const AdministrativeSupportTeamPage: React.FC = () => {
 
     /* Sekme etiketleri + içerikleri                                           */
     const tabsConfig = [
-        { label: 'Talep Girişi', content: <AdministrativeRequestTable /> },
+        {
+            label: 'Talep Girişi',
+            content: <AdministrativeRequestTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
     ];
 
     return (

--- a/src/components/common/pollingManagement/class-course/index.tsx
+++ b/src/components/common/pollingManagement/class-course/index.tsx
@@ -21,7 +21,7 @@ const PollingManagementPage: React.FC = () => {
             content: <ExecutiveStatusTable />,
             activeBgColor: '#5C67F7',
             activeTextColor: '#FFFFFF',
-            passiveBgColor: '#E1E4FB',
+            passiveBgColor: '#5C67F726',
             passiveTextColor: '#5C67F7',
         },
         {
@@ -29,7 +29,7 @@ const PollingManagementPage: React.FC = () => {
             content: <PollingListTable />,
             activeBgColor: '#5C67F7',
             activeTextColor: '#FFFFFF',
-            passiveBgColor: '#E1E4FB',
+            passiveBgColor: '#5C67F726',
             passiveTextColor: '#5C67F7',
         },
         {
@@ -37,7 +37,7 @@ const PollingManagementPage: React.FC = () => {
             content: <PollingCountsTable />,
             activeBgColor: '#5C67F7',
             activeTextColor: '#FFFFFF',
-            passiveBgColor: '#E1E4FB',
+            passiveBgColor: '#5C67F726',
             passiveTextColor: '#5C67F7',
         },
 

--- a/src/components/common/pollingManagement/clupPolling/index.tsx
+++ b/src/components/common/pollingManagement/clupPolling/index.tsx
@@ -16,10 +16,38 @@ const ClupPollingManagementPage: React.FC = () => {
 
     /* sekme başlıkları ve içerikleri */
     const tabs = [
-        { label: 'Kulüp Planla', content: <ClubGroupPlanTable /> },
-        { label: 'Kulüp Programı', content: <ClubProgramTable /> },
-        { label: 'Kulüp Yoklama', content: <ClubPollingTable /> },
-        { label: 'Yoklama Sayıları', content: <ClubCountTable /> },
+        {
+            label: 'Kulüp Planla',
+            content: <ClubGroupPlanTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+        {
+            label: 'Kulüp Programı',
+            content: <ClubProgramTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+        {
+            label: 'Kulüp Yoklama',
+            content: <ClubPollingTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+        {
+            label: 'Yoklama Sayıları',
+            content: <ClubCountTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
     ];
 
     return (

--- a/src/components/common/pollingManagement/foodPolling/index.tsx
+++ b/src/components/common/pollingManagement/foodPolling/index.tsx
@@ -16,10 +16,38 @@ const ClupPollingManagementPage: React.FC = () => {
 
     /* sekme başlıkları ve içerikleri */
     const tabs = [
-        { label: 'Grup Planla', content: <FoodGroupPlanTable /> },
-        { label: 'Görevli Listesi', content: <FoodOfficerListTable /> },
-        { label: 'Yemek Yoklama', content: <FoodAttendanceTable /> },
-        { label: 'Yoklama Sayıları', content: <FoodPollingCountsTable /> },
+        {
+            label: 'Grup Planla',
+            content: <FoodGroupPlanTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+        {
+            label: 'Görevli Listesi',
+            content: <FoodOfficerListTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+        {
+            label: 'Yemek Yoklama',
+            content: <FoodAttendanceTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+        {
+            label: 'Yoklama Sayıları',
+            content: <FoodPollingCountsTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
     ];
 
     return (

--- a/src/components/common/pollingManagement/oneToOne/index.tsx
+++ b/src/components/common/pollingManagement/oneToOne/index.tsx
@@ -19,11 +19,46 @@ const OneToOneManagementPage: React.FC = () => {
 
   /* sekme başlıkları ve içerikleri */
   const tabs = [
-    { label: 'Öğretmen Birebir', content: <TeacherOneByOnePlanTable /> },
-    { label: 'Birebir Planla', content: <StudentPlanTable /> },
-    { label: 'Birebir Yoklama', content: <OneToOnePollingTable /> },
-    { label: 'Öğretmen Birebir Sayıları', content: <CountTeacherTable /> },
-    { label: 'Öğrenci Birebir Sayıları', content: <CountStudentTable /> },
+    {
+      label: 'Öğretmen Birebir',
+      content: <TeacherOneByOnePlanTable />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#5C67F726',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Birebir Planla',
+      content: <StudentPlanTable />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#5C67F726',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Birebir Yoklama',
+      content: <OneToOnePollingTable />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#5C67F726',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Öğretmen Birebir Sayıları',
+      content: <CountTeacherTable />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#5C67F726',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Öğrenci Birebir Sayıları',
+      content: <CountStudentTable />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#5C67F726',
+      passiveTextColor: '#5C67F7',
+    },
   ];
 
   return (

--- a/src/components/common/pollingManagement/parent/parentindex.tsx
+++ b/src/components/common/pollingManagement/parent/parentindex.tsx
@@ -9,7 +9,14 @@ const ParentIndexPage: FC = () => {
     const [activeIdx, setActiveIdx] = useState<number>(0);
 
     const tabs = [
-        { label: 'Talep Girişi', content: <ParentRequestEntryTable /> },
+        {
+            label: 'Talep Girişi',
+            content: <ParentRequestEntryTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
     ];
 
     return (

--- a/src/components/common/pollingManagement/personel-teachers/index.tsx
+++ b/src/components/common/pollingManagement/personel-teachers/index.tsx
@@ -20,9 +20,30 @@ const StaffPollingManagementPage: React.FC = () => {
 
     /* Sekme etiketleri + içerikleri                                           */
     const tabsConfig = [
-        { label: 'Talep Yönetimi', content: <DemandManagementTable /> },
-        { label: 'Günlük Yoklama', content: <DailyPollingTable /> },
-        { label: 'Yoklama Sayıları', content: <PollingCountsTable /> },
+        {
+            label: 'Talep Yönetimi',
+            content: <DemandManagementTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+        {
+            label: 'Günlük Yoklama',
+            content: <DailyPollingTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+        {
+            label: 'Yoklama Sayıları',
+            content: <PollingCountsTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
     ];
 
     return (

--- a/src/components/common/pollingManagement/studyPolling/index.tsx
+++ b/src/components/common/pollingManagement/studyPolling/index.tsx
@@ -16,10 +16,38 @@ const StudyPollingPage: React.FC = () => {
 
     /* tabs: label + React element to render */
     const tabsConfig = [
-        { label: 'Etüt Planla', content: <StudyPlanTable /> },
-        { label: 'Etüt Programı', content: <StudyProgramTable /> },
-        { label: 'Etüt Yoklama', content: <StudyPollingTable /> },
-        { label: 'Yoklama Sayıları', content: <PollingCountTable /> },
+        {
+            label: 'Etüt Planla',
+            content: <StudyPlanTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+        {
+            label: 'Etüt Programı',
+            content: <StudyProgramTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+        {
+            label: 'Etüt Yoklama',
+            content: <StudyPollingTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+        {
+            label: 'Yoklama Sayıları',
+            content: <PollingCountTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
     ];
 
     return (

--- a/src/components/common/pollingManagement/teachers/teacherIndex.tsx
+++ b/src/components/common/pollingManagement/teachers/teacherIndex.tsx
@@ -15,9 +15,30 @@ const TeacherPollingManagementPage: React.FC = () => {
 
     /* sekme başlıkları ve içerikleri */
     const tabsConfig = [
-        { label: 'Öğretmen Yoklama Listesi', content: <TeachersTable /> },
-        { label: 'Öğretmen Nöbet  Yoklama Listesi', content: <TeachersPollingTable /> },
-        { label: 'Ders Yoklama', content: <LessonPollingTable /> },
+        {
+            label: 'Öğretmen Yoklama Listesi',
+            content: <TeachersTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+        {
+            label: 'Öğretmen Nöbet  Yoklama Listesi',
+            content: <TeachersPollingTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+        {
+            label: 'Ders Yoklama',
+            content: <LessonPollingTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
     ];
 
     return (


### PR DESCRIPTION
## Summary
- unify polling management tab styling to match the guidance module

## Testing
- `npm run build` *(fails: Cannot find module 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_683f0056b334832cb3259c79a6fb2497