### PR TITLE
Align homework UI with pollingManagement

### DIFF
--- a/src/components/common/homework/index.tsx
+++ b/src/components/common/homework/index.tsx
@@ -1,6 +1,7 @@
 /* components/common/homework/index.tsx */
 import React, { useState } from 'react';
 import TabsContainer from './components/organisms/TabsContainer';
+import Pageheader from '../../page-header/pageheader';
 
 import PlannedAssignmentsTable from './pages/plannedAssignments/table';
 import DefiningHomeworkPage from './pages/assignmentsDefinition/table';
@@ -12,16 +13,51 @@ const HomeworkTrackingPage: React.FC = () => {
     const [activeIdx, setActiveIdx] = useState(0);
 
     const tabsConfig = [
-        { label: 'Planlanan Ödevler', content: <PlannedAssignmentsTable /> },
-        { label: 'Ödev Tanımlama', content: <DefiningHomeworkPage /> },
-        { label: 'Ödev Kontrolü', content: <AssignmentsCheckTable /> },
-        { label: 'Ödev Listesi', content: <AssignmentsListTable /> },
-        { label: 'Ödev Sayıları', content: <AssignmentsCountPage /> },
+        {
+            label: 'Planlanan Ödevler',
+            content: <PlannedAssignmentsTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+        {
+            label: 'Ödev Tanımlama',
+            content: <DefiningHomeworkPage />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+        {
+            label: 'Ödev Kontrolü',
+            content: <AssignmentsCheckTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+        {
+            label: 'Ödev Listesi',
+            content: <AssignmentsListTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+        {
+            label: 'Ödev Sayıları',
+            content: <AssignmentsCountPage />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
     ];
 
     return (
         <div className="px-4">
-            <h5>Ödev Takip</h5>
+            <Pageheader title="Ödev Yönetimi" currentpage="Ödev Takip" />
 
             <TabsContainer
                 tabs={tabsConfig}

--- a/src/components/common/homework/pages/assignmentsCount/index.tsx
+++ b/src/components/common/homework/pages/assignmentsCount/index.tsx
@@ -12,9 +12,30 @@ const AssignmentsCountPage: React.FC = () => {
     const [selectedTab, setSelectedTab] = useState(0);
 
     const tabsConfig = [
-        { label: 'Verilen Ödevler', content: <GivenHomeworkCount /> },
-        { label: 'Planlanan Ödevler', content: <PlannedHomeworkCount /> },
-        { label: 'Tamamlanan Ödevler', content: <CompletedHomeworkCount /> },
+        {
+            label: 'Verilen Ödevler',
+            content: <GivenHomeworkCount />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+        {
+            label: 'Planlanan Ödevler',
+            content: <PlannedHomeworkCount />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+        {
+            label: 'Tamamlanan Ödevler',
+            content: <CompletedHomeworkCount />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
     ];
 
     return (


### PR DESCRIPTION
## Summary
- update homework module design to include `Pageheader` heading
- use same tab colour scheme as pollingManagement
- update assignments count page tab colours

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_683f0320c8ac832ca61fff704a67e30f