### PR TITLE
Implement class list modal and table

### DIFF
--- a/src/components/common/listManagement/students/pages/classList/crud.tsx
+++ b/src/components/common/listManagement/students/pages/classList/crud.tsx
@@ -1,0 +1,106 @@
+import { useMemo, useState } from 'react';
+import { Form, Button } from 'react-bootstrap';
+import ReusableTable, { ColumnDefinition } from '../../../../ReusableTable';
+import { useListStudents } from '../../../../../hooks/student/useList';
+
+interface Row {
+  id: number;
+  student_no: string;
+  gender: string;
+  full_name: string;
+}
+
+interface Props {
+  show: boolean;
+  onClose: () => void;
+  programId: number;
+  levelId: number;
+  classroomId: number;
+  headerTitle: string;
+}
+
+export default function StudentListModal({
+  show,
+  onClose,
+  programId,
+  levelId,
+  classroomId,
+  headerTitle,
+}: Props) {
+  const [withImages, setWithImages] = useState(false);
+
+  const { data = [], loading, error } = useListStudents({
+    enabled: show,
+    program_id: programId,
+    level_id: levelId,
+    classroom_id: classroomId,
+    page: 1,
+    paginate: 50,
+  });
+
+  const rows: Row[] = useMemo(
+    () =>
+      data.map((s: any) => ({
+        id: s.id,
+        student_no: s.student_no ?? '-',
+        gender: s.gender_id === 1 ? 'Kadın' : 'Erkek',
+        full_name: `${s.first_name ?? ''} ${s.last_name ?? ''}`.trim(),
+      })),
+    [data],
+  );
+
+  const columns: ColumnDefinition<Row>[] = [
+    { key: 'index', label: 'Sıra No', render: (_r, _o, idx) => idx! + 1 },
+    { key: 'student_no', label: 'Okul No', render: r => r.student_no },
+    { key: 'gender', label: 'Cinsiyet', render: r => r.gender },
+    { key: 'full_name', label: 'Adı Soyadı', render: r => r.full_name },
+  ];
+
+  const handleExportExcel = () => {
+    const header = [
+      ['T.C'],
+      [headerTitle],
+      ['Sıra No', 'Okul No', 'Cinsiyet', 'Adı Soyadı'],
+    ];
+    const body = rows.map((r, idx) => [String(idx + 1), r.student_no, r.gender, r.full_name]);
+    const csv = [...header, ...body].map(r => r.join(',')).join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'class_list.csv';
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const headerNode = (
+    <div className="d-flex align-items-center gap-3 mb-2">
+      <Form.Check
+        type="switch"
+        id="with-images"
+        label="Resimli Liste"
+        checked={withImages}
+        onChange={e => setWithImages(e.currentTarget.checked)}
+      />
+      {withImages && <Form.Control type="file" multiple size="sm" />}
+      <Button variant="outline-secondary" size="sm" onClick={handleExportExcel}>
+        Excel
+      </Button>
+    </div>
+  );
+
+  return (
+    <ReusableTable<Row>
+      showModal={show}
+      onCloseModal={onClose}
+      tableMode="single"
+      pageTitle={headerTitle}
+      columns={columns}
+      data={rows}
+      loading={loading}
+      error={error}
+      showExportButtons={false}
+      customHeader={headerNode}
+    />
+  );
+}

--- a/src/components/common/listManagement/students/pages/classList/table.tsx
+++ b/src/components/common/listManagement/students/pages/classList/table.tsx
@@ -1,0 +1,78 @@
+import { useState, useMemo } from 'react';
+import { Button } from 'react-bootstrap';
+import ReusableTable, { ColumnDefinition } from '../../../../ReusableTable';
+import { useClassroomList } from '../../../../../hooks/classrooms/useList';
+import StudentListModal from './crud';
+
+interface Row {
+  id: number;
+  program_id: number;
+  level_id: number;
+  program_name: string;
+  level_name: string;
+  classroom_name: string;
+}
+
+export default function ClassListTable() {
+  const { classroomData = [], loading, error } = useClassroomList({
+    enabled: true,
+    branchId: 0,
+  });
+
+  const rows: Row[] = useMemo(
+    () =>
+      classroomData.map((c: any) => ({
+        id: c.id,
+        program_id: c.level?.program?.id ?? 0,
+        level_id: c.level?.id ?? 0,
+        program_name: c.level?.program?.name ?? '-',
+        level_name: c.level?.name ?? '-',
+        classroom_name: c.name ?? '-',
+      })),
+    [classroomData],
+  );
+
+  const [selected, setSelected] = useState<Row | null>(null);
+
+  const columns: ColumnDefinition<Row>[] = useMemo(
+    () => [
+      { key: 'program_name', label: 'Okul Seviyesi', render: r => r.program_name },
+      { key: 'level_name', label: 'Sınıf Seviyesi', render: r => r.level_name },
+      { key: 'classroom_name', label: 'Sınıf / Şube', render: r => r.classroom_name },
+      {
+        key: 'actions',
+        label: 'İşlemler',
+        render: r => (
+          <Button variant="primary" size="sm" onClick={() => setSelected(r)}>
+            <i className="ti ti-eye" />
+          </Button>
+        ),
+      },
+    ],
+    [],
+  );
+
+  return (
+    <>
+      <ReusableTable<Row>
+        pageTitle="Sınıf Listeleri"
+        tableMode="single"
+        columns={columns}
+        data={rows}
+        loading={loading}
+        error={error}
+        showExportButtons={false}
+      />
+      {selected && (
+        <StudentListModal
+          show
+          onClose={() => setSelected(null)}
+          programId={selected.program_id}
+          levelId={selected.level_id}
+          classroomId={selected.id}
+          headerTitle={`${selected.program_name} ${selected.level_name} ${selected.classroom_name} SINIF LİSTESİ`}
+        />
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- create class list table
- add student list modal with Excel export

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails to compile due to missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68400456529c832c893f947ac17ca987