### PR TITLE
Add student list management module

### DIFF
--- a/src/components/common/listManagement/students/index.tsx
+++ b/src/components/common/listManagement/students/index.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import TabsContainer from './component/organisms/TabsContainer';
+import ClassListTable from './pages/classList/table';
+import Pageheader from '../../page-header/pageheader';
+
+const StudentListManagementPage: React.FC = () => {
+    const [activeIdx, setActiveIdx] = useState<number>(0);
+
+    const tabs = [
+        {
+            label: 'Sınıf Listesi',
+            content: <ClassListTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+    ];
+
+    return (
+        <div className="px-4">
+            <Pageheader title="Yoklama Yönetimi" currentpage="Öğrenciler" />
+            <TabsContainer tabs={tabs} onTabChange={setActiveIdx} />
+        </div>
+    );
+};
+
+export default StudentListManagementPage;

--- a/src/components/sidebar/nav.tsx
+++ b/src/components/sidebar/nav.tsx
@@ -25,6 +25,20 @@ export const MENUITEMS: any = [
     menutitle: "MAIN",
   },
 
+  // ----- YOKLAMA YÖNETİMİ -----
+  {
+    title: "Yoklama Yönetimi",
+    icon: Dashboardicon,
+    type: "sub",
+    children: [
+      {
+        title: "Öğrenciler",
+        path: "listManagement/students/index",
+        type: "link",
+      },
+    ],
+  },
+
   // ----- ÖĞRENCİLER -----
   {
     title: "Öğrenciler",

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -405,7 +405,11 @@ const RentDetailPage = lazy(() => import("../components/common/rent/RentDetail")
 const RentDetailTable = lazy(() => import("../components/common/rent/table"));
 const RentDetailCrud = lazy(() => import("../components/common/rent/crud"));
 const EstimatedBudgetTable = lazy(() => import("../components/common/estimatedBudget/table"));
-//assignmentStudents 
+//assignmentStudents
+
+// list management - students
+import StudentListManagementPage from "../components/common/listManagement/students/index";
+import ClassListTable from "../components/common/listManagement/students/pages/classList/table";
 
 
 //yoklama sayfaları
@@ -2111,6 +2115,18 @@ export const Routedata = [
 
     path: `${import.meta.env.BASE_URL}pollingManagement/idareİndex`,
     element: <AdministrativeSupportTeamPage />,
+  },
+
+  // list management - students
+  {
+    id: 29000,
+    path: `${import.meta.env.BASE_URL}listManagement/students/index`,
+    element: <StudentListManagementPage />,
+  },
+  {
+    id: 29001,
+    path: `${import.meta.env.BASE_URL}listManagement/students/classList`,
+    element: <ClassListTable />,
   },
 
 


### PR DESCRIPTION
## Summary
- add navigation entry for student list management
- implement `StudentListManagementPage` with class list tab
- register new routes for the students list management module

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6840066fd510832c9364a09ca18cb992