### PR TITLE
Add pagination and improve class list export

### DIFF
--- a/src/components/common/ReusableTable.tsx
+++ b/src/components/common/ReusableTable.tsx
@@ -1262,7 +1262,7 @@ function ReusableTable<T extends { [key: string]: any }>({
     return showModal ? (
       <Modal show={true} onHide={onCloseModal} centered size="lg">
         <Modal.Header closeButton>
-          <Modal.Title>{exportFileName}</Modal.Title>
+          <Modal.Title>{modalTitle ?? exportFileName}</Modal.Title>
         </Modal.Header>
         <Modal.Body>{content}</Modal.Body>
       </Modal>

--- a/src/components/common/listManagement/students/pages/classList/crud.tsx
+++ b/src/components/common/listManagement/students/pages/classList/crud.tsx
@@ -32,14 +32,24 @@ export default function StudentListCrud() {
   /* —— resimli liste anahtarı —— */
   const [withImages, setWithImages] = useState(false);
 
+  /* —— sayfalama —— */
+  const [page, setPage] = useState(1);
+  const [paginate, setPaginate] = useState(50);
+
   /* —— öğrenci listesi —— */
-  const { data = [], loading, error } = useListStudents({
+  const {
+    data = [],
+    loading,
+    error,
+    totalPages,
+    totalItems,
+  } = useListStudents({
     enabled: true,
     program_id: programId || undefined,
     level_id: levelId || undefined,
     classroom_id: classroomId,
-    page: 1,
-    paginate: 50,
+    page,
+    paginate,
   });
 
   /* —— rows —— */
@@ -67,6 +77,7 @@ export default function StudentListCrud() {
     const header = [
       ['T.C'],
       [headerTitle],
+      [],
       ['Sıra No', 'Okul No', 'Cinsiyet', 'Adı Soyadı'],
     ];
     const body = rows.map((r, idx) => [
@@ -114,6 +125,15 @@ export default function StudentListCrud() {
       error={error}
       showExportButtons={false}
       customHeader={headerNode}
+      currentPage={page}
+      totalPages={totalPages}
+      totalItems={totalItems}
+      pageSize={paginate}
+      onPageChange={setPage}
+      onPageSizeChange={s => {
+        setPaginate(s);
+        setPage(1);
+      }}
       showModal={true}
       onCloseModal={() => navigate(-1)}
     />


### PR DESCRIPTION
## Summary
- add pagination support to class list CRUD page
- insert a blank row before table headers when exporting
- show provided modal title in single table mode

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68401eb169e4832cbda48752c79cd7ad