### PR TITLE
Use profile_picture field for student images

### DIFF
--- a/src/components/common/listManagement/students/pages/classList/crud.tsx
+++ b/src/components/common/listManagement/students/pages/classList/crud.tsx
@@ -20,7 +20,11 @@ interface Row {
   student_no: string;
   gender: string;
   full_name: string;
-  image_url?: string | null;
+  /**
+   * Öğrencinin vesikalık fotoğrafı için URL
+   * API'den `profile_picture` alanı olarak geliyor
+   */
+  profile_picture?: string | null;
 }
 
 type QueryParams = {
@@ -83,7 +87,7 @@ export default function StudentListCrud() {
         student_no: s.student_no ?? '-',
         gender: s.gender_id === 1 ? 'Kadın' : 'Erkek',
         full_name: `${s.first_name ?? ''} ${s.last_name ?? ''}`.trim(),
-        image_url: s.image_url ?? null,            // API’de varsa
+        profile_picture: s.profile_picture ?? null, // "Vesikalık" fotoğraf
       })),
     [data],
   );
@@ -99,9 +103,9 @@ export default function StudentListCrud() {
     key: 'image',
     label: 'Öğrencinin Resmi',
     render: r =>
-      r.image_url ? (
+      r.profile_picture ? (
         <img
-          src={r.image_url}
+          src={r.profile_picture}
           alt="Öğrenci"
           style={{ width: 42, height: 42, objectFit: 'cover', borderRadius: 4 }}
         />


### PR DESCRIPTION
## Summary
- show student photos using the `profile_picture` field when image view is enabled

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684026f9c3d8832ca9b1e521f2b85e08