### PR TITLE
Custom CSV export header for class list

### DIFF
--- a/src/components/common/ReusableTable.tsx
+++ b/src/components/common/ReusableTable.tsx
@@ -102,6 +102,8 @@ interface ReusableTableProps<T> {
   period_paginate?: boolean;
   period_field?: boolean;
   period_date?: boolean;
+  /** CSV export verisini özelleştirmek için kullanılır */
+  customCsvData?: (string | number | boolean | null)[][];
 
 }
 export function useDebounce<T>(value: T, delay: number): T {
@@ -147,18 +149,22 @@ function ReusableTable<T extends { [key: string]: any }>({
   period_field,
   period_date,
 
+  customCsvData,
+
 }: ReusableTableProps<T>) {
   const navigate = useNavigate(); // useNavigate hook'u eklendi
 
   // CSV başlıkları ve veri dönüşümü
   const csvHeaders = useMemo(() => {
+    if (customCsvData) return undefined;
     return columns.map((col) => ({
       label: col.label,
       key: col.key,
     }));
-  }, [columns]);
+  }, [columns, customCsvData]);
 
   const csvData = useMemo(() => {
+    if (customCsvData) return customCsvData;
     return (data ?? []).map((row) => {
       const newObj: any = {};
       columns.forEach((col) => {
@@ -166,7 +172,7 @@ function ReusableTable<T extends { [key: string]: any }>({
       });
       return newObj;
     });
-  }, [data, columns]);
+  }, [customCsvData, data, columns]);
 
   const handleExportPDF = () => {
     const doc = new jsPDF("p", "pt");

--- a/src/components/common/listManagement/students/pages/classList/crud.tsx
+++ b/src/components/common/listManagement/students/pages/classList/crud.tsx
@@ -147,6 +147,33 @@ export default function StudentListCrud() {
     </div>
   );
 
+  const seasonName = useMemo(() => {
+    try {
+      const userDataString = localStorage.getItem('userData');
+      if (!userDataString) return '';
+      const userData = JSON.parse(userDataString);
+      return userData.default_season?.name ?? '';
+    } catch {
+      return '';
+    }
+  }, []);
+
+  const exportCsvData = useMemo(() => {
+    const headerRows = [
+      ['T.C'],
+      [seasonName],
+      ['Sınıf Listesi'],
+      columns.map(c => c.label),
+    ];
+    const tableRows = rows.map(r =>
+      columns.map(col => {
+        if (col.key === 'image') return r.profile_picture ?? '';
+        return (r as any)[col.key] ?? '';
+      }),
+    );
+    return [...headerRows, ...tableRows];
+  }, [seasonName, columns, rows]);
+
 
   return (
     <ReusableTable<Row>
@@ -166,6 +193,7 @@ export default function StudentListCrud() {
       customHeader={headerNode}
       showExportButtons
       exportFileName="class_list"
+      customCsvData={exportCsvData}
       showModal
       onCloseModal={() => navigate(-1)}
     />


### PR DESCRIPTION
## Summary
- enable passing custom CSV data in `ReusableTable`
- export class list with custom header rows for TC, season, and title

## Testing
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684031377784832ca1d0f520fefad2c1