### PR TITLE
Fix dropdownHeight prop type

### DIFF
--- a/src/@spk-reusable-components/reusable-plugins/spk-multiselect.tsx
+++ b/src/@spk-reusable-components/reusable-plugins/spk-multiselect.tsx
@@ -15,12 +15,43 @@ interface SpkMultiselectProps {
     loading?: boolean;
     onChange: (values: any[]) => void;
     noDataLabel?: string;
-    dropdownHeight?: number | any;
+    dropdownHeight?: string | number;
 }
 
-const SpkMultiselect: React.FC<SpkMultiselectProps> = ({ options, mainClass, placeholder, multi = true, labelField, valueField, values = [], clearable = true, searchable = true, disabledLabel, loading = false, onChange, noDataLabel, dropdownHeight }) => {
+const SpkMultiselect: React.FC<SpkMultiselectProps> = ({
+    options,
+    mainClass,
+    placeholder,
+    multi = true,
+    labelField,
+    valueField,
+    values = [],
+    clearable = true,
+    searchable = true,
+    disabledLabel,
+    loading = false,
+    onChange,
+    noDataLabel,
+    dropdownHeight = '300px',
+}) => {
+    const height = dropdownHeight !== undefined ? String(dropdownHeight) : undefined;
     return (
-        <Select className={mainClass} placeholder={placeholder} multi={multi} labelField={labelField} valueField={valueField} options={options} values={values} clearable={clearable} searchable={searchable} disabledLabel={disabledLabel} loading={loading} onChange={onChange} noDataLabel={noDataLabel} dropdownHeight={dropdownHeight} />
+        <Select
+            className={mainClass}
+            placeholder={placeholder}
+            multi={multi}
+            labelField={labelField}
+            valueField={valueField}
+            options={options}
+            values={values}
+            clearable={clearable}
+            searchable={searchable}
+            disabledLabel={disabledLabel}
+            loading={loading}
+            onChange={onChange}
+            noDataLabel={noDataLabel}
+            dropdownHeight={height}
+        />
     );
 };
 


### PR DESCRIPTION
## Summary
- support numeric or string values for SpkMultiselect dropdown height
- convert value to string for `react-dropdown-select`

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68414084f7b4832c918900f9a471caf2