### PR TITLE
Add page headers to student pages

### DIFF
--- a/src/components/common/student/appointments/index.tsx
+++ b/src/components/common/student/appointments/index.tsx
@@ -17,6 +17,7 @@ import { useListStudents } from "../../../hooks/student/useList";
 import { useAppointmentDelete } from "../../../hooks/appointment/deleteAppointment";
 import appoipmentButtonHover from "../../../../assets/images/media/appoipment-buton-hover.svg";
 import appoipmentButton from "../../../../assets/images/media/appoipment-buton.svg";
+import Pageheader from "../../../page-header/pageheader";
 
 type QueryParams = {
   [x: string]: any;
@@ -404,33 +405,36 @@ export default function QuestionLabeling() {
   );
 
   return (
-    <ReusableTable<data>
-      columns={columns}
-      pageTitle="Randevu Listesi"
-      data={appointmentData as data[]}
-      loading={loading}
-      showModal={false}
-      showExportButtons={true}
-      tableMode="single"
-      error={error}
-      filters={filters}
-      currentPage={page}
-      totalPages={totalPages}
-      totalItems={totalItems}
-      pageSize={pageSize}
-      onPageChange={(newPage) => {
-        setPage(newPage);
-      }}
-      onPageSizeChange={(newSize) => {
-        setPageSize(newSize);
-        setPage(1);
-      }}
-      exportFileName="question_labeling"
-      onDeleteRow={(row) => {
-        if (row.id !== undefined) {
-          removeAppointment(row.id);
-        }
-      }}
-    />
+    <div className="px-4">
+      <Pageheader title="Öğrenci Yönetimi" currentpage="Randevu Listesi" />
+      <ReusableTable<data>
+        columns={columns}
+        pageTitle="Randevu Listesi"
+        data={appointmentData as data[]}
+        loading={loading}
+        showModal={false}
+        showExportButtons={true}
+        tableMode="single"
+        error={error}
+        filters={filters}
+        currentPage={page}
+        totalPages={totalPages}
+        totalItems={totalItems}
+        pageSize={pageSize}
+        onPageChange={(newPage) => {
+          setPage(newPage);
+        }}
+        onPageSizeChange={(newSize) => {
+          setPageSize(newSize);
+          setPage(1);
+        }}
+        exportFileName="question_labeling"
+        onDeleteRow={(row) => {
+          if (row.id !== undefined) {
+            removeAppointment(row.id);
+          }
+        }}
+      />
+    </div>
   );
 }

--- a/src/components/common/student/calculate/index.tsx
+++ b/src/components/common/student/calculate/index.tsx
@@ -18,6 +18,7 @@ import { useCoursesTable } from "../../../hooks/course/useList";
 import { useSchoolTypesList } from "../../../hooks/schoolTypes/useSchoolTypesList";
 import { useServicesTable } from "../../../hooks/service/useList";
 import { useDiscountsTable } from "../../../hooks/discounts/useList";
+import Pageheader from "../../../page-header/pageheader";
 import { usePaymentMethodsList } from "../../../hooks/paymentMethods/useList";
 
 // Types
@@ -346,7 +347,8 @@ export default function CalculatePage({ studentId }: CalculatePageProps = {}) {
   }
 
   return (
-    <div>
+    <div className="px-4">
+      <Pageheader title="Öğrenci Yönetimi" currentpage="Ücret Hesapla" />
       {/* Hizmet Yok Modal */}
       <Modal
         show={showNoServiceModal}

--- a/src/components/common/student/final-register/combine.tsx
+++ b/src/components/common/student/final-register/combine.tsx
@@ -17,6 +17,7 @@ import CreateEnrollmentStep2, {
 } from "./step2/create_enrollment";
 import CreateInstallmentStep3 from "./step3/create_installment"; // <-- Step3 bileşeni
 import CreateInstallmentStep4 from "./step4/create_aggrement"; // <-- Step3 bileşeni
+import Pageheader from "../../../page-header/pageheader";
 
 // Hooks
 import { useListStudents } from "../../../hooks/student/useList";
@@ -404,7 +405,8 @@ const [selectedBranchId, setSelectedBranchId] = useState<number>(
   };
 
   return (
-    <>
+    <div className="px-4">
+      <Pageheader title="Öğrenci Yönetimi" currentpage="Kesin Kayıt" />
       {/* TCKN Kontrol Modal */}
       {isClient && (
         <Modal
@@ -586,7 +588,7 @@ const [selectedBranchId, setSelectedBranchId] = useState<number>(
           </Card.Body>
         </Card>
       )}
-    </>
+    </div>
   );
 };
 

--- a/src/components/common/student/import/index.tsx
+++ b/src/components/common/student/import/index.tsx
@@ -3,6 +3,7 @@ import React, { useState, useRef } from "react";
 import { toast } from "react-toastify";
 import { Modal, Button } from "react-bootstrap";
 import { Link } from "@mui/material";
+import Pageheader from "../../../page-header/pageheader";
 
 interface IRule {
   icon: string;
@@ -252,7 +253,9 @@ export default function ExcelImportPage() {
         minHeight: "100vh",
         width: "100%"
       }}
+      className="px-4"
     >
+      <Pageheader title="Öğrenci Yönetimi" currentpage="Toplu Öğrenci Aktarma" />
       {/* Content Area */}
       <div style={{ width: "100%", borderRadius: "8px" }}>
         <div style={{ marginBottom: "2rem" }}>

--- a/src/components/common/student/meetings/table.tsx
+++ b/src/components/common/student/meetings/table.tsx
@@ -16,6 +16,7 @@ import info from "../../../../assets/images/media/info.svg";
 import info_hover from "../../../../assets/images/media/info-hover.svg";
 import inside from "../../../../assets/images/media/svg/inside-button.svg";
 import outside from "../../../../assets/images/media/svg/outside-button.svg";
+import Pageheader from "../../../page-header/pageheader";
 
 type QueryParams = {
   [x: string]: any;
@@ -456,22 +457,25 @@ export default function MeetingListPage() {
   );
 
   return (
-    <ReusableTable<Meeting>
-      columns={columns}
-      data={meetingsData}
-      loading={loading}
-      error={error}
-      showModal={false}
-      showExportButtons={true}
-      filters={filters}
-      tableMode="single"
-      totalPages={totalPages}
-      totalItems={totalItems}
-      pageSize={pageSize}
-      exportFileName="meetings"
-      currentPage={page}
-      onPageChange={setPage}
-      onPageSizeChange={setPageSize}
-    />
+    <div className="px-4">
+      <Pageheader title="Öğrenci Yönetimi" currentpage="Görüşmeler" />
+      <ReusableTable<Meeting>
+        columns={columns}
+        data={meetingsData}
+        loading={loading}
+        error={error}
+        showModal={false}
+        showExportButtons={true}
+        filters={filters}
+        tableMode="single"
+        totalPages={totalPages}
+        totalItems={totalItems}
+        pageSize={pageSize}
+        exportFileName="meetings"
+        currentPage={page}
+        onPageChange={setPage}
+        onPageSizeChange={setPageSize}
+      />
+    </div>
   );
 }

--- a/src/components/common/student/pre-register/list.tsx
+++ b/src/components/common/student/pre-register/list.tsx
@@ -17,6 +17,7 @@ import { deleteStudent } from "../../../../slices/student/delete/thunk";
 import appointment_button from "../../../../assets/images/media/appoipment-buton.svg";
 import appointment_hover from "../../../../assets/images/media/appoipment-buton-hover.svg";
 import { formatDateForApi } from "../../../../utils/formatters";
+import Pageheader from "../../../page-header/pageheader";
 
 type QueryParams = {
   [x: string]: any;
@@ -478,25 +479,28 @@ export default function StudentListPage() {
 
 
   return (
-    <ReusableTable<IStudent>
-      onAdd={() => navigate(`/pre-register/crud`)}
-      pageTitle="Ön Kayıt / Liste"
-      exportFileName="students"
-      showExportButtons={true}
-      columns={columns}
-      data={data}
-      filters={filters}
-      loading={loading}
-      error={error}
+    <div className="px-4">
+      <Pageheader title="Öğrenci Yönetimi" currentpage="Ön Kayıt / Liste" />
+      <ReusableTable<IStudent>
+        onAdd={() => navigate(`/pre-register/crud`)}
+        pageTitle="Ön Kayıt / Liste"
+        exportFileName="students"
+        showExportButtons={true}
+        columns={columns}
+        data={data}
+        filters={filters}
+        loading={loading}
+        error={error}
 
-      totalPages={totalPages}
-      totalItems={totalItems}
+        totalPages={totalPages}
+        totalItems={totalItems}
 
-      tableMode="single"
+        tableMode="single"
 
-      onDeleteRow={(row) => {
-        deleteStudent(row.id);
-      }}
-    />
+        onDeleteRow={(row) => {
+          deleteStudent(row.id);
+        }}
+      />
+    </div>
   );
 }

--- a/src/components/common/student/service_management/index.tsx
+++ b/src/components/common/student/service_management/index.tsx
@@ -3,13 +3,15 @@ import { useState } from "react";
 import { Row, Col, Card } from "react-bootstrap";
 import ServiceTable from "./service/table"; // 1. adımda oluşturduğumuz service table
 import DiscountTable from "./discount/table"; // 2. adımda oluşturduğumuz discount table
+import Pageheader from "../../../page-header/pageheader";
 
 export default function CombinedPage() {
   const [selectedServiceId, setSelectedServiceId] = useState<number>();
   const [enabled, setEnabled] = useState(false);
 
   return (
-    <div>
+    <div className="px-4">
+      <Pageheader title="Öğrenci Yönetimi" currentpage="Hizmet Yönetimi" />
       <Row>
         <Col md={6}>
           <Card>


### PR DESCRIPTION
## Summary
- import Pageheader component in student pages
- wrap student routes with Pageheader like polling management pages

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_684154f65218832cbb3605c76974302e