### PR TITLE
Add unified student management page

### DIFF
--- a/src/components/common/student/index.tsx
+++ b/src/components/common/student/index.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import TabsContainer from '../pollingManagement/class-course/component/organisms/TabsContainer';
+import PreRegisterList from './pre-register/list';
+import AppointmentsList from './appointments/index';
+import MeetingListPage from './meetings/table';
+import ExcelImportPage from './import/index';
+import CombineFinalRegister from './final-register/combine';
+import ServiceManagementPage from './service_management/index';
+import CalculatePage from './calculate/index';
+import Pageheader from '../page-header/pageheader';
+
+const StudentManagementPage: React.FC = () => {
+  const [, setActiveIdx] = useState<number>(0);
+
+  const tabs = [
+    {
+      label: 'Ön Kayıt',
+      content: <></>,
+      children: [
+        { label: 'Ön Kayıt', content: <PreRegisterList /> },
+        { label: 'Randevu', content: <AppointmentsList /> },
+        { label: 'Görüşme', content: <MeetingListPage /> },
+        { label: 'Toplu Öğrenci Aktarımı', content: <ExcelImportPage /> },
+      ],
+    },
+    {
+      label: 'Kayıt',
+      content: <></>,
+      children: [
+        { label: 'Kesin Kayıt', content: <CombineFinalRegister /> },
+        { label: 'Hizmet Yönetimi', content: <ServiceManagementPage /> },
+        { label: 'Ücret Hesapla', content: <CalculatePage /> },
+        { label: 'Kayıt Kontrol', content: <div>Kayıt Kontrol</div> },
+      ],
+    },
+  ];
+
+  return (
+    <div className="px-4">
+      <Pageheader title="Öğrenci" currentpage="Öğrenci Yönetimi" />
+      <TabsContainer tabs={tabs} onTabChange={(idx) => setActiveIdx(idx)} />
+    </div>
+  );
+};
+
+export default StudentManagementPage;

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -15,6 +15,9 @@ const StudentList = lazy(
 const Calculate = lazy(
   () => import("../components/common/student/calculate/index")
 );
+const StudentManagementPage = lazy(
+  () => import("../components/common/student/index")
+);
 // exams
 const ExamsResult = lazy(() => import("../components/common/exams/examResult"));
 const ExamAnalysis = lazy(
@@ -508,6 +511,11 @@ export const Routedata = [
     id: 4,
     path: `${import.meta.env.BASE_URL}student/pre-register`,
     element: <StudentList />,
+  },
+  {
+    id: 40,
+    path: `${import.meta.env.BASE_URL}students`,
+    element: <StudentManagementPage />,
   },
   {
     id: 5,


### PR DESCRIPTION
## Summary
- create StudentManagementPage with nested tabs for student operations
- expose new StudentManagementPage in routing

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: missing type declarations)*


------
https://chatgpt.com/codex/tasks/task_e_68416a54ea10832cb29cfded0bed360b