### PR TITLE
Combine pre-register pages

### DIFF
--- a/src/Route/routingdata.tsx
+++ b/src/Route/routingdata.tsx
@@ -9,9 +9,6 @@ const Analytics = lazy(
 const StudentImport = lazy(
   () => import("../components/common/student/import/index")
 );
-const StudentList = lazy(
-  () => import("../components/common/student/pre-register/list")
-);
 const Calculate = lazy(
   () => import("../components/common/student/calculate/index")
 );
@@ -83,6 +80,9 @@ const EducationalStructure = lazy(
 );
 const PreRegisterList = lazy(
   () => import("../components/common/student/pre-register/list")
+);
+const PreRegisterIndex = lazy(
+  () => import("../components/common/student/pre-register/index")
 );
 const AppointmentsList = lazy(
   () => import("../components/common/student/appointments/index")
@@ -410,7 +410,7 @@ export const Routedata = [
   {
     id: 4,
     path: `${import.meta.env.BASE_URL}student/pre-register`,
-    element: <StudentList />,
+    element: <PreRegisterIndex />,
   },
   {
     id: 5,
@@ -816,7 +816,7 @@ export const Routedata = [
   {
     id: 23,
     path: `${import.meta.env.BASE_URL}pre-register/list`,
-    element: <PreRegisterList />,
+    element: <PreRegisterIndex />,
   },
   {
     id: 23,

--- a/src/components/common/student/pre-register/index.tsx
+++ b/src/components/common/student/pre-register/index.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import TabsContainer from '../../pollingManagement/class-course/component/organisms/TabsContainer';
+import Pageheader from '../../../page-header/pageheader';
+import PreRegisterList from './list';
+import AppointmentsList from '../appointments/index';
+import MeetingTable from '../meetings/table';
+import StudentImport from '../import/index';
+
+const PreRegisterIndexPage: React.FC = () => {
+  const [active, setActive] = useState<number>(0);
+
+  const tabs = [
+    { label: 'Ön Kayıt', content: <PreRegisterList /> },
+    { label: 'Randevu', content: <AppointmentsList /> },
+    { label: 'Görüşme', content: <MeetingTable /> },
+    { label: 'Toplu Öğrenci Aktarımı', content: <StudentImport /> },
+  ];
+
+  return (
+    <div className="px-4">
+      <Pageheader
+        title="Öğrenciler"
+        subtitle="Ön Kayıt"
+        currentpage="Ön Kayıt"
+        activepage="Ön Kayıt"
+      />
+      <TabsContainer
+        tabs={tabs}
+        selectedIndex={active}
+        onTabChange={(idx) => setActive(idx)}
+      />
+    </div>
+  );
+};
+
+export default PreRegisterIndexPage;

--- a/src/components/sidebar/nav.tsx
+++ b/src/components/sidebar/nav.tsx
@@ -33,21 +33,8 @@ export const MENUITEMS: any = [
     children: [
       {
         title: "Ön Kayıt",
-        type: "sub",
-        children: [
-          // Matches  route -> path: /pre-register
-          { title: "Ön Kayıt", path: "/pre-register/list", type: "link" },
-          // Matches  route -> path: /appointments
-          { title: "Randevu", path: "/appointments", type: "link" },
-          // Matches  route -> path: /meetings
-          { title: "Görüşme", path: "/meetings", type: "link" },
-          // Matches  route -> path: /student/import
-          {
-            title: "Toplu Öğrenci Aktarma",
-            path: "/student/import",
-            type: "link",
-          },
-        ],
+        type: "link",
+        path: "/pre-register/list",
       },
       {
         title: "Kayıt",


### PR DESCRIPTION
## Summary
- add a unified pre-register index with tabs
- update navigation to point to a single link
- update routes to load the new index page

## Testing
- `npm run build` *(fails: cannot find module 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_6841e5476418832ca8f934d2e710c981