### PR TITLE
Combine student preregistration pages

### DIFF
--- a/src/components/common/student/pre-register/index.tsx
+++ b/src/components/common/student/pre-register/index.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import TabsContainer from '../../pollingManagement/class-course/component/organisms/TabsContainer';
+import Pageheader from '../../page-header/pageheader';
+
+import PreRegisterList from './list';
+import AppointmentsList from '../appointments';
+import MeetingList from '../meetings/table';
+import StudentImport from '../import';
+
+const PreRegisterIndexPage: React.FC = () => {
+  const [, setActiveIdx] = useState<number>(0);
+
+  const tabs = [
+    {
+      label: 'Ön Kayıt',
+      content: <PreRegisterList />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#5C67F726',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Randevu',
+      content: <AppointmentsList />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#5C67F726',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Görüşme',
+      content: <MeetingList />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#5C67F726',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Toplu Öğrenci Aktarma',
+      content: <StudentImport />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#5C67F726',
+      passiveTextColor: '#5C67F7',
+    },
+  ];
+
+  return (
+    <div className="px-4">
+      <Pageheader title="Öğrenciler" currentpage="Ön Kayıt" />
+      <TabsContainer tabs={tabs} onTabChange={(idx) => setActiveIdx(idx)} />
+    </div>
+  );
+};
+
+export default PreRegisterIndexPage;

--- a/src/components/sidebar/nav.tsx
+++ b/src/components/sidebar/nav.tsx
@@ -49,18 +49,7 @@ export const MENUITEMS: any = [
         title: "Ön Kayıt",
         type: "sub",
         children: [
-          // Matches  route -> path: /pre-register
-          { title: "Ön Kayıt", path: "/pre-register/list", type: "link" },
-          // Matches  route -> path: /appointments
-          { title: "Randevu", path: "/appointments", type: "link" },
-          // Matches  route -> path: /meetings
-          { title: "Görüşme", path: "/meetings", type: "link" },
-          // Matches  route -> path: /student/import
-          {
-            title: "Toplu Öğrenci Aktarma",
-            path: "/student/import",
-            type: "link",
-          },
+          { title: "Ön Kayıt", path: "/pre-register", type: "link" },
         ],
       },
       {

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -9,9 +9,6 @@ const Analytics = lazy(
 const StudentImport = lazy(
   () => import("../components/common/student/import/index")
 );
-const StudentList = lazy(
-  () => import("../components/common/student/pre-register/list")
-);
 const Calculate = lazy(
   () => import("../components/common/student/calculate/index")
 );
@@ -95,8 +92,8 @@ const AddressStructurePage = lazy(
 const DiscountStudentDetail = lazy(
   () => import("../components/common/discountStudent/detail")
 );
-const PreRegisterList = lazy(
-  () => import("../components/common/student/pre-register/list")
+const PreRegisterIndex = lazy(
+  () => import("../components/common/student/pre-register/index")
 );
 const AppointmentsList = lazy(
   () => import("../components/common/student/appointments/index")
@@ -508,7 +505,7 @@ export const Routedata = [
   {
     id: 4,
     path: `${import.meta.env.BASE_URL}student/pre-register`,
-    element: <StudentList />,
+    element: <PreRegisterIndex />,
   },
 
   {
@@ -955,8 +952,8 @@ export const Routedata = [
   },
   {
     id: 23,
-    path: `${import.meta.env.BASE_URL}pre-register/list`,
-    element: <PreRegisterList />,
+    path: `${import.meta.env.BASE_URL}pre-register`,
+    element: <PreRegisterIndex />,
   },
   {
     id: 23,


### PR DESCRIPTION
## Summary
- add tabbed index page for preregistration features
- link sidebar to new page
- route preregistration paths to tabbed index

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` *(fails: missing type declarations and TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841e7fc35f8832c8be0c621373d6f36