### PR TITLE
Add student registration index page

### DIFF
--- a/src/components/common/student/register/index.tsx
+++ b/src/components/common/student/register/index.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import TabsContainer from '../../pollingManagement/class-course/component/organisms/TabsContainer';
+import Pageheader from '../../../page-header/pageheader';
+
+import FinalRegisterCombine from '../final-register/combine';
+import ServiceManagement from '../service_management';
+import CalculatePage from '../calculate';
+import InternalsTable from '../../internal/table';
+
+const RegisterIndexPage: React.FC = () => {
+  const [, setActiveIdx] = useState<number>(0);
+
+  const tabs = [
+    {
+      label: 'Kesin Kayıt',
+      content: <FinalRegisterCombine />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#5C67F726',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Hizmet Yönetimi',
+      content: <ServiceManagement />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#5C67F726',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Ücret Hesapla',
+      content: <CalculatePage />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#5C67F726',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Kayıt Kontrol',
+      content: <InternalsTable />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#5C67F726',
+      passiveTextColor: '#5C67F7',
+    },
+  ];
+
+  return (
+    <div className="px-4">
+      <Pageheader title="Öğrenciler" currentpage="Kayıt" />
+      <TabsContainer tabs={tabs} onTabChange={(idx) => setActiveIdx(idx)} />
+    </div>
+  );
+};
+
+export default RegisterIndexPage;

--- a/src/components/sidebar/nav.tsx
+++ b/src/components/sidebar/nav.tsx
@@ -56,21 +56,11 @@ export const MENUITEMS: any = [
         title: "Kayıt",
         type: "sub",
         children: [
-          // Matches route -> path: /final-register/:studentId?
           {
-            title: "Kesin Kayıt",
+            title: "Kayıt",
             path: "/final-register",
             type: "link",
           },
-          // Matches route -> path: /service-management
-          {
-            title: "Hizmet Yönetimi",
-            path: "/service-management",
-            type: "link",
-          },
-          // Matches route -> path: /calculate
-          { title: "Ücret Hesapla", path: "/calculate", type: "link" },
-          { title: "Kayıt Kontrol", path: "/internals", type: "link" },
         ],
       },
     ],

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -306,8 +306,8 @@ const Invoicedetail = lazy(() => import("../components/common/invoice/detail"));
 const Createinvoice = lazy(
   () => import("../components/common/invoice/auto_create_invoice")
 );
-const CombineFinalRegister = lazy(
-  () => import("../components/common/student/final-register/combine")
+const RegisterIndex = lazy(
+  () => import("../components/common/student/register")
 );
 
 const SchoolTypeCrud = lazy(
@@ -948,7 +948,7 @@ export const Routedata = [
   {
     id: 23,
     path: `${import.meta.env.BASE_URL}final-register/:studentId?`,
-    element: <CombineFinalRegister />,
+    element: <RegisterIndex />,
   },
   {
     id: 23,


### PR DESCRIPTION
## Summary
- consolidate registration pages under one tabbed page
- update routes to use new registration index
- simplify student register sidebar navigation

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6841ea81a4bc832c84a2b2ae95dd9dfa