### PR TITLE
Fix student menu items

### DIFF
--- a/src/components/sidebar/menuloop.tsx
+++ b/src/components/sidebar/menuloop.tsx
@@ -27,7 +27,9 @@ function Menuloop({ MenuItems, toggleSidemenu, local_varaiable, level, HoverTogg
           ""
         )}
         </span>
-        <i className="ri-arrow-down-s-line side-menu__angle"></i>
+        {MenuItems.children && MenuItems.children.length > 0 && (
+          <i className="ri-arrow-down-s-line side-menu__angle"></i>
+        )}
       </Link>
       <ul className={`slide-menu child${level}  ${MenuItems.active ? 'double-menu-active' : ''} ${MenuItems?.dirchange ? "force-left" : ""} `} style={MenuItems.active ? { display: "block" } : { display: "none" }}>
         {level <= 1 ? <li className="slide side-menu__label1">

--- a/src/components/sidebar/nav.tsx
+++ b/src/components/sidebar/nav.tsx
@@ -45,24 +45,8 @@ export const MENUITEMS: any = [
     icon: Dashboardicon,
     type: "sub",
     children: [
-      {
-        title: "Ön Kayıt",
-        type: "sub",
-        children: [
-          { title: "Ön Kayıt", path: "/pre-register", type: "link" },
-        ],
-      },
-      {
-        title: "Kayıt",
-        type: "sub",
-        children: [
-          {
-            title: "Kayıt",
-            path: "/final-register",
-            type: "link",
-          },
-        ],
-      },
+      { title: "Ön Kayıt", path: "/pre-register", type: "link" },
+      { title: "Kayıt", path: "/final-register", type: "link" },
     ],
   },
   //ödev


### PR DESCRIPTION
## Summary
- simplify the Students menu to have direct links
- show submenu arrow only when item has children

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68428a7a6b20832cb55ae79d981c1b8f