### PR TITLE
Add Daily Operations tab menu

### DIFF
--- a/src/components/common/daily/Authority.tsx
+++ b/src/components/common/daily/Authority.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const Authority = () => (
+  <div className="container mt-3">
+    <h5 className="mb-3">Yetkili</h5>
+    <p>Yetkili ile ilgili i\xC3\xA7erik buraya gelecek.</p>
+  </div>
+);
+
+export default Authority;

--- a/src/components/common/daily/Payments.tsx
+++ b/src/components/common/daily/Payments.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const Payments = () => (
+  <div className="container mt-3">
+    <h5 className="mb-3">\xC3\x96demeler</h5>
+    <p>\xC3\x96demelerle ilgili i\xC3\xA7erik buraya gelecek.</p>
+  </div>
+);
+
+export default Payments;

--- a/src/components/common/daily/index.tsx
+++ b/src/components/common/daily/index.tsx
@@ -1,12 +1,13 @@
 import TabsContainer from '../guidance/components/organisms/TabsContainer';
 import Summary from './Summary';
 import PaymentDetailsTable from '../payment_details/table';
-import OtherIncomeTable from '../otherIncome/table';
+import IncomeListPage from '../income/table';
 import ExpenseListPage from '../expences/main/table';
 import CreditCardTable from '../creditcard/table';
 import PaymentTab from '../personel/financialSummary/PaymentTab';
 import TransfersTable from '../transfers/table';
-import Tasks from './Tasks';
+import Payments from './Payments';
+import Authority from './Authority';
 
 const DailyModule = () => {
   const tabsConfig = [
@@ -27,8 +28,8 @@ const DailyModule = () => {
       passiveTextColor: '#5C67F7',
     },
     {
-      label: 'Farklı Gelirler',
-      content: <OtherIncomeTable />,
+      label: 'Gelirler',
+      content: <IncomeListPage />,
       activeBgColor: '#5C67F7',
       activeTextColor: '#FFFFFF',
       passiveBgColor: '#E1E4FB',
@@ -43,6 +44,14 @@ const DailyModule = () => {
       passiveTextColor: '#5C67F7',
     },
     {
+      label: 'Personel Ödemeleri',
+      content: <PaymentTab />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#E1E4FB',
+      passiveTextColor: '#5C67F7',
+    },
+    {
       label: 'Kart Yönetimi',
       content: <CreditCardTable />,
       activeBgColor: '#5C67F7',
@@ -51,8 +60,8 @@ const DailyModule = () => {
       passiveTextColor: '#5C67F7',
     },
     {
-      label: 'Personel Ödemeleri',
-      content: <PaymentTab />,
+      label: 'Ödemeler',
+      content: <Payments />,
       activeBgColor: '#5C67F7',
       activeTextColor: '#FFFFFF',
       passiveBgColor: '#E1E4FB',
@@ -67,8 +76,8 @@ const DailyModule = () => {
       passiveTextColor: '#5C67F7',
     },
     {
-      label: 'Notlar',
-      content: <Tasks />,
+      label: 'Yetkili',
+      content: <Authority />,
       activeBgColor: '#5C67F7',
       activeTextColor: '#FFFFFF',
       passiveBgColor: '#E1E4FB',

--- a/src/components/sidebar/nav.tsx
+++ b/src/components/sidebar/nav.tsx
@@ -234,17 +234,17 @@ export const MENUITEMS: any = [
         children: [
           { title: "Finansal Özet", path: "/financial-summary", type: "link" },
           { title: "Taksitler", path: "/debts", type: "link" },
-          { title: "Farklı Gelirler", path: "/other-income", type: "link" },
+          { title: "Gelirler", path: "/incomes", type: "link" },
           { title: "Giderler", path: "/expenses", type: "link" },
-          { title: "Kart Yönetimi", path: "/creditcards", type: "link" },
           {
             title: "Personel Ödemeleri",
             path: "/studentpaymentdetails",
             type: "link",
           },
+          { title: "Kart Yönetimi", path: "/creditcards", type: "link" },
+          { title: "Ödemeler", path: "/payments", type: "link" },
           { title: "Transfer", path: "/transfer", type: "link" },
-          { title: "Günlük", path: "/daily", type: "link" },
-
+          { title: "Yetkili", path: "/daily", type: "link" },
         ],
       },
       {

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -399,6 +399,7 @@ import StatusNumbersIndex from "../components/common/guidance/workSchedule/Tab1/
 import Dashboard from "../components/common/dashboard";
 import ChecksAndPromissoryTable from "../components/common/checksandpromissory/table";
 const DailyModule = lazy(() => import("../components/common/daily"));
+const PaymentsPage = lazy(() => import("../components/common/daily/Payments"));
 const RentDetailPage = lazy(() => import("../components/common/rent/RentDetail"));
 const RentDetailTable = lazy(() => import("../components/common/rent/table"));
 const RentDetailCrud = lazy(() => import("../components/common/rent/crud"));
@@ -1740,6 +1741,11 @@ export const Routedata = [
     id: 2000,
     path: `${import.meta.env.BASE_URL}daily`,
     element: <DailyModule />,
+  },
+  {
+    id: 2005,
+    path: `${import.meta.env.BASE_URL}payments`,
+    element: <PaymentsPage />,
   },
   {
     id: 2001,


### PR DESCRIPTION
## Summary
- add Payments and Authority placeholder components
- update DailyModule tabs to match new order
- update sidebar navigation for new tab sequence
- add route for payments page

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68469fa2a1fc832c9ede8e9dd2b62d62