### PR TITLE
Create unified Daily Operations tab page

### DIFF
--- a/src/components/common/daily/index.tsx
+++ b/src/components/common/daily/index.tsx
@@ -1,7 +1,8 @@
 import TabsContainer from '../guidance/components/organisms/TabsContainer';
 import Summary from './Summary';
+import DebtsTable from '../debts/table';
+import IncomeListPage from '../income/table';
 import PaymentDetailsTable from '../payment_details/table';
-import OtherIncomeTable from '../otherIncome/table';
 import ExpenseListPage from '../expences/main/table';
 import CreditCardTable from '../creditcard/table';
 import PaymentTab from '../personel/financialSummary/PaymentTab';
@@ -20,15 +21,15 @@ const DailyModule = () => {
     },
     {
       label: 'Taksitler',
-      content: <PaymentDetailsTable />,
+      content: <DebtsTable />,
       activeBgColor: '#5C67F7',
       activeTextColor: '#FFFFFF',
       passiveBgColor: '#E1E4FB',
       passiveTextColor: '#5C67F7',
     },
     {
-      label: 'Farklı Gelirler',
-      content: <OtherIncomeTable />,
+      label: 'Gelirler',
+      content: <IncomeListPage />,
       activeBgColor: '#5C67F7',
       activeTextColor: '#FFFFFF',
       passiveBgColor: '#E1E4FB',
@@ -37,15 +38,6 @@ const DailyModule = () => {
     {
       label: 'Giderler',
       content: <ExpenseListPage />,
-      activeBgColor: '#5C67F7',
-      activeTextColor: '#FFFFFF',
-      passiveBgColor: '#E1E4FB',
-      passiveTextColor: '#5C67F7',
-    },
-
-    {
-      label: 'Kart Yönetimi',
-      content: <CreditCardTable />,
       activeBgColor: '#5C67F7',
       activeTextColor: '#FFFFFF',
       passiveBgColor: '#E1E4FB',
@@ -60,6 +52,22 @@ const DailyModule = () => {
       passiveTextColor: '#5C67F7',
     },
     {
+      label: 'Kart Yönetimi',
+      content: <CreditCardTable />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#E1E4FB',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Ödemeler',
+      content: <PaymentDetailsTable />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#E1E4FB',
+      passiveTextColor: '#5C67F7',
+    },
+    {
       label: 'Transfer',
       content: <TransfersTable />,
       activeBgColor: '#5C67F7',
@@ -68,7 +76,7 @@ const DailyModule = () => {
       passiveTextColor: '#5C67F7',
     },
     {
-      label: 'Notlar',
+      label: 'Yetkili',
       content: <Tasks />,
       activeBgColor: '#5C67F7',
       activeTextColor: '#FFFFFF',

--- a/src/components/sidebar/nav.tsx
+++ b/src/components/sidebar/nav.tsx
@@ -230,22 +230,8 @@ export const MENUITEMS: any = [
     children: [
       {
         title: "Günlük İşlemler",
-        type: "sub",
-        children: [
-          { title: "Finansal Özet", path: "/financial-summary", type: "link" },
-          { title: "Taksitler", path: "/debts", type: "link" },
-          { title: "Farklı Gelirler", path: "/other-income", type: "link" },
-          { title: "Giderler", path: "/expenses", type: "link" },
-          { title: "Kart Yönetimi", path: "/creditcards", type: "link" },
-          {
-            title: "Personel Ödemeleri",
-            path: "/studentpaymentdetails",
-            type: "link",
-          },
-          { title: "Günlük", path: "/daily", type: "link" },
-          { title: "Transfer", path: "/transfer", type: "link" },
-
-        ],
+        path: "/daily",
+        type: "link",
       },
       {
         title: "Gelirler",


### PR DESCRIPTION
## Summary
- combine accounting daily pages into a single tab view
- simplify sidebar navigation to a single "Günlük İşlemler" link

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6846a423e154832ca8e50458e6bf8c46