### PR TITLE
Add DailyBurada page

### DIFF
--- a/src/components/common/dailyburada/Tasks.tsx
+++ b/src/components/common/dailyburada/Tasks.tsx
@@ -1,0 +1,21 @@
+import { Todolist, Todolist1 } from '../data/dashboard/crmdata';
+
+const Tasks = () => (
+  <div className="container mt-3">
+    <h5 className="mb-3">Notlar ve Yapılması Gerekenler</h5>
+    <ul className="list-unstyled">
+      {Todolist.map((t) => (
+        <li key={t.id} className="mb-2">
+          <span className="fw-semibold">{t.title}</span> - {t.description}
+        </li>
+      ))}
+      {Todolist1.map((t) => (
+        <li key={t.id} className="mb-2">
+          <span className="fw-semibold">{t.title}</span> - {t.description}
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+export default Tasks;

--- a/src/components/common/dailyburada/index.tsx
+++ b/src/components/common/dailyburada/index.tsx
@@ -1,0 +1,97 @@
+import TabsContainer from '../guidance/components/organisms/TabsContainer';
+import FinancialSummary from '../accounting/financialSummary';
+import DebtsTable from '../debts/table';
+import OtherIncomeTable from '../otherIncome/table';
+import ExpenseListPage from '../expences/main/table';
+import PaymentTab from '../personel/financialSummary/PaymentTab';
+import CreditCardTable from '../creditcard/table';
+import PaymentDetailsTable from '../payment_details/table';
+import TransfersTable from '../transfers/table';
+import Tasks from './Tasks';
+import Pageheader from '../../page-header/pageheader';
+
+const DailyBuradaModule = () => {
+  const tabsConfig = [
+    {
+      label: 'Finansal Özet',
+      content: <FinancialSummary />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#E1E4FB',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Taksitler',
+      content: <DebtsTable />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#E1E4FB',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Gelirler',
+      content: <OtherIncomeTable />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#E1E4FB',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Giderler',
+      content: <ExpenseListPage />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#E1E4FB',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Personel Ödemeleri',
+      content: <PaymentTab />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#E1E4FB',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Kart Yönetimi',
+      content: <CreditCardTable />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#E1E4FB',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Ödemeler',
+      content: <PaymentDetailsTable />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#E1E4FB',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Transfer',
+      content: <TransfersTable />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#E1E4FB',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Yetkili',
+      content: <Tasks />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#E1E4FB',
+      passiveTextColor: '#5C67F7',
+    },
+  ];
+
+  return (
+    <div className="px-4">
+      <Pageheader title="Finans ve Muhasebe" currentpage="Günlük Burada" />
+      <TabsContainer tabs={tabsConfig} />
+    </div>
+  );
+};
+
+export default DailyBuradaModule;

--- a/src/components/sidebar/nav.tsx
+++ b/src/components/sidebar/nav.tsx
@@ -234,6 +234,11 @@ export const MENUITEMS: any = [
         type: "link",
       },
       {
+        title: "Günlük Burada",
+        path: "/dailyburada",
+        type: "link",
+      },
+      {
         title: "Gelirler",
         type: "sub",
         children: [

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -399,6 +399,9 @@ import StatusNumbersIndex from "../components/common/guidance/workSchedule/Tab1/
 import Dashboard from "../components/common/dashboard";
 import ChecksAndPromissoryTable from "../components/common/checksandpromissory/table";
 const DailyModule = lazy(() => import("../components/common/daily"));
+const DailyBuradaModule = lazy(
+  () => import("../components/common/dailyburada")
+);
 
 const RentDetailPage = lazy(() => import("../components/common/rent/RentDetail"));
 const RentDetailTable = lazy(() => import("../components/common/rent/table"));
@@ -1741,6 +1744,11 @@ export const Routedata = [
     id: 2000,
     path: `${import.meta.env.BASE_URL}daily`,
     element: <DailyModule />,
+  },
+  {
+    id: 20001,
+    path: `${import.meta.env.BASE_URL}dailyburada`,
+    element: <DailyBuradaModule />,
   },
   {
     id: 2001,


### PR DESCRIPTION
## Summary
- introduce DailyBurada module patterned after PollingManagement page
- register new DailyBurada module route
- link DailyBurada page from the sidebar

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: TypeScript errors and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6846ab7ff87c832c89cda748c0695189