### PR TITLE
Fix pagination total fallback

### DIFF
--- a/src/components/hooks/debts/useList.tsx
+++ b/src/components/hooks/debts/useList.tsx
@@ -31,8 +31,14 @@ export function useDebtsTable() {
   const debtsData: DebtData[] = data || [];
   const paginationMeta: DebtMeta | null = meta;
 
-  const totalPages = paginationMeta ? paginationMeta.last_page : 1;
-  const totalItems = paginationMeta ? paginationMeta.total : 0;
+  const totalPages =
+    paginationMeta && typeof paginationMeta.last_page === 'number'
+      ? paginationMeta.last_page
+      : 1;
+  const totalItems =
+    paginationMeta && typeof paginationMeta.total === 'number'
+      ? paginationMeta.total
+      : debtsData.length;
 
   return {
     debtsData,


### PR DESCRIPTION
## Summary
- handle missing pagination metadata in `useDebtsTable`

## Testing
- `npm run build` *(fails: Cannot find module 'vite' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6847eece5650832c9fc8d6616d453808