### PR TITLE
Add authorized operations page

### DIFF
--- a/src/components/common/dailyOperationsAuthorized/component/atoms/CustomTab.tsx
+++ b/src/components/common/dailyOperationsAuthorized/component/atoms/CustomTab.tsx
@@ -1,0 +1,21 @@
+import { FC } from "react";
+import Box from "@mui/material/Box";
+
+interface TabPanelProps {
+    children?: React.ReactNode;
+    index: number;
+    value: number;
+}
+
+const CustomTab: FC<TabPanelProps> = ({ children, value, index }) => (
+    <div
+        className="mt-5"
+        hidden={value !== index}
+        id={`simple-tabpanel-${index}`}
+        aria-labelledby={`simple-tab-${index}`}
+    >
+        {value === index && <Box>{children}</Box>}
+    </div>
+);
+
+export default CustomTab;

--- a/src/components/common/dailyOperationsAuthorized/component/organisms/SearchFilters.tsx
+++ b/src/components/common/dailyOperationsAuthorized/component/organisms/SearchFilters.tsx
@@ -1,0 +1,243 @@
+import React from "react";
+import { Row, Col, Form, Button } from "react-bootstrap";
+import { Typeahead } from "react-bootstrap-typeahead";
+import SpkFlatpickr from "../../../../../../@spk-reusable-components/reusable-plugins/spk-flatpicker";
+
+export interface FilterDefinition {
+    key: string;
+    label: string;
+    col?: number;
+    type:
+    | "text"
+    | "number"
+    | "date"
+    | "doubledate"
+    | "checkbox"
+    | "select"
+    | "currency"
+    | "togglebar"
+    | "email"
+    | "phone"
+    | "textarea"
+    | "iban"
+
+    | "autocomplete"
+    | "multiselect";
+    value?: string | string[] | { startDate: string; endDate: string };
+    options?: { value: string; label: string }[];
+    selectProps?: any;
+    plus?: boolean | string;
+    dependencyKey?: string;
+    onChange?: (value: any) => void;
+    onClick?: (value: string) => void;
+    onFocus?: () => void;
+}
+
+interface FilterGroupProps {
+    filters: FilterDefinition[];
+    navigate: (path: string) => void;
+    columnsPerRow?: number;
+}
+
+function InputWithPlus({
+    children,
+    fieldDef,
+    navigate,
+}: {
+    children: React.ReactNode;
+    fieldDef: FilterDefinition;
+    navigate: (path: string) => void;
+}) {
+    return (
+        <div style={{ display: "flex", alignItems: "center", gap: 5 }}>
+            <div style={{ flex: 1 }}>{children}</div>
+            {typeof fieldDef.plus === "string" && (
+                <Button
+                    variant="outline-secondary"
+                    onClick={() => navigate(fieldDef.plus as string)}
+                >
+                    <i className="bi bi-plus" />
+                </Button>
+            )}
+        </div>
+    );
+}
+
+const FilterGroup: React.FC<FilterGroupProps> = ({
+    filters,
+    navigate,
+    columnsPerRow = 2,
+}) => {
+    if (!filters || filters.length === 0) return null;
+
+    const groups: FilterDefinition[][] = [];
+    for (let i = 0; i < filters.length; i += columnsPerRow) {
+        groups.push(filters.slice(i, i + columnsPerRow));
+    }
+
+    const colSize = Math.floor(12 / columnsPerRow);
+
+    return (
+        <div className="mb-3 px-4 bg-white rounded-3">
+            {groups.map((group, idx) => (
+                <Row key={`filter-row-${idx}`} className="mb-2">
+                    {group.map((filter) => (
+                        <Col key={filter.key} md={colSize}>
+                            <Form.Group>
+                                <Row>
+                                    <Col md={12}>
+                                        <Form.Label>{filter.label}</Form.Label>
+
+                                        {filter.type === "autocomplete" ? (
+                                            <InputWithPlus fieldDef={filter} navigate={navigate}>
+                                                <Typeahead
+                                                    id={`typeahead-${filter.key}`}
+                                                    labelKey="label"
+                                                    options={filter.options || []}
+                                                    placeholder="Aramak için yazın..."
+                                                    onChange={(selected) => {
+                                                        if (
+                                                            selected &&
+                                                            selected.length > 0 &&
+                                                            filter.onChange
+                                                        ) {
+                                                            filter.onChange((selected[0] as any).value);
+                                                        }
+                                                    }}
+                                                    onFocus={filter.onFocus}
+                                                    onInputChange={(text) => {
+                                                        if (filter.onChange) filter.onChange(text);
+                                                    }}
+                                                    disabled={
+                                                        filter.dependencyKey
+                                                            ? !filters.find(
+                                                                (f) => f.key === filter.dependencyKey
+                                                            )?.value
+                                                            : false
+                                                    }
+                                                />
+                                            </InputWithPlus>
+                                        ) : filter.type === "date" ? (
+                                            <InputWithPlus fieldDef={filter} navigate={navigate}>
+                                                <SpkFlatpickr
+                                                    value={
+                                                        filter.value
+                                                            ? new Date(filter.value as string)
+                                                            : undefined
+                                                    }
+                                                    onfunChange={(dates: Date[]) => {
+                                                        if (!dates?.length) {
+                                                            filter.onChange?.(null);
+                                                            return;
+                                                        }
+                                                        const iso = dates[0].toISOString().split("T")[0];
+                                                        filter.onChange?.(iso);
+                                                    }}
+                                                    options={{
+                                                        dateFormat: "Y-m-d",
+                                                        allowInput: false,
+                                                    }}
+                                                    inputClass="form-control"
+                                                    placeholder="Tarih seçiniz"
+                                                />
+                                            </InputWithPlus>
+                                        ) : filter.type === "doubledate" ? (
+                                            <InputWithPlus fieldDef={filter} navigate={navigate}>
+                                                <SpkFlatpickr
+                                                    value={
+                                                        filter.value
+                                                            ? `${(filter.value as any).startDate} to ${(filter.value as any).endDate
+                                                            }`
+                                                            : undefined
+                                                    }
+                                                    onfunChange={(dates: Date[]) => {
+                                                        if (!dates || dates.length < 2) {
+                                                            filter.onChange?.(null);
+                                                            return;
+                                                        }
+                                                        const startDate = dates[0]
+                                                            .toISOString()
+                                                            .split("T")[0];
+                                                        const endDate = dates[1]
+                                                            .toISOString()
+                                                            .split("T")[0];
+                                                        filter.onChange?.({ startDate, endDate });
+                                                    }}
+                                                    options={{
+                                                        dateFormat: "Y-m-d",
+                                                        mode: "range",
+                                                        allowInput: false,
+                                                    }}
+                                                    inputClass="form-control"
+                                                    placeholder="Tarih aralığı seçiniz"
+                                                />
+                                            </InputWithPlus>
+                                        ) : filter.options ? (
+                                            <InputWithPlus fieldDef={filter} navigate={navigate}>
+                                                <Form.Select
+                                                    value={
+                                                        typeof filter.value === "string"
+                                                            ? filter.value
+                                                            : filter.value &&
+                                                                "startDate" in filter.value &&
+                                                                "endDate" in filter.value
+                                                                ? `${filter.value.startDate} - ${filter.value.endDate}`
+                                                                : undefined
+                                                    }
+                                                    onChange={(e) => filter.onChange?.(e.target.value)}
+                                                    onClick={(e) =>
+                                                        filter.onClick?.(
+                                                            (e.target as HTMLSelectElement).value
+                                                        )
+                                                    }
+                                                    onFocus={filter.onFocus}
+                                                    disabled={
+                                                        filter.dependencyKey
+                                                            ? !filters.find(
+                                                                (f) => f.key === filter.dependencyKey
+                                                            )?.value
+                                                            : false
+                                                    }
+                                                >
+                                                    <option value="">Seçiniz</option>
+                                                    {filter.options.map((opt) => (
+                                                        <option key={opt.value} value={opt.value}>
+                                                            {opt.label}
+                                                        </option>
+                                                    ))}
+                                                </Form.Select>
+                                            </InputWithPlus>
+                                        ) : (
+                                            <InputWithPlus fieldDef={filter} navigate={navigate}>
+                                                <Form.Control
+                                                    type={filter.type || "text"}
+                                                    value={filter.value as string}
+                                                    onChange={(e) => filter.onChange?.(e.target.value)}
+                                                    onClick={(e) =>
+                                                        filter.onClick?.(
+                                                            (e.target as HTMLInputElement).value
+                                                        )
+                                                    }
+                                                    onFocus={filter.onFocus}
+                                                    disabled={
+                                                        filter.dependencyKey
+                                                            ? !filters.find(
+                                                                (f) => f.key === filter.dependencyKey
+                                                            )?.value
+                                                            : false
+                                                    }
+                                                />
+                                            </InputWithPlus>
+                                        )}
+                                    </Col>
+                                </Row>
+                            </Form.Group>
+                        </Col>
+                    ))}
+                </Row>
+            ))}
+        </div>
+    );
+};
+
+export default FilterGroup;

--- a/src/components/common/dailyOperationsAuthorized/component/organisms/TabsContainer.tsx
+++ b/src/components/common/dailyOperationsAuthorized/component/organisms/TabsContainer.tsx
@@ -1,0 +1,230 @@
+import Box from "@mui/material/Box";
+import Tabs from "@mui/material/Tabs";
+import Tab from "@mui/material/Tab";
+import { FC, useState, useEffect } from "react";
+
+interface TabConfig {
+    label: string;
+    content: React.ReactNode;
+    children?: TabConfig[] | undefined;
+    activeBgColor?: string;
+    activeTextColor?: string;
+    passiveBgColor?: string;
+    passiveTextColor?: string;
+    width?: string;
+    height?: string;
+}
+interface TabsContainerProps {
+    tabs: TabConfig[];
+    onTabChange?: (parentTabIndex: number, childTabIndex: number | null) => void;
+}
+
+const TabsContainer: FC<TabsContainerProps> = ({ tabs, onTabChange }) => {
+    // LocalStorage'dan kaydedilmiş tab durumunu al
+    const [value, setValue] = useState<number>(() => {
+        const savedValue = localStorage.getItem("selectedParentTab");
+        return savedValue ? parseInt(savedValue, 10) : 0;
+    });
+
+    const [childValue, setChildValue] = useState<number | null>(() => {
+        const savedChildValue = localStorage.getItem("selectedChildTab");
+        return savedChildValue ? parseInt(savedChildValue, 10) : null;
+    });
+
+    useEffect(() => {
+        // Tab yapısı değişirse doğrulama yap
+        const savedParentTab = localStorage.getItem("selectedParentTab");
+        if (savedParentTab) {
+            const parentIndex = parseInt(savedParentTab, 10);
+            const validParentIndex = parentIndex < tabs.length ? parentIndex : 0;
+            setValue(validParentIndex);
+
+            if (tabs[validParentIndex]?.children?.length) {
+                const savedChildTab = localStorage.getItem("selectedChildTab");
+                if (savedChildTab) {
+                    const childIndex = parseInt(savedChildTab, 10);
+                    const validChildIndex =
+                        childIndex < tabs[validParentIndex].children!.length
+                            ? childIndex
+                            : 0;
+                    setChildValue(validChildIndex);
+                } else {
+                    setChildValue(0);
+                }
+            }
+        } else if (tabs?.[0]?.children?.length) {
+            setChildValue(0);
+        }
+    }, [tabs]);
+
+    const handleChange = (_: React.SyntheticEvent, newValue: number) => {
+        setValue(newValue);
+        localStorage.setItem("selectedParentTab", newValue.toString());
+        const hasChildren = tabs?.[newValue]?.children?.length;
+        if (hasChildren) {
+            setChildValue(0);
+            localStorage.setItem("selectedChildTab", "0");
+        } else {
+            setChildValue(null);
+            localStorage.removeItem("selectedChildTab");
+        }
+
+        if (onTabChange) onTabChange(newValue, hasChildren ? 0 : null);
+    };
+
+    const handleChildChange = (_: React.SyntheticEvent, newValue: number) => {
+        setChildValue(newValue);
+        localStorage.setItem("selectedChildTab", newValue.toString());
+        if (onTabChange) onTabChange(value, newValue);
+    };
+
+    const tabStyle = {
+        components: {
+            MuiTab: {
+                styleOverrides: {
+                    root: {
+                        minHeight: "36px",
+                        height: "36px",
+                        minWidth: "165px",
+                        maxWidth: "165px",
+                    },
+                },
+            },
+        },
+    };
+
+    return (
+        <Box
+            sx={{
+                overflowX: "auto",
+                minWidth: "100%",
+                borderRadius: "8px",
+                padding: "12px",
+                // Tab component stilini override et
+                "& .MuiTab-root": tabStyle.components.MuiTab.styleOverrides.root,
+            }}
+        >
+            <Tabs
+                value={value}
+                onChange={handleChange}
+                allowScrollButtonsMobile
+                variant="scrollable"
+                textColor="inherit"
+                sx={{
+                    display: "flex",
+                    justifyContent: "flex-start",
+                    "& .MuiTabs-indicator": {
+                        display: "none",
+                    },
+                }}
+            >
+                {tabs.map((tab, index) => (
+                    <Tab
+                        key={index}
+                        label={tab.label}
+                        disableRipple
+                        sx={{
+                            textTransform: "none",
+                            fontWeight: 600,
+                            color:
+                                value === index
+                                    ? tab.activeTextColor || "#FFF"
+                                    : tab.passiveTextColor || "#5C67F7",
+                            fontSize: "13px",
+                            borderRadius: "8px",
+                            backgroundColor:
+                                value === index
+                                    ? tab.activeBgColor || "#5C67F7"
+                                    : tab.passiveBgColor || "#E1E4FB",
+                            minWidth: tab.width || "200px",
+                            height: tab.height || "30px",
+                            px: 1,
+                            py: 1,
+                            mr: 3,
+                            opacity: "1 !important",
+                        }}
+                    />
+                ))}
+            </Tabs>
+
+            {tabs.map((tab, index) => (
+                <Box
+                    key={index}
+                    role="tabpanel"
+                    hidden={value !== index}
+                    id={`tabpanel-${index}`}
+                    aria-labelledby={`tab-${index}`}
+                >
+                    {value === index && (
+                        <div className="mt-3">
+                            {tab.content}
+
+                            {tab.children && (
+                                <Tabs
+                                    value={childValue ?? 0}
+                                    onChange={handleChildChange}
+                                    allowScrollButtonsMobile
+                                    textColor="inherit"
+                                    variant="scrollable"
+                                    sx={{
+                                        display: "flex",
+                                        justifyContent: "flex-start",
+                                        mt: 1,
+                                        "& .MuiTabs-indicator": {
+                                            display: "none",
+                                        },
+                                    }}
+                                >
+                                    {tab.children.map((child, childIndex) => (
+                                        <Tab
+                                            key={childIndex}
+                                            label={child.label}
+                                            disableRipple
+                                            sx={{
+                                                textTransform: "none",
+                                                fontWeight: 500,
+                                                color:
+                                                    childValue === childIndex
+                                                        ? child.activeTextColor || "#FFF"
+                                                        : child.passiveTextColor || "#4CAF50",
+                                                fontSize: "12px",
+                                                borderRadius: "6px",
+                                                backgroundColor:
+                                                    childValue === childIndex
+                                                        ? child.activeBgColor || "#4CAF50"
+                                                        : child.passiveBgColor || "#C8E6C9",
+                                                minWidth: child.width || "150px",
+                                                height: child.height || "42px",
+                                                px: 1,
+                                                py: 1,
+                                                mr: 3,
+                                                opacity: "1 !important",
+                                            }}
+                                        />
+                                    ))}
+                                </Tabs>
+                            )}
+
+                            {tab.children &&
+                                tab.children.map((child, childIndex) => (
+                                    <Box
+                                        key={childIndex}
+                                        role="tabpanel"
+                                        hidden={childValue !== childIndex}
+                                        id={`child-tabpanel-${childIndex}`}
+                                        aria-labelledby={`child-tab-${childIndex}`}
+                                    >
+                                        {childValue === childIndex && (
+                                            <div className="mt-2">{child.content}</div>
+                                        )}
+                                    </Box>
+                                ))}
+                        </div>
+                    )}
+                </Box>
+            ))}
+        </Box>
+    );
+};
+
+export default TabsContainer;

--- a/src/components/common/dailyOperationsAuthorized/index.tsx
+++ b/src/components/common/dailyOperationsAuthorized/index.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import TabsContainer from './component/organisms/TabsContainer';
+import DailyOperationsAuthorizedTable from './table';
+import Pageheader from '../page-header/pageheader';
+
+const DailyOperationsAuthorizedPage: React.FC = () => {
+  const [, setActiveIdx] = useState<number>(0);
+
+  const tabsConfig = [
+    {
+      label: 'Yetkili',
+      content: <DailyOperationsAuthorizedTable />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#5C67F726',
+      passiveTextColor: '#5C67F7',
+    },
+  ];
+
+  return (
+    <div className="px-4">
+      <Pageheader title="Finans ve Muhasebe" currentpage="Yetkili İşlemler" />
+      <TabsContainer tabs={tabsConfig} onTabChange={(idx: number) => setActiveIdx(idx)} />
+    </div>
+  );
+};
+
+export default DailyOperationsAuthorizedPage;

--- a/src/components/common/dailyOperationsAuthorized/table.tsx
+++ b/src/components/common/dailyOperationsAuthorized/table.tsx
@@ -1,0 +1,81 @@
+import { useMemo } from 'react';
+import ReusableTable, { ColumnDefinition, FilterDefinition } from '../ReusableTable';
+import { useAuthorizedOperationsTable } from '../../hooks/auth/authorizedOperations/useAuthorizedOperations';
+import { AuthorizedOperation } from '../../../types/auth/authorizedOperations';
+
+export default function DailyOperationsAuthorizedTable() {
+  const {
+    data,
+    loading,
+    error,
+    page,
+    pageSize,
+    totalPages,
+    totalItems,
+    setPage,
+    setPageSize,
+    searchTerm,
+    setSearchTerm,
+  } = useAuthorizedOperationsTable();
+
+  const columns: ColumnDefinition<AuthorizedOperation>[] = useMemo(
+    () => [
+      { key: 'full_name', label: 'Ad Soyad' },
+      {
+        key: 'taken_amount',
+        label: 'Al\u0131nan \u00dccret',
+        render: r => `${Number(r.taken_amount).toLocaleString()} \u20BA`,
+      },
+      {
+        key: 'given_amount',
+        label: 'Verilen \u00dccret',
+        render: r => `${Number(r.given_amount).toLocaleString()} \u20BA`,
+      },
+      {
+        key: 'remaining_amount',
+        label: 'Kalan \u00dccret',
+        render: r => `${Number(r.remaining_amount).toLocaleString()} \u20BA`,
+      },
+    ],
+    []
+  );
+
+  const filters: FilterDefinition[] = useMemo(
+    () => [
+      {
+        key: 'search',
+        label: 'Ad Soyad',
+        type: 'text',
+        value: searchTerm,
+        onChange: (val: string) => {
+          setSearchTerm(val);
+          setPage(1);
+        },
+      },
+    ],
+    [searchTerm, setPage]
+  );
+
+  return (
+    <ReusableTable<AuthorizedOperation>
+      pageTitle="Yetkili \u0130\u015flemleri"
+      columns={columns}
+      data={data}
+      loading={loading}
+      error={error}
+      tableMode="single"
+      currentPage={page}
+      totalPages={totalPages}
+      totalItems={totalItems}
+      pageSize={pageSize}
+      onPageChange={(newPage) => setPage(newPage)}
+      onPageSizeChange={(newSize) => {
+        setPageSize(newSize);
+        setPage(1);
+      }}
+      filters={filters}
+      showExportButtons
+      exportFileName="authorized_operations"
+    />
+  );
+}

--- a/src/components/hooks/auth/authorizedOperations/useAuthorizedOperations.tsx
+++ b/src/components/hooks/auth/authorizedOperations/useAuthorizedOperations.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import axiosInstance from '../../../../services/axiosClient';
+import { AUTHORIZED_OPERATIONS } from '../../../../helpers/url_helper';
+import { AuthorizedOperation, AuthorizedOperationListResponse } from '../../../../types/auth/authorizedOperations';
+
+export function useAuthorizedOperationsTable() {
+  const [data, setData] = useState<AuthorizedOperation[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState<number>(1);
+  const [pageSize, setPageSize] = useState<number>(25);
+  const [totalPages, setTotalPages] = useState<number>(1);
+  const [totalItems, setTotalItems] = useState<number>(0);
+  const [searchTerm, setSearchTerm] = useState<string>('');
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      try {
+        let url = `${AUTHORIZED_OPERATIONS}?page=${page}&paginate=${pageSize}`;
+        if (searchTerm) {
+          url += `&search=${encodeURIComponent(searchTerm)}`;
+        }
+        const resp = await axiosInstance.get(url);
+        const respData = resp.data as AuthorizedOperationListResponse;
+        setData(respData.data || []);
+        setTotalPages(respData.meta?.last_page ?? 1);
+        setTotalItems(respData.meta?.total ?? respData.data.length);
+      } catch (err: any) {
+        setError(err.response?.data?.message || 'Fetch authorized operations failed');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [page, pageSize, searchTerm]);
+
+  return {
+    data,
+    loading,
+    error,
+    page,
+    pageSize,
+    totalPages,
+    totalItems,
+    setPage,
+    setPageSize,
+    searchTerm,
+    setSearchTerm,
+  };
+}

--- a/src/helpers/url_helper.ts
+++ b/src/helpers/url_helper.ts
@@ -1,5 +1,6 @@
 //AUTHENTICATION
 export const LOGIN_USER = "/auth/login";
+export const AUTHORIZED_OPERATIONS = "/auth/authorized-operations";
 
 export const DEFAULT_URL = "https://anlakogrenme.com/api/v1";
 export const BRANCHES = '/branches';

--- a/src/types/auth/authorizedOperations.tsx
+++ b/src/types/auth/authorizedOperations.tsx
@@ -1,0 +1,32 @@
+export interface AuthorizedOperation {
+  id: number;
+  full_name: string;
+  taken_amount: number;
+  given_amount: number;
+  remaining_amount: number;
+}
+
+export interface AuthorizedOperationMeta {
+  current_page: number;
+  from: number;
+  last_page: number;
+  per_page: number;
+  to: number;
+  total: number;
+  links: {
+    url: string | null;
+    label: string;
+    active: boolean;
+  }[];
+}
+
+export interface AuthorizedOperationListResponse {
+  data: AuthorizedOperation[];
+  first_page_url?: string;
+  last_page?: number;
+  last_page_url?: string;
+  next_page_url?: string | null;
+  path?: string;
+  prev_page_url?: string | null;
+  meta?: AuthorizedOperationMeta;
+}


### PR DESCRIPTION
## Summary
- add API path for authorized operations
- build a DailyOperationsAuthorized page with table
- fetch authorized operations from server
- reuse TabsContainer and SearchFilters components

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6847f1b918cc832c93012fc3e7ad90a9