### PR TITLE
Use ReusableTable for financial summary

### DIFF
--- a/src/components/common/dailyTransactionsFinancialSummary/index.tsx
+++ b/src/components/common/dailyTransactionsFinancialSummary/index.tsx
@@ -1,4 +1,5 @@
-import { Table } from 'react-bootstrap';
+import React, { useMemo, useState } from 'react';
+import ReusableTable, { ColumnDefinition, FilterDefinition } from '../ReusableTable';
 import { useFinancialSummary } from '../../hooks/accounting/financial_summary/useFinancialSummary';
 
 interface RowData {
@@ -10,82 +11,110 @@ interface RowData {
   description?: string;
 }
 
-const DailyTransactionsFinancialSummary = () => {
+const DailyTransactionsFinancialSummary: React.FC = () => {
   const { summary, loading } = useFinancialSummary();
 
-  if (loading) return <div>Loading...</div>;
-
-  const rows: RowData[] = [];
-
-  if (summary) {
-    rows.push({
-      category: 'Kasa Nakit',
-      cash: summary.liquid_assets?.cash ?? '-',
-      creditCard: '-',
-      other: '-',
-      total: summary.liquid_assets?.cash ?? '-',
-    });
-    rows.push({
-      category: 'Kalan Alacaklar',
-      cash: summary.liquid_assets?.remaining_receivables ?? '-',
-      creditCard: '-',
-      other: '-',
-      total: summary.liquid_assets?.remaining_receivables ?? '-',
-    });
-
-    summary.liquid_assets?.banks?.forEach((b) => {
-      rows.push({
-        category: b.bank_name,
-        cash: '-',
-        creditCard: b.amount ?? '-',
+  const rows: RowData[] = useMemo(() => {
+    const arr: RowData[] = [];
+    if (summary) {
+      arr.push({
+        category: 'Kasa Nakit',
+        cash: summary.liquid_assets?.cash ?? '-',
+        creditCard: '-',
         other: '-',
-        total: b.amount ?? '-',
+        total: summary.liquid_assets?.cash ?? '-',
       });
-    });
+      arr.push({
+        category: 'Kalan Alacaklar',
+        cash: summary.liquid_assets?.remaining_receivables ?? '-',
+        creditCard: '-',
+        other: '-',
+        total: summary.liquid_assets?.remaining_receivables ?? '-',
+      });
 
-    rows.push({
-      category: 'Personel Ödemeleri',
-      cash: '-',
-      creditCard: '-',
-      other: summary.liabilities?.personnel_payables ?? '-',
-      total: summary.liabilities?.personnel_payables ?? '-',
-    });
+      summary.liquid_assets?.banks?.forEach((b) => {
+        arr.push({
+          category: b.bank_name,
+          cash: '-',
+          creditCard: b.amount ?? '-',
+          other: '-',
+          total: b.amount ?? '-',
+        });
+      });
 
-    rows.push({
-      category: 'Tedarikçi Borçları',
-      cash: '-',
-      creditCard: '-',
-      other: summary.liabilities?.supplier_debts ?? '-',
-      total: summary.liabilities?.supplier_debts ?? '-',
-    });
-  }
+      arr.push({
+        category: 'Personel Ödemeleri',
+        cash: '-',
+        creditCard: '-',
+        other: summary.liabilities?.personnel_payables ?? '-',
+        total: summary.liabilities?.personnel_payables ?? '-',
+      });
+
+      arr.push({
+        category: 'Tedarikçi Borçları',
+        cash: '-',
+        creditCard: '-',
+        other: summary.liabilities?.supplier_debts ?? '-',
+        total: summary.liabilities?.supplier_debts ?? '-',
+      });
+    }
+    return arr;
+  }, [summary]);
+
+  const [search, setSearch] = useState('');
+
+  const filteredRows = useMemo(() => {
+    if (!search) return rows;
+    const term = search.toLocaleLowerCase('tr-TR');
+    return rows.filter((r) =>
+      r.category.toLocaleLowerCase('tr-TR').includes(term)
+    );
+  }, [rows, search]);
+
+  const columns: ColumnDefinition<RowData>[] = useMemo(
+    () => [
+      { key: 'category', label: 'Kategori', render: (r) => r.category },
+      { key: 'cash', label: 'Nakit', render: (r) => r.cash },
+      { key: 'creditCard', label: 'Kredi Kartı', render: (r) => r.creditCard },
+      { key: 'other', label: 'Diğer', render: (r) => r.other },
+      { key: 'total', label: 'Toplam', render: (r) => r.total },
+      { key: 'description', label: 'Açıklama', render: (r) => r.description || '-' },
+    ],
+    []
+  );
+
+  const filters: FilterDefinition[] = useMemo(
+    () => [
+      {
+        key: 'search',
+        label: 'Kategori Ara',
+        type: 'text',
+        value: search,
+        onChange: (val: string) => setSearch(val),
+      },
+    ],
+    [search]
+  );
 
   return (
     <div className="container mt-3">
-      <Table bordered hover>
-        <thead>
-          <tr>
-            <th>Kategori</th>
-            <th>Nakit</th>
-            <th>Kredi Kartı</th>
-            <th>Diğer</th>
-            <th>Toplam</th>
-            <th>Açıklama</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row, idx) => (
-            <tr key={idx}>
-              <td>{row.category}</td>
-              <td>{row.cash}</td>
-              <td>{row.creditCard}</td>
-              <td>{row.other}</td>
-              <td>{row.total}</td>
-              <td>{row.description || '-'}</td>
-            </tr>
-          ))}
-        </tbody>
-      </Table>
+      <ReusableTable<RowData>
+        pageTitle="Finansal Özet"
+        columns={columns}
+        data={filteredRows}
+        loading={loading}
+        error={null}
+        tableMode="single"
+        currentPage={1}
+        totalPages={1}
+        totalItems={filteredRows.length}
+        pageSize={filteredRows.length}
+        onPageChange={() => {}}
+        onPageSizeChange={() => {}}
+        filters={filters}
+        showModal={false}
+        exportFileName="financial-summary"
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- refactor dailyTransactionsFinancialSummary to use ReusableTable instead of raw table

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_68480c84d98c832c9364f99ced320826