### PR TITLE
Add DailyIncome table

### DIFF
--- a/src/components/common/daily/index.tsx
+++ b/src/components/common/daily/index.tsx
@@ -4,7 +4,7 @@ import TabsContainer from './component/organisms/TabsContainer';
 
 import DailyTransactionsFinancialSummary from '../dailyTransactionsFinancialSummary';
 import StudentInstallmentsTable from '../studentInstallments';
-import OtherIncomeTable from '../otherIncome/table';
+import DailyIncomeTable from '../dailyIncome/table';
 import ExpenseListPage from '../expences/main/table';
 import PaymentTab from '../personel/financialSummary/PaymentTab';
 import CreditCardTable from '../creditcard/table';
@@ -36,7 +36,7 @@ const DailyModule: React.FC = () => {
     },
     {
       label: 'Gelirler',
-      content: <OtherIncomeTable />,
+      content: <DailyIncomeTable />,
       activeBgColor: '#5C67F7',
       activeTextColor: '#FFFFFF',
       passiveBgColor: '#5C67F726',

--- a/src/components/common/dailyIncome/table.tsx
+++ b/src/components/common/dailyIncome/table.tsx
@@ -1,0 +1,83 @@
+import { useMemo } from 'react';
+import ReusableTable, { ColumnDefinition } from '../ReusableTable';
+import { useOtherIncomeTable } from '../../hooks/otherIncome/useOtherIncomeList';
+import { OtherIncomeData } from '../../../types/otherIncome/list';
+
+interface DailyIncomeData extends OtherIncomeData {
+  branch_name?: string | null;
+  received_amount?: string;
+  paid_amount?: string;
+  remaining_amount?: string;
+}
+
+export default function DailyIncomeTable() {
+  const {
+    otherIncomeData,
+    loading,
+    error,
+    page,
+    paginate,
+    totalPages,
+    totalItems,
+    setPage,
+    setPaginate,
+  } = useOtherIncomeTable({ enabled: true });
+
+  const columns: ColumnDefinition<DailyIncomeData>[] = useMemo(
+    () => [
+      { key: 'season', label: 'Sezon', render: r => r.season || '-' },
+      { key: 'branch_name', label: 'Şube', render: r => r.branch_name || '-' },
+      { key: 'date', label: 'Tarih', render: r => r.date || '-' },
+      {
+        key: 'customer',
+        label: 'Müşteri',
+        render: r => r.customer?.name || '-',
+      },
+      { key: 'income_item', label: 'Gelir Kalemi', render: r => r.income_item || '-' },
+      {
+        key: 'received_amount',
+        label: 'Alınan Tutar',
+        render: r =>
+          r.received_amount ? `${Number(r.received_amount).toLocaleString()} ₺` : '-',
+      },
+      {
+        key: 'paid_amount',
+        label: 'Ödenen Tutar',
+        render: r =>
+          r.paid_amount ? `${Number(r.paid_amount).toLocaleString()} ₺` : '-',
+      },
+      {
+        key: 'remaining_amount',
+        label: 'Kalan Tutar',
+        render: r =>
+          r.remaining_amount ? `${Number(r.remaining_amount).toLocaleString()} ₺` : '-',
+      },
+      { key: 'payment_method', label: 'Ödeme Şekli', render: r => r.payment_method || '-' },
+      { key: 'description', label: 'Açıklama', render: r => r.description || '-' },
+      { key: 'id', label: 'Makbuz No', render: r => String(r.id) },
+    ],
+    []
+  );
+
+  return (
+    <ReusableTable<DailyIncomeData>
+      pageTitle="Gelirler"
+      columns={columns}
+      data={otherIncomeData as DailyIncomeData[]}
+      loading={loading}
+      error={error}
+      tableMode="single"
+      currentPage={page}
+      totalPages={totalPages}
+      totalItems={totalItems}
+      pageSize={paginate}
+      onPageChange={(newPage) => setPage(newPage)}
+      onPageSizeChange={(newSize) => {
+        setPaginate(newSize);
+        setPage(1);
+      }}
+      showExportButtons
+      exportFileName="daily-income"
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add a DailyIncomeTable component using other-income API
- show this table in the Daily module instead of OtherIncomeTable

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68482df2a288832c9cb9127dbacc4411