### PR TITLE
Add DailyAuthority component

### DIFF
--- a/src/components/common/daily/index.tsx
+++ b/src/components/common/daily/index.tsx
@@ -10,7 +10,7 @@ import DailyStaffAppointmentsTable from "../dailyStaffAppointments";
 import DailyCardManagementTable from '../dailyCardManagement';
 import DailyTransactionsPaymentsTable from '../dailyTransactionsPayments/table';
 import DailyTransferTable from '../dailyTransfer';
-import DailyOperationsAuthorized from '../dailyOperationsAuthorized';
+import DailyAuthority from '../dailyAuthority';
 import Pageheader from '../../page-header/pageheader';
 
 const DailyModule: React.FC = () => {
@@ -84,7 +84,7 @@ const DailyModule: React.FC = () => {
     },
     {
       label: 'Yetkili',
-      content: <DailyOperationsAuthorized />,
+      content: <DailyAuthority />,
       activeBgColor: '#5C67F7',
       activeTextColor: '#FFFFFF',
       passiveBgColor: '#5C67F726',

--- a/src/components/common/dailyAuthority/index.tsx
+++ b/src/components/common/dailyAuthority/index.tsx
@@ -1,0 +1,2 @@
+import DailyAuthorityTable from './table';
+export default DailyAuthorityTable;

--- a/src/components/common/dailyAuthority/table.tsx
+++ b/src/components/common/dailyAuthority/table.tsx
@@ -1,0 +1,83 @@
+import React, { useMemo, useState } from 'react';
+import ReusableTable, { ColumnDefinition, FilterDefinition } from '../ReusableTable';
+import { useDailySummary } from '../../hooks/accounting/useDailySummary';
+
+interface AuthorityRow {
+  name: string;
+  received: number;
+  given: number;
+  balance: number;
+}
+
+const DailyAuthorityTable: React.FC = () => {
+  const { data, loading } = useDailySummary();
+  const userData = localStorage.getItem('userData') ? JSON.parse(localStorage.getItem('userData') || '{}') : {};
+  const fullName = userData?.me ? `${userData.me.first_name} ${userData.me.last_name}` : '-';
+
+  const received = useMemo(() => {
+    if (!data) return 0;
+    return data.payments.reduce((sum, p) => sum + Number(p.total || 0), 0);
+  }, [data]);
+
+  const given = useMemo(() => {
+    if (!data) return 0;
+    return data.transfers.reduce((sum, t) => sum + Number(t.total || 0), 0);
+  }, [data]);
+
+  const balance = received - given;
+
+  const rows: AuthorityRow[] = useMemo(() => [
+    { name: fullName, received, given, balance }
+  ], [fullName, received, given, balance]);
+
+  const [search, setSearch] = useState('');
+
+  const filteredRows = useMemo(() => {
+    if (!search) return rows;
+    const term = search.toLocaleLowerCase('tr-TR');
+    return rows.filter((r) =>
+      r.name.toLocaleLowerCase('tr-TR').includes(term)
+    );
+  }, [rows, search]);
+
+  const columns: ColumnDefinition<AuthorityRow>[] = useMemo(() => [
+    { key: 'name', label: 'Adı Soyadı', render: r => r.name },
+    { key: 'received', label: 'Alınan Tutar', render: r => `${r.received.toLocaleString()} ₺` },
+    { key: 'given', label: 'Verilen Tutar', render: r => `${r.given.toLocaleString()} ₺` },
+    { key: 'balance', label: 'Kalan Tutar', render: r => `${r.balance.toLocaleString()} ₺` },
+  ], []);
+
+  const filters: FilterDefinition[] = useMemo(() => [
+    {
+      key: 'search',
+      label: 'Yetkili Ara',
+      type: 'text',
+      value: search,
+      onChange: (val: string) => setSearch(val)
+    }
+  ], [search]);
+
+  return (
+    <div className="container mt-3">
+      <ReusableTable<AuthorityRow>
+        pageTitle="Yetkili İşlemleri"
+        columns={columns}
+        data={filteredRows}
+        loading={loading}
+        error={null}
+        tableMode="single"
+        currentPage={1}
+        totalPages={1}
+        totalItems={filteredRows.length}
+        pageSize={filteredRows.length}
+        onPageChange={() => {}}
+        onPageSizeChange={() => {}}
+        filters={filters}
+        showModal={false}
+        exportFileName="authorized-operations"
+      />
+    </div>
+  );
+};
+
+export default DailyAuthorityTable;


### PR DESCRIPTION
## Summary
- add new dailyAuthority table component using daily-summary API
- export the new table from an index file
- update Daily module to use DailyAuthority component

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68483bf6e7f4832ca0c2417c57df9c2e