### PR TITLE
Add rent detail modal and summary cards

### DIFF
--- a/src/components/common/rent/RentDetailModal.tsx
+++ b/src/components/common/rent/RentDetailModal.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useMemo, useState } from "react";
+import { Modal, Tabs, Tab, Button, Card } from "react-bootstrap";
+import ReusableTable, { ColumnDefinition } from "../ReusableTable";
+import ReusableModalForm, { FieldDefinition } from "../ReusableModalForm";
+import { useRentShow } from "../../hooks/rent/useRentShow";
+import { RentInstallment, RentPayment } from "../../../types/rent/detail";
+
+interface RentDetailModalProps {
+  show: boolean;
+  rentId: number | null;
+  onClose: () => void;
+}
+
+const RentDetailModal: React.FC<RentDetailModalProps> = ({ show, rentId, onClose }) => {
+  const { rent, getRent } = useRentShow();
+  const [installments, setInstallments] = useState<RentInstallment[]>([]);
+  const [payments, setPayments] = useState<RentPayment[]>([]);
+  const [showInstModal, setShowInstModal] = useState(false);
+  const [showPayModal, setShowPayModal] = useState(false);
+
+  useEffect(() => {
+    if (show && rentId) {
+      (async () => {
+        const r = await getRent(rentId);
+        if (r) {
+          setInstallments(r.installments || []);
+          const pays = r.installments.flatMap((i) => i.payments || []);
+          setPayments(pays);
+        }
+      })();
+    }
+  }, [show, rentId, getRent]);
+
+  const installmentColumns: ColumnDefinition<RentInstallment>[] = useMemo(
+    () => [
+      { key: "installment_no", label: "Sıra No" },
+      { key: "due_date", label: "Tarih" },
+      { key: "amount", label: "Tutar" },
+    ],
+    []
+  );
+
+  const paymentColumns: ColumnDefinition<RentPayment>[] = useMemo(
+    () => [
+      { key: "payment_no", label: "Sıra No" },
+      { key: "payment_date", label: "Tarih" },
+      { key: "amount", label: "Tutar" },
+    ],
+    []
+  );
+
+  const totalPaid = useMemo(() => {
+    return payments.reduce((sum, p) => sum + Number(p.amount || 0), 0);
+  }, [payments]);
+
+  const remaining = useMemo(() => {
+    if (!rent) return 0;
+    return Number(rent.total_rent) - totalPaid;
+  }, [rent, totalPaid]);
+
+  const addInstallment = (values: { due_date: string; amount: number }) => {
+    const current = installments.reduce((s, i) => s + Number(i.amount), 0);
+    if (rent && current + values.amount > Number(rent.total_rent)) {
+      alert("Taksit toplamı kira toplamını geçemez");
+      return;
+    }
+    const newItem: RentInstallment = {
+      installment_no: installments.length + 1,
+      due_date: values.due_date,
+      amount: String(values.amount),
+      remaining_amount: String(values.amount),
+      payments: [],
+    };
+    setInstallments([...installments, newItem]);
+    setShowInstModal(false);
+  };
+
+  const addPayment = (values: { payment_date: string; amount: number }) => {
+    const newPayment: RentPayment = {
+      payment_no: payments.length + 1,
+      payment_date: values.payment_date,
+      amount: String(values.amount),
+    };
+    setPayments([...payments, newPayment]);
+    setShowPayModal(false);
+  };
+
+  const installmentFields: FieldDefinition[] = [
+    { name: "due_date", label: "Tarih", type: "date", required: true },
+    { name: "amount", label: "Tutar", type: "currency", required: true },
+  ];
+
+  const paymentFields: FieldDefinition[] = [
+    { name: "payment_date", label: "Tarih", type: "date", required: true },
+    { name: "amount", label: "Tutar", type: "currency", required: true },
+  ];
+
+  return (
+    <>
+      <Modal show={show} onHide={onClose} size="lg" centered>
+        <Modal.Header closeButton>
+          <Modal.Title>Kira Detayı</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Tabs defaultActiveKey="installments" id="rent-detail-tabs" className="mb-3">
+            <Tab eventKey="installments" title="Taksitler">
+              <div className="mb-2 text-end">
+                <Button size="sm" onClick={() => setShowInstModal(true)}>
+                  Ekle
+                </Button>
+              </div>
+              <ReusableTable
+                columns={installmentColumns}
+                data={installments}
+                totalItems={installments.length}
+              />
+            </Tab>
+            <Tab eventKey="payments" title="Ödemeler">
+              <div className="mb-2 text-end">
+                <Button size="sm" onClick={() => setShowPayModal(true)}>
+                  Ekle
+                </Button>
+              </div>
+              <ReusableTable
+                columns={paymentColumns}
+                data={payments}
+                totalItems={payments.length}
+              />
+              <Card className="mt-3">
+                <Card.Body>
+                  <div className="d-flex justify-content-between">
+                    <span>Toplam Ödenen:</span>
+                    <span>{totalPaid}</span>
+                  </div>
+                  <div className="d-flex justify-content-between">
+                    <span>Kalan:</span>
+                    <span>{remaining}</span>
+                  </div>
+                </Card.Body>
+              </Card>
+            </Tab>
+          </Tabs>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={onClose}>
+            Kapat
+          </Button>
+        </Modal.Footer>
+      </Modal>
+
+      <ReusableModalForm
+        show={showInstModal}
+        title="Taksit Ekle"
+        fields={installmentFields}
+        initialValues={{ due_date: "", amount: 0 }}
+        onSubmit={addInstallment}
+        confirmButtonLabel="Ekle"
+        cancelButtonLabel="Vazgeç"
+        onClose={() => setShowInstModal(false)}
+      />
+
+      <ReusableModalForm
+        show={showPayModal}
+        title="Ödeme Ekle"
+        fields={paymentFields}
+        initialValues={{ payment_date: "", amount: 0 }}
+        onSubmit={addPayment}
+        confirmButtonLabel="Ekle"
+        cancelButtonLabel="Vazgeç"
+        onClose={() => setShowPayModal(false)}
+      />
+    </>
+  );
+};
+
+export default RentDetailModal;

--- a/src/components/common/rent/table.tsx
+++ b/src/components/common/rent/table.tsx
@@ -1,7 +1,10 @@
-import { useMemo } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { Card } from "react-bootstrap";
 import ReusableTable, { ColumnDefinition } from "../ReusableTable";
 import { useRentList, RentItem } from "../../hooks/rent/useRentList";
+import { useRentShow } from "../../hooks/rent/useRentShow";
+import RentDetailModal from "./RentDetailModal";
 
 export default function RentTable() {
   const navigate = useNavigate();
@@ -17,19 +20,74 @@ export default function RentTable() {
     setPage,
     setPageSize,
   } = useRentList({ enabled: true });
+  const { getRent } = useRentShow();
+
+  const [showDetail, setShowDetail] = useState(false);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  const [rowDetails, setRowDetails] = useState<Record<number, { paid: number; remaining: number }>>({});
+  const [totals, setTotals] = useState({ rent: 0, paid: 0, remaining: 0 });
+
+  useEffect(() => {
+    async function calcDetails() {
+      let totalRent = 0;
+      let totalPaid = 0;
+      const details: Record<number, { paid: number; remaining: number }> = {};
+
+      for (const r of rentData) {
+        totalRent += Number(r.total_rent);
+        const detail = await getRent(r.id);
+        let paid = 0;
+        if (detail) {
+          paid = detail.installments.reduce(
+            (sum, inst) => sum + (Number(inst.amount) - Number(inst.remaining_amount)),
+            0
+          );
+        }
+        totalPaid += paid;
+        details[r.id] = { paid, remaining: Number(r.total_rent) - paid };
+      }
+
+      setRowDetails(details);
+      setTotals({ rent: totalRent, paid: totalPaid, remaining: totalRent - totalPaid });
+    }
+
+    if (rentData.length) calcDetails();
+  }, [rentData, getRent]);
 
   const columns: ColumnDefinition<RentItem>[] = useMemo(
     () => [
-      { key: "id", label: "ID" },
-      { key: "rent_date", label: "Tarih" },
-      { key: "total_rent", label: "Toplam" },
+      {
+        key: "rowNo",
+        label: "Sıra No",
+        render: (_row, _open, rowIndex) => rowIndex + 1,
+      },
+      { key: "rent_date", label: "Kiranın Adı" },
+      {
+        key: "total_rent",
+        label: "Ödenecek Tutar",
+        render: (row) => Number(row.total_rent).toLocaleString(),
+      },
+      {
+        key: "paid_amount",
+        label: "Ödenen Tutar",
+        render: (row) => rowDetails[row.id]?.paid?.toLocaleString() ?? "-",
+      },
+      {
+        key: "remaining_amount",
+        label: "Kalan Tutar",
+        render: (row) => rowDetails[row.id]?.remaining?.toLocaleString() ?? "-",
+      },
       {
         key: "actions",
         label: "İşlemler",
         render: (row) => (
           <>
             <button
-              onClick={() => navigate(`/rentdetail/${row.id}`)}
+              onClick={() => {
+                setSelectedId(row.id);
+                setShowDetail(true);
+              }}
               className="btn btn-icon btn-sm btn-primary-light rounded-pill"
             >
               <i className="ti ti-eye" />
@@ -44,11 +102,37 @@ export default function RentTable() {
         ),
       },
     ],
-    [navigate]
+    [navigate, rowDetails]
   );
 
   return (
     <div className="container mt-3">
+      <div className="row mb-4">
+        <div className="col-md-4">
+          <Card>
+            <Card.Body>
+              <h6>Kira Toplamı</h6>
+              <span>{totals.rent.toLocaleString()}</span>
+            </Card.Body>
+          </Card>
+        </div>
+        <div className="col-md-4">
+          <Card>
+            <Card.Body>
+              <h6>Ödenen</h6>
+              <span>{totals.paid.toLocaleString()}</span>
+            </Card.Body>
+          </Card>
+        </div>
+        <div className="col-md-4">
+          <Card>
+            <Card.Body>
+              <h6>Kalan</h6>
+              <span>{totals.remaining.toLocaleString()}</span>
+            </Card.Body>
+          </Card>
+        </div>
+      </div>
       <ReusableTable<RentItem>
         pageTitle="Kira Listesi"
         onAdd={() => navigate("/rentcrud")}
@@ -67,6 +151,11 @@ export default function RentTable() {
           setPage(1);
         }}
         exportFileName="rents"
+      />
+      <RentDetailModal
+        show={showDetail}
+        rentId={selectedId}
+        onClose={() => setShowDetail(false)}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- add `RentDetailModal` component for showing installments and payments in tabs
- show total rent, paid and remaining cards above rent table
- fetch rent details to compute row and overall totals
- open modal from table instead of navigating to a new page

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68492f6899dc832c835cb382501263b6