### PR TITLE
Add rent dashboard cards

### DIFF
--- a/src/components/common/rent/table.tsx
+++ b/src/components/common/rent/table.tsx
@@ -2,9 +2,12 @@ import { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import ReusableTable, { ColumnDefinition } from "../ReusableTable";
 import { useRentList, RentItem } from "../../hooks/rent/useRentList";
+import { useRentDelete } from "../../hooks/rent/useRentDelete";
+import Spkcardscomponent from "../../../@spk-reusable-components/reusable-dashboards/spk-cards.tsx";
 
 export default function RentTable() {
   const navigate = useNavigate();
+  const { removeRent } = useRentDelete();
 
   const {
     rentData,
@@ -18,11 +21,66 @@ export default function RentTable() {
     setPageSize,
   } = useRentList({ enabled: true });
 
+  const totalRent = useMemo(
+    () => rentData.reduce((sum, r) => sum + Number(r.total_rent || 0), 0),
+    [rentData]
+  );
+  const totalPaid = useMemo(
+    () => rentData.reduce((sum, r) => sum + Number((r as any).paid_amount || 0), 0),
+    [rentData]
+  );
+  const totalRemaining = useMemo(
+    () => rentData.reduce((sum, r) => sum + Number((r as any).remaining_amount || (Number(r.total_rent || 0) - Number((r as any).paid_amount || 0))), 0),
+    [rentData]
+  );
+
+  const cards = useMemo(
+    () => [
+      {
+        id: 1,
+        title: "Kira Toplamı",
+        count: totalRent.toLocaleString(),
+        iconClass: "ti ti-wallet",
+        backgroundColor: "primary",
+      },
+      {
+        id: 2,
+        title: "Ödenen",
+        count: totalPaid.toLocaleString(),
+        iconClass: "ti ti-check",
+        backgroundColor: "primary1",
+      },
+      {
+        id: 3,
+        title: "Kalan",
+        count: totalRemaining.toLocaleString(),
+        iconClass: "ti ti-calendar-minus",
+        backgroundColor: "primary2",
+      },
+    ],
+    [totalRent, totalPaid, totalRemaining]
+  );
+
   const columns: ColumnDefinition<RentItem>[] = useMemo(
     () => [
-      { key: "id", label: "ID" },
-      { key: "rent_date", label: "Tarih" },
-      { key: "total_rent", label: "Toplam" },
+      { key: "id", label: "Sıra No" },
+      { key: "rent_date", label: "Kiranın Adı" },
+      { key: "total_rent", label: "Ödenecek Tutar" },
+      {
+        key: "paid_amount",
+        label: "Ödenen Tutar",
+        render: (r) => (r.paid_amount ? r.paid_amount : "-")
+      },
+      {
+        key: "remaining_amount",
+        label: "Kalan Tutar",
+        render: (r) =>
+          r.remaining_amount
+            ? r.remaining_amount
+            : r.total_rent
+            ? String(Number(r.total_rent) - Number(r.paid_amount || 0))
+            : "-",
+      },
       {
         key: "actions",
         label: "İşlemler",
@@ -40,15 +98,38 @@ export default function RentTable() {
             >
               <i className="ti ti-pencil" />
             </button>
+            <button
+              onClick={() => removeRent(Number(row.id))}
+              className="btn btn-icon btn-sm btn-danger-light rounded-pill"
+            >
+              <i className="ti ti-trash" />
+            </button>
           </>
         ),
       },
     ],
-    [navigate]
+    [navigate, removeRent]
   );
 
   return (
     <div className="container mt-3">
+      <div className="row mb-3">
+        {cards.map((card) => (
+          <div className="col-md-4" key={card.id}>
+            <Spkcardscomponent
+              textbefore={false}
+              textafter={false}
+              cardClass="overflow-hidden main-content-card"
+              headingClass="d-block mb-1"
+              mainClass="d-flex align-items-start justify-content-between mb-2"
+              Icon={true}
+              card={card}
+              badgeClass="md rounded-pill"
+              dataClass="mb-0"
+            />
+          </div>
+        ))}
+      </div>
       <ReusableTable<RentItem>
         pageTitle="Kira Listesi"
         onAdd={() => navigate("/rentcrud")}

--- a/src/components/hooks/rent/useRentDelete.tsx
+++ b/src/components/hooks/rent/useRentDelete.tsx
@@ -1,0 +1,23 @@
+import { useState } from "react";
+import axiosInstance from "../../../services/axiosClient";
+import { RENTS } from "../../../helpers/url_helper";
+
+export function useRentDelete() {
+  const [status, setStatus] = useState<'IDLE' | 'LOADING' | 'SUCCEEDED' | 'FAILED'>('IDLE');
+  const [error, setError] = useState<string | null>(null);
+
+  const removeRent = async (id: number): Promise<boolean> => {
+    try {
+      setStatus('LOADING');
+      await axiosInstance.delete(`${RENTS}/${id}`);
+      setStatus('SUCCEEDED');
+      return true;
+    } catch (err: any) {
+      setStatus('FAILED');
+      setError(err.response?.data?.message || 'Delete rent failed');
+      return false;
+    }
+  };
+
+  return { status, error, removeRent };
+}

--- a/src/components/hooks/rent/useRentList.tsx
+++ b/src/components/hooks/rent/useRentList.tsx
@@ -8,6 +8,8 @@ export interface RentItem {
   season_id: number;
   rent_date: string;
   total_rent: string;
+  paid_amount?: string;
+  remaining_amount?: string;
 }
 
 export interface RentListParams {


### PR DESCRIPTION
## Summary
- extend rent list item with paid and remaining amounts
- add hook for deleting rents
- show summary cards above rent table
- add delete button and new columns in rent table

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: TypeScript errors due to missing configs)*

------
https://chatgpt.com/codex/tasks/task_e_684931e5d1bc832c9c4b7dfee23b5314