### PR TITLE
Fix rent add and show details as modal

### DIFF
--- a/src/components/common/rent/RentDetail.tsx
+++ b/src/components/common/rent/RentDetail.tsx
@@ -1,11 +1,16 @@
 import React, { useEffect, useMemo } from "react";
 import { useParams } from "react-router-dom";
-import { Card } from "react-bootstrap";
+import { Card, Modal } from "react-bootstrap";
 import ReusableTable, { ColumnDefinition } from "../ReusableTable";
 import { useRentShow } from "../../hooks/rent/useRentShow";
 import { RentInstallment, RentPayment } from "../../../types/rent/detail";
 
-const RentDetailPage: React.FC = () => {
+interface RentDetailModalProps {
+  show: boolean;
+  onClose: () => void;
+}
+
+const RentDetailPage: React.FC<RentDetailModalProps> = ({ show, onClose }) => {
   const { id } = useParams<{ id: string }>();
   const { rent, getRent } = useRentShow();
 
@@ -53,40 +58,46 @@ const RentDetailPage: React.FC = () => {
   }, [rent, totalPaid]);
 
   if (!rent) {
-    return <div>Yükleniyor...</div>;
+    return null;
   }
 
   return (
-    <div className="container mt-3">
-      <h4>Kira Ödemeleri</h4>
-      <p>Kira Toplamı: {rent.total_rent}</p>
-      <p>Ödenen: {totalPaid}</p>
-      <p>Kalan: {remaining}</p>
-      <div className="row">
-        <div className="col-md-6 mb-3">
-          <Card>
-            <Card.Header as="h5">Taksitler</Card.Header>
-            <Card.Body className="p-3">
-              <ReusableTable<RentInstallment>
-                columns={installmentColumns}
-                data={rent.installments}
-              />
-            </Card.Body>
-          </Card>
+    <Modal show={show} onHide={onClose} centered size="lg">
+      <Modal.Header closeButton>
+        <Modal.Title>Kira Ödemeleri</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <div className="container-fluid">
+          <p>Kira Toplamı: {rent.total_rent}</p>
+          <p>Ödenen: {totalPaid}</p>
+          <p>Kalan: {remaining}</p>
+          <div className="row">
+            <div className="col-md-6 mb-3">
+              <Card>
+                <Card.Header as="h5">Taksitler</Card.Header>
+                <Card.Body className="p-3">
+                  <ReusableTable<RentInstallment>
+                    columns={installmentColumns}
+                    data={rent.installments}
+                  />
+                </Card.Body>
+              </Card>
+            </div>
+            <div className="col-md-6 mb-3">
+              <Card>
+                <Card.Header as="h5">Ödemeler</Card.Header>
+                <Card.Body className="p-3">
+                  <ReusableTable<RentPayment>
+                    columns={paymentColumns}
+                    data={payments}
+                  />
+                </Card.Body>
+              </Card>
+            </div>
+          </div>
         </div>
-        <div className="col-md-6 mb-3">
-          <Card>
-            <Card.Header as="h5">Ödemeler</Card.Header>
-            <Card.Body className="p-3">
-              <ReusableTable<RentPayment>
-                columns={paymentColumns}
-                data={payments}
-              />
-            </Card.Body>
-          </Card>
-        </div>
-      </div>
-    </div>
+      </Modal.Body>
+    </Modal>
   );
 };
 

--- a/src/components/common/rent/crud.tsx
+++ b/src/components/common/rent/crud.tsx
@@ -5,6 +5,7 @@ import ReusableModalForm, { FieldDefinition } from "../ReusableModalForm";
 import { useRentShow } from "../../hooks/rent/useRentShow";
 import { useRentAdd, RentAddPayload } from "../../hooks/rent/useRentAdd";
 import { useRentUpdate, RentUpdatePayload } from "../../hooks/rent/useRentUpdate";
+import { useSeasonsBranches } from "../../header/hooks/useSeasonsBranches";
 
 interface RentModalProps {
   show: boolean;
@@ -30,6 +31,7 @@ const RentModal: React.FC<RentModalProps> = ({ show, onClose, onRefresh }) => {
   const { rent, getRent } = useRentShow();
   const { status: addStatus, error: addError, addNewRent } = useRentAdd();
   const { status: updateStatus, error: updateError, updateRent } = useRentUpdate();
+  const { selectedSeason, selectedBranch } = useSeasonsBranches();
 
   useEffect(() => {
     if (mode === "update" && id) {
@@ -58,8 +60,8 @@ const RentModal: React.FC<RentModalProps> = ({ show, onClose, onRefresh }) => {
     const payloadBase = {
       rent_date: values.rent_date,
       total_rent: values.total_rent,
-      branch_id: 0,
-      season_id: 0,
+      branch_id: selectedBranch || 0,
+      season_id: selectedSeason || 0,
     };
     if (mode === "add") {
       await addNewRent(payloadBase as RentAddPayload);

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -1755,7 +1755,9 @@ export const Routedata = [
   {
     id: 2001,
     path: `${import.meta.env.BASE_URL}rentdetail/:id`,
-    element: <RentDetailPage />,
+    element: (
+      <RentDetailPage show={true} onClose={() => window.history.back()} />
+    ),
   },
 
   {


### PR DESCRIPTION
## Summary
- include selected season and branch when adding rents
- render rent details inside a modal
- open rent details as modal from routing

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: TS errors because environment lacks required dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6849341d3758832c8a4d506c4be7afa3