### PR TITLE
Update supplier invoice modal and table

### DIFF
--- a/src/components/common/supplier/supplierDetail/tabs/invoice/crud.tsx
+++ b/src/components/common/supplier/supplierDetail/tabs/invoice/crud.tsx
@@ -121,11 +121,11 @@ export default function InvoiceCrudPage() {
       label: "Gider Kalemi",
       type: "select",
       options: categoryOptions,
-      required: false,
+      required: true,
     },
     {
       name: "payable_amount",
-      label: "Miktar",
+      label: "Tutar",
       type: "text",
       required: true,
     },
@@ -133,7 +133,7 @@ export default function InvoiceCrudPage() {
       name: "description",
       label: "Açıklama",
       type: "textarea",
-      required: false,
+      required: true,
     },
     // Sadece update modunda removeOldPdf checkbox
     ...(mode === "update"
@@ -228,7 +228,7 @@ export default function InvoiceCrudPage() {
       error={error || null}
       onClose={() => navigate(-1)}
       autoGoBackOnModalClose={true}
-      mode="single" // or "double" 
+      mode="double" // 2 taraflı modal
     />
   )
 }

--- a/src/components/common/supplier/supplierDetail/tabs/invoice/table.tsx
+++ b/src/components/common/supplier/supplierDetail/tabs/invoice/table.tsx
@@ -49,6 +49,11 @@ export default function SupplierInvoiceTab({ supplierId, enabled }: SupplierInvo
         render: (row) => row.issue_date || "-",
       },
       {
+        key: "fis_seri_no",
+        label: "Fatura Seri No",
+        render: (row) => row.fis_seri_no || "-",
+      },
+      {
         key: "invoice_type_code",
         label: "Fatura Tipi",
         render: (row) => row.invoice_type_code || "-",
@@ -59,14 +64,21 @@ export default function SupplierInvoiceTab({ supplierId, enabled }: SupplierInvo
         render: (row) => row.payable_amount || "0.00",
       },
       {
-        key: "fis_seri_no",
-        label: "Fiş Seri No",
-        render: (row) => row.fis_seri_no || "-",
+        key: "gider_kalemi",
+        label: "Gider Kalemi",
+        render: (row) => row.gider_kalemi || "-",
       },
       {
-        key: "fatura_adi",
-        label: "Fatura Adı",
-        render: (row) => row.fatura_adi || "-",
+        key: "dokuman",
+        label: "Doküman",
+        render: (row) =>
+          row.pdf_path ? (
+            <a href={row.pdf_path} target="_blank" rel="noopener noreferrer">
+              PDF
+            </a>
+          ) : (
+            "-"
+          ),
       },
       {
         key: "actions",


### PR DESCRIPTION
## Summary
- use two-column layout in supplier invoice modal
- make expense category and description required
- rename amount label to Tutar
- show new columns in supplier invoice list and link to PDF

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68494d97769c832c9768e2e7cfcf2f3b