### PR TITLE
Implement new supplier note layout

### DIFF
--- a/src/components/common/supplier/supplierDetail/tabs/notes/crud.tsx
+++ b/src/components/common/supplier/supplierDetail/tabs/notes/crud.tsx
@@ -92,8 +92,8 @@ export default function SupplierNoteCrud() {
       fields={fields}
       initialValues={initialValues}
       onSubmit={handleSubmit}
-      confirmButtonLabel={mode === "add" ? "Kaydet" : "Güncelle"}
-      cancelButtonLabel="İptal"
+      confirmButtonLabel={mode === "add" ? "Ekle" : "Güncelle"}
+      cancelButtonLabel="Vazgeç"
       isLoading={loading}
       error={error || null}
       onClose={() => navigate(-1)}

--- a/src/components/common/supplier/supplierDetail/tabs/notes/table.tsx
+++ b/src/components/common/supplier/supplierDetail/tabs/notes/table.tsx
@@ -5,6 +5,9 @@ import ReusableTable, { ColumnDefinition } from "../../../../ReusableTable"
 import { useSupplierNotesList } from "../../../../../hooks/supplierNotes/useList"
 import { useSupplierNotesDelete } from "../../../../../hooks/supplierNotes/useDelete"
 import { SupplierNoteData } from "../../../../../../types/supplierNotes/list"
+import { useDispatch } from "react-redux"
+import { AppDispatch } from "../../../../../../store"
+import { fetchSupplierNotes } from "../../../../../../slices/supplierNotes/list/thunk"
 
 interface SupplierNotesTabProps {
   supplierId: number
@@ -13,6 +16,7 @@ interface SupplierNotesTabProps {
 
 export default function SupplierNotesTab({ supplierId, enabled }: SupplierNotesTabProps) {
   const navigate = useNavigate()
+  const dispatch = useDispatch<AppDispatch>()
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(10)
   const [search] = useState("")
@@ -31,14 +35,24 @@ export default function SupplierNotesTab({ supplierId, enabled }: SupplierNotesT
   const columns: ColumnDefinition<SupplierNoteData>[] = useMemo(() => {
     return [
       {
+        key: "branch_name",
+        label: "Şube",
+        render: (row) => row.branch_name || "-",
+      },
+      {
+        key: "created_at",
+        label: "Tarih",
+        render: (row) => row.created_at || "-",
+      },
+      {
         key: "note",
         label: "Not",
         render: (row) => row.note || "-",
       },
       {
-        key: "created_at",
-        label: "Oluşturulma Tarihi",
-        render: (row) => row.created_at || "-",
+        key: "user_name",
+        label: "Kullanıcı",
+        render: (row) => row.user_name || "-",
       },
       {
         key: "actions",
@@ -69,7 +83,17 @@ export default function SupplierNotesTab({ supplierId, enabled }: SupplierNotesT
 
   function handleDeleteRow(row: SupplierNoteData) {
     if (!row.id) return
-    deleteExistingSupplierNote({ supplierId, supplierNoteId: row.id })
+    deleteExistingSupplierNote({ supplierId, supplierNoteId: row.id }).then(() => {
+      dispatch(
+        fetchSupplierNotes({
+          supplierId,
+          page,
+          pageSize,
+          search,
+          enabled,
+        })
+      )
+    })
   }
 
   return (

--- a/src/types/supplierNotes/list.tsx
+++ b/src/types/supplierNotes/list.tsx
@@ -1,10 +1,13 @@
 export interface SupplierNoteData {
     id: number
     supplier_id: number
+    branch_id?: number | null
+    branch_name?: string | null
     note: string
     created_at: string
     updated_at: string
     platform_id: number
+    user_name?: string | null
   }
   
   export interface SupplierNotesListLinks {


### PR DESCRIPTION
## Summary
- show branch, date, note and user columns in supplier note table
- refresh note table after delete
- adjust add/update note modal buttons
- extend supplier note type for branch and user info

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684963bde474832cafa2d5a350d4f253