### PR TITLE
Add headers to income pages

### DIFF
--- a/src/components/common/income/table.tsx
+++ b/src/components/common/income/table.tsx
@@ -4,6 +4,7 @@ import ReusableTable, { ColumnDefinition, FilterDefinition } from '../ReusableTa
 import { useIncomeTable } from '../../hooks/income/useList';
 import { IncomeData } from '../../../types/income/list';
 import { Button } from 'react-bootstrap';
+import Pageheader from '../../page-header/pageheader';
 
 export default function IncomeListPage() {
   const navigate = useNavigate();
@@ -69,11 +70,8 @@ export default function IncomeListPage() {
   );
 
   return (
-    <div className="">
-      <div className="">
-        <h4>Gelir Listesi</h4>
-
-      </div>
+    <div className="container-fluid mt-3">
+      <Pageheader title="Gelirler" currentpage="Gelir Kayıtları" />
       <ReusableTable<IncomeData>
         columns={columns}
         tableMode='single'

--- a/src/components/common/otherIncome/table.tsx
+++ b/src/components/common/otherIncome/table.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import ReusableTable, { ColumnDefinition } from '../ReusableTable';
+import Pageheader from '../../page-header/pageheader';
 import { useOtherIncomeTable } from '../../hooks/otherIncome/useOtherIncomeList';
 import { OtherIncomeData } from '../../../types/otherIncome/list';
 import { useOtherIncomeDelete } from '../../hooks/otherIncome/useOtherIncomeDelete';
@@ -76,6 +77,7 @@ export default function OtherIncomeTable() {
 
   return (
     <div className="container-fluid mt-3">
+      <Pageheader title="Gelirler" currentpage="Farklı Gelirler" />
       <ReusableTable<OtherIncomeData>
 
         onAdd={() => navigate('/other-income/crud')}


### PR DESCRIPTION
## Summary
- show "Gelirler" breadcrumb header on income pages
- show "Gelirler" breadcrumb header on other income pages

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684965dafad0832c80bc86d4bf3065f0