### PR TITLE
Use Pageheader in expenses and rent tables

### DIFF
--- a/src/components/common/expences/main/table.tsx
+++ b/src/components/common/expences/main/table.tsx
@@ -14,6 +14,7 @@ import { useSeasonsList } from "../../../hooks/season/useSeasonsList";
 import { useBranchTable } from "../../../hooks/branch/useBranchList";
 import { useCategoriesList } from "../../../hooks/expences/expenseCategories/useCategoriesList";
 import { useSuppliersTable } from "../../../hooks/suppliers/useSuppliersList";
+import Pageheader from "../../../page-header/pageheader";
 
 export default function ExpenseListPage() {
   const navigate = useNavigate();
@@ -247,7 +248,8 @@ export default function ExpenseListPage() {
   );
 
   return (
-    <>
+    <div className="container-fluid mt-3">
+      <Pageheader title="Giderler" currentpage="Gider Kayıtları" />
       <FilterGroup filters={filters} columnsPerRow={4} navigate={navigate} />
 
       <ReusableTable<IExpense>
@@ -273,6 +275,6 @@ export default function ExpenseListPage() {
           removeExpence(Number(row.id));
         }}
       />
-    </>
+    </div>
   );
 }

--- a/src/components/common/rent/table.tsx
+++ b/src/components/common/rent/table.tsx
@@ -4,6 +4,7 @@ import ReusableTable, { ColumnDefinition } from "../ReusableTable";
 import { useRentList, RentItem } from "../../hooks/rent/useRentList";
 import { useRentDelete } from "../../hooks/rent/useRentDelete";
 import Spkcardscomponent from "../../../@spk-reusable-components/reusable-dashboards/spk-cards.tsx";
+import Pageheader from "../../page-header/pageheader";
 
 export default function RentTable() {
   const navigate = useNavigate();
@@ -113,6 +114,7 @@ export default function RentTable() {
 
   return (
     <div className="container mt-3">
+      <Pageheader title="Giderler" currentpage="Kira Giderleri" />
       <div className="row mb-3">
         {cards.map((card) => (
           <div className="col-md-4" key={card.id}>


### PR DESCRIPTION
## Summary
- use the common Pageheader component in expense and rent table pages

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6849694806d4832cb4ea69b339717b34