### PR TITLE
Apply single mode design for supplier tabs

### DIFF
--- a/src/components/common/supplier/supplierDetail/tabs/notes/table.tsx
+++ b/src/components/common/supplier/supplierDetail/tabs/notes/table.tsx
@@ -106,6 +106,7 @@ export default function SupplierNotesTab({ supplierId, enabled }: SupplierNotesT
       data={supplierNotesData || []}
       loading={loading}
       error={error || deleteError}
+      tableMode="single"
       currentPage={current_page ?? 1}
       totalPages={totalPages}
       totalItems={totalItems}

--- a/src/components/common/supplier/supplierDetail/tabs/payments/table.tsx
+++ b/src/components/common/supplier/supplierDetail/tabs/payments/table.tsx
@@ -110,6 +110,7 @@ export default function SupplierPaymentsTab({ supplierId, enabled }: SupplierPay
       data={supplierPaymentsData || []}
       loading={loading}
       error={error || deleteError}
+      tableMode="single"
       pageSize={pageSize}
       onPageChange={(newPage) => setPage(newPage)}
       onPageSizeChange={(newSize) => {

--- a/src/components/common/supplier/supplierDetail/tabs/refunds/table.tsx
+++ b/src/components/common/supplier/supplierDetail/tabs/refunds/table.tsx
@@ -106,6 +106,7 @@ export default function SupplierRefundTab({ supplierId, enabled }: SupplierRefun
       data={refunds || []}
       loading={loading}
       error={error || deleteError}
+      tableMode="single"
 
       pageSize={pageSize}
       onPageChange={(newPage) => setPage(newPage)}


### PR DESCRIPTION
## Summary
- enable single-mode table layout on supplier payments, refunds and notes pages

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68497d8fa994832ca39e2d340b281f6e