### PR TITLE
Add printable supplier payment receipt page

### DIFF
--- a/src/components/common/supplier/supplierDetail/tabs/payments/receipt.tsx
+++ b/src/components/common/supplier/supplierDetail/tabs/payments/receipt.tsx
@@ -1,0 +1,43 @@
+import { useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { useSupplierPaymentsDetail } from "../../../../../hooks/supplierPayments/useDetail";
+import { useSupplierShow } from "../../../../../hooks/suppliers/useSuppliersShow";
+
+export default function SupplierPaymentReceipt() {
+  const { supplierId, paymentId } = useParams<{ supplierId?: string; paymentId?: string }>();
+  const navigate = useNavigate();
+  const { supplierPayment, getSupplierPayment } = useSupplierPaymentsDetail();
+  const { supplier, getSupplier } = useSupplierShow();
+
+  useEffect(() => {
+    if (supplierId && paymentId) {
+      getSupplierPayment({ supplierId: Number(supplierId), supplierPaymentId: Number(paymentId) });
+      getSupplier(supplierId);
+    }
+  }, [supplierId, paymentId, getSupplierPayment, getSupplier]);
+
+  return (
+    <div className="container mt-4" style={{ maxWidth: "600px" }}>
+      <div className="d-flex justify-content-between mb-3">
+        <h4>\u00d6deme Makbuzu</h4>
+        <button className="btn btn-primary" onClick={() => window.print()}>Yazd\u0131r</button>
+      </div>
+      <hr />
+      {supplierPayment ? (
+        <div>
+          <p><strong>Makbuz No:</strong> {supplierPayment.id}</p>
+          <p><strong>Tedarik\u00e7i:</strong> {supplier?.name || supplierId}</p>
+          <p><strong>Tarih:</strong> {supplierPayment.payment_date}</p>
+          <p><strong>\u00d6deme \u015eekli:</strong> {supplierPayment.payment_method?.name ?? "-"}</p>
+          <p><strong>Tutar:</strong> {Number(supplierPayment.amount).toLocaleString()} \u20ba</p>
+          {supplierPayment.description && (
+            <p><strong>A\u00e7\u0131klama:</strong> {supplierPayment.description}</p>
+          )}
+        </div>
+      ) : (
+        <p>Y\u00fckleniyor...</p>
+      )}
+      <button className="btn btn-secondary mt-3" onClick={() => navigate(-1)}>Geri D\u00f6n</button>
+    </div>
+  );
+}

--- a/src/components/common/supplier/supplierDetail/tabs/payments/table.tsx
+++ b/src/components/common/supplier/supplierDetail/tabs/payments/table.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from "react"
-import { DEFAULT_URL } from "../../../../../../helpers/url_helper"
 import { useNavigate } from "react-router-dom"
 import ReusableTable, { ColumnDefinition } from "../../../../ReusableTable"
 
@@ -79,11 +78,11 @@ export default function SupplierPaymentsTab({ supplierId, enabled }: SupplierPay
             >
               <i className="ti ti-trash" />
             </button>
-            {row.pdf_path && (
+            {row.id && (
               <button
                 className="btn btn-icon btn-sm btn-primary-light rounded-pill"
                 onClick={() =>
-                  window.open(`${DEFAULT_URL}/${row.pdf_path}`, "_blank")
+                  navigate(`/supplierPaymentReceipt/${supplierId}/${row.id}`)
                 }
               >
                 <i className="ti ti-printer" />

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -143,6 +143,10 @@ const SupplierPaymentCrud = lazy(
   () =>
     import("../components/common/supplier/supplierDetail/tabs/payments/crud")
 );
+const SupplierPaymentReceipt = lazy(
+  () =>
+    import("../components/common/supplier/supplierDetail/tabs/payments/receipt")
+);
 const SupplierNoteCrud = lazy(
   () => import("../components/common/supplier/supplierDetail/tabs/notes/crud")
 );
@@ -669,6 +673,11 @@ export const Routedata = [
     id: 10,
     path: `${import.meta.env.BASE_URL}supplierPaymentCrud/:id?`,
     element: <SupplierPaymentCrud />,
+  },
+  {
+    id: 10,
+    path: `${import.meta.env.BASE_URL}supplierPaymentReceipt/:supplierId/:paymentId`,
+    element: <SupplierPaymentReceipt />,
   },
   {
     id: 10,


### PR DESCRIPTION
## Summary
- enable printing supplier payments by navigating to new receipt page
- create SupplierPaymentReceipt component to render receipt information
- register SupplierPaymentReceipt route

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: missing type declarations during build)*

------
https://chatgpt.com/codex/tasks/task_e_684a761a2c64832cb086c807a6d55b95