### PR TITLE
Update receipt modal buttons and styling

### DIFF
--- a/src/components/common/supplier/supplierDetail/tabs/payments/receipt.css
+++ b/src/components/common/supplier/supplierDetail/tabs/payments/receipt.css
@@ -1,0 +1,21 @@
+.receipt-modal-body {
+  background-color: #f9f9f9;
+  border: 1px solid #e3e3e3;
+  border-radius: 6px;
+  padding: 1rem 1.5rem;
+  font-size: 0.95rem;
+}
+
+.receipt-modal-body p {
+  margin-bottom: 0.25rem;
+}
+
+.receipt-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.receipt-modal-footer .btn {
+  min-width: 90px;
+}

--- a/src/components/common/supplier/supplierDetail/tabs/payments/receipt.tsx
+++ b/src/components/common/supplier/supplierDetail/tabs/payments/receipt.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Modal, Button } from "react-bootstrap";
+import "./receipt.css";
 import {
   useSupplierPaymentsDetail,
 } from "../../../../../hooks/supplierPayments/useDetail";
@@ -24,7 +25,7 @@ export default function SupplierPaymentReceipt() {
       <Modal.Header closeButton>
         <Modal.Title>\u00d6deme Makbuzu</Modal.Title>
       </Modal.Header>
-      <Modal.Body>
+      <Modal.Body className="receipt-modal-body">
         {supplierPayment ? (
           <div>
             <p>
@@ -52,12 +53,12 @@ export default function SupplierPaymentReceipt() {
           <p>Y\u00fckleniyor...</p>
         )}
       </Modal.Body>
-      <Modal.Footer>
+      <Modal.Footer className="receipt-modal-footer">
         <Button variant="outline-secondary" onClick={() => window.print()}>
-          Yazd\u0131r
+          YAZDIR
         </Button>
         <Button variant="outline-secondary" onClick={() => navigate(-1)}>
-          Kapat
+          gerı dön
         </Button>
       </Modal.Footer>
     </Modal>


### PR DESCRIPTION
## Summary
- tweak supplier payment receipt style
- change receipt buttons to 'YAZDIR' and 'gerı dön'

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_684a79ad6890832c885b5efe8d21cd26