### PR TITLE
Add discount student receipt printing

### DIFF
--- a/src/Route/routingdata.tsx
+++ b/src/Route/routingdata.tsx
@@ -75,6 +75,9 @@ const Debts = lazy(() => import("../components/common/debts/table"));
 const DiscountStudent = lazy(
   () => import("../components/common/discountStudent/table")
 );
+const DiscountStudentReceipt = lazy(
+  () => import("../components/common/discountStudent/receipt")
+);
 const EducationalStructure = lazy(
   () => import("../components/common/academic/educational_structure/index")
 );
@@ -478,6 +481,11 @@ export const Routedata = [
     id: 13,
     path: `${import.meta.env.BASE_URL}discountlist`,
     element: <DiscountStudent />,
+  },
+  {
+    id: 13,
+    path: `${import.meta.env.BASE_URL}discountlist/receipt`,
+    element: <DiscountStudentReceipt />,
   },
   {
     id: 14,

--- a/src/components/common/discountStudent/receipt.tsx
+++ b/src/components/common/discountStudent/receipt.tsx
@@ -1,0 +1,65 @@
+import { useLocation } from "react-router-dom";
+import { useEffect } from "react";
+import { DiscountStudentData } from "../../../types/discountStudent/list";
+
+export default function DiscountStudentReceipt() {
+  const location = useLocation();
+  const data = (location.state as { data?: DiscountStudentData })?.data;
+
+  useEffect(() => {
+    // Print automatically when component mounts
+    setTimeout(() => window.print(), 300);
+  }, []);
+
+  if (!data) {
+    return <div className="p-4">Veri bulunamadı</div>;
+  }
+
+  return (
+    <div className="container p-4">
+      <h2 className="text-center mb-4">İndirimli Öğrenci Makbuzu</h2>
+      <table className="table table-bordered">
+        <tbody>
+          <tr>
+            <th>Sözleşme No</th>
+            <td>{data.sozlesme_no}</td>
+          </tr>
+          <tr>
+            <th>Okul No</th>
+            <td>{data.okul_no}</td>
+          </tr>
+          <tr>
+            <th>Ad Soyad</th>
+            <td>
+              {data.ad} {data.soyad}
+            </td>
+          </tr>
+          <tr>
+            <th>Program</th>
+            <td>{data.program}</td>
+          </tr>
+          <tr>
+            <th>Devre</th>
+            <td>{data.devre}</td>
+          </tr>
+          <tr>
+            <th>Sınıf</th>
+            <td>{data.sinif}</td>
+          </tr>
+          <tr>
+            <th>İndirim Adı</th>
+            <td>{data.indirim_adi}</td>
+          </tr>
+          <tr>
+            <th>Enrol. İndirim</th>
+            <td>{data.enrollment_indirim}</td>
+          </tr>
+          <tr>
+            <th>Toplam</th>
+            <td>₺{data.toplam.toLocaleString()}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/common/discountStudent/table.tsx
+++ b/src/components/common/discountStudent/table.tsx
@@ -60,6 +60,14 @@ export default function DiscountStudentTable() {
                             <i className="ti ti-pencil" />
                         </button>
                         <button
+                            className="btn btn-icon btn-sm btn-warning-light rounded-pill"
+                            onClick={() =>
+                                navigate(`/discountlist/receipt`, { state: { data: row } })
+                            }
+                        >
+                            <i className="ti ti-printer" />
+                        </button>
+                        <button
                             className="btn btn-icon btn-sm btn-danger-light rounded-pill"
                             onClick={() => {
                                 /* delete action */


### PR DESCRIPTION
## Summary
- add a print receipt page for discount students
- include print button in discount student table rows
- register receipt route in routing data

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684a7c74d1f8832cbd4df4c9fa73107f