### PR TITLE
Enhance financial summary filters and layout

### DIFF
--- a/src/components/common/accounting/financialSummary/index.tsx
+++ b/src/components/common/accounting/financialSummary/index.tsx
@@ -1,58 +1,120 @@
-import { Table } from "react-bootstrap";
+import { Table, Card, Row, Col, Form } from "react-bootstrap";
+import { useState } from "react";
 import { useFinancialSummary } from "../../../hooks/accounting/financial_summary/useFinancialSummary";
+import { useSeasonsList } from "../../../hooks/season/useSeasonsList";
+import { formatCurrency } from "../../../../utils/formatters";
 
 const FinancialSummary = () => {
-  const { summary, loading } = useFinancialSummary();
+  const [seasonId, setSeasonId] = useState("");
+  const [date, setDate] = useState("");
+
+  const { seasonsData } = useSeasonsList({ enabled: true, page: 1, paginate: 100 });
+
+  const { summary, loading } = useFinancialSummary({
+    season_id: seasonId ? Number(seasonId) : undefined,
+    date: date || undefined,
+  });
 
   if (loading) return <div>Loading...</div>;
 
+  const liquidTotal =
+    (summary?.liquid_assets.cash || 0) +
+    (summary?.liquid_assets.remaining_receivables || 0) +
+    (summary?.liquid_assets.banks.reduce((a, b) => a + (b.amount || 0), 0) || 0);
+
+  const liabilitiesTotal =
+    (summary?.liabilities.personnel_payables || 0) +
+    (summary?.liabilities.supplier_debts || 0);
+
   return (
     <div className="container mt-3">
-      <h5 className="mb-3">Likid Varlıklar</h5>
-      <Table bordered hover>
-        <thead>
-          <tr>
-            <th>Ad</th>
-            <th>Tutar</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Kasa Nakit</td>
-            <td>{summary?.liquid_assets.cash}</td>
-          </tr>
-          <tr>
-            <td>Kalan Alacaklar</td>
-            <td>{summary?.liquid_assets.remaining_receivables}</td>
-          </tr>
-          {summary?.liquid_assets.banks.map((b, idx) => (
-            <tr key={idx}>
-              <td>{b.bank_name}</td>
-              <td>{b.amount}</td>
-            </tr>
-          ))}
-        </tbody>
-      </Table>
+      <Form className="mb-4">
+        <Row className="g-3 align-items-end">
+          <Col xs={12} md={3}>
+            <Form.Label>Sezon</Form.Label>
+            <Form.Select value={seasonId} onChange={(e) => setSeasonId(e.target.value)}>
+              <option value="">Seçiniz</option>
+              {(seasonsData || []).map((s: any) => (
+                <option key={s.id} value={s.id}>
+                  {s.name}
+                </option>
+              ))}
+            </Form.Select>
+          </Col>
+          <Col xs={12} md={3}>
+            <Form.Label>Tarih</Form.Label>
+            <Form.Control type="date" value={date} onChange={(e) => setDate(e.target.value)} />
+          </Col>
+        </Row>
+      </Form>
 
-      <h5 className="mb-3 mt-4">Borçlar</h5>
-      <Table bordered hover>
-        <thead>
-          <tr>
-            <th>Ad</th>
-            <th>Tutar</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Maaş Ödemeleri</td>
-            <td>{summary?.liabilities.personnel_payables}</td>
-          </tr>
-          <tr>
-            <td>Tedarikçi Borçları</td>
-            <td>{summary?.liabilities.supplier_debts}</td>
-          </tr>
-        </tbody>
-      </Table>
+      <Row className="g-3">
+        <Col xs={12} md={6}>
+          <Card className="custom-card">
+            <Card.Body>
+              <h5 className="mb-3">Likid Varlıklar</h5>
+              <Table bordered hover responsive>
+                <thead>
+                  <tr>
+                    <th>Ad</th>
+                    <th>Tutar</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Kasa Nakit</td>
+                    <td>{formatCurrency(summary?.liquid_assets.cash)}</td>
+                  </tr>
+                  <tr>
+                    <td>Kalan Alacaklar</td>
+                    <td>{formatCurrency(summary?.liquid_assets.remaining_receivables)}</td>
+                  </tr>
+                  {summary?.liquid_assets.banks.map((b, idx) => (
+                    <tr key={idx}>
+                      <td>{b.bank_name}</td>
+                      <td>{formatCurrency(b.amount)}</td>
+                    </tr>
+                  ))}
+                  <tr className="fw-bold">
+                    <td>Toplam</td>
+                    <td>{formatCurrency(liquidTotal)}</td>
+                  </tr>
+                </tbody>
+              </Table>
+            </Card.Body>
+          </Card>
+        </Col>
+
+        <Col xs={12} md={6}>
+          <Card className="custom-card h-100">
+            <Card.Body>
+              <h5 className="mb-3">Borçlar</h5>
+              <Table bordered hover responsive>
+                <thead>
+                  <tr>
+                    <th>Ad</th>
+                    <th>Tutar</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Maaş Ödemeleri</td>
+                    <td>{formatCurrency(summary?.liabilities.personnel_payables)}</td>
+                  </tr>
+                  <tr>
+                    <td>Tedarikçi Borçları</td>
+                    <td>{formatCurrency(summary?.liabilities.supplier_debts)}</td>
+                  </tr>
+                  <tr className="fw-bold">
+                    <td>Toplam</td>
+                    <td>{formatCurrency(liabilitiesTotal)}</td>
+                  </tr>
+                </tbody>
+              </Table>
+            </Card.Body>
+          </Card>
+        </Col>
+      </Row>
     </div>
   );
 };

--- a/src/components/hooks/accounting/financial_summary/useFinancialSummary.tsx
+++ b/src/components/hooks/accounting/financial_summary/useFinancialSummary.tsx
@@ -6,15 +6,25 @@ import { fetchFinancialSummary } from "../../../../slices/accounting/financial_s
 import FinancialSummaryStatus from "../../../../enums/accounting/financial_summary/status";
 import { FinancialSummaryData } from "../../../../types/accounting/financial_summary";
 
-export function useFinancialSummary() {
+interface UseFinancialSummaryArgs {
+  season_id?: number;
+  date?: string;
+}
+
+export function useFinancialSummary(args?: UseFinancialSummaryArgs) {
   const dispatch = useDispatch<AppDispatch>();
   const { data, status, error } = useSelector(
     (state: RootState) => state.financialSummary
   );
 
   useEffect(() => {
-    dispatch(fetchFinancialSummary());
-  }, [dispatch]);
+    dispatch(
+      fetchFinancialSummary({
+        season_id: args?.season_id,
+        date: args?.date,
+      })
+    );
+  }, [dispatch, args?.season_id, args?.date]);
 
   const loading = status === FinancialSummaryStatus.LOADING;
   const summary: FinancialSummaryData | null = data;

--- a/src/slices/accounting/financial_summary/thunk.tsx
+++ b/src/slices/accounting/financial_summary/thunk.tsx
@@ -3,14 +3,26 @@ import axiosInstance from "../../../services/axiosClient";
 import { FINANCIAL_SUMMARY } from "../../../helpers/url_helper";
 import { FinancialSummaryData } from "../../../types/accounting/financial_summary";
 
+interface FinancialSummaryArgs {
+  season_id?: number;
+  date?: string;
+}
+
 export const fetchFinancialSummary = createAsyncThunk<
   FinancialSummaryData,
-  void
->("financialSummary/fetch", async (_, { rejectWithValue }) => {
+  FinancialSummaryArgs | undefined
+>("financialSummary/fetch", async (args, { rejectWithValue }) => {
   try {
-    const resp = await axiosInstance.get(FINANCIAL_SUMMARY);
+    const params = new URLSearchParams();
+    if (args?.season_id) params.append("season_id", String(args.season_id));
+    if (args?.date) params.append("date", args.date);
+    const queryString = params.toString();
+    const url = queryString ? `${FINANCIAL_SUMMARY}?${queryString}` : FINANCIAL_SUMMARY;
+    const resp = await axiosInstance.get(url);
     return resp.data as FinancialSummaryData;
   } catch (err: any) {
-    return rejectWithValue(err.response?.data?.message || "Fetch financial summary failed");
+    return rejectWithValue(
+      err.response?.data?.message || "Fetch financial summary failed"
+    );
   }
 });


### PR DESCRIPTION
## Summary
- add query params to financial summary thunk
- allow useFinancialSummary to accept season and date filters
- redesign financial summary page
  - add season and date filters
  - display totals with currency format
  - use cards and responsive layout

## Testing
- `npm run build` *(fails: cannot find module typings)*

------
https://chatgpt.com/codex/tasks/task_e_684a7fd97178832c8af8cf013611dec1