### PR TITLE
Fix season select to fetch lazily

### DIFF
--- a/src/components/common/accounting/financialSummary/index.tsx
+++ b/src/components/common/accounting/financialSummary/index.tsx
@@ -18,8 +18,10 @@ const FinancialSummary = () => {
   const [seasonId, setSeasonId] = useState("");
   const [date, setDate] = useState("");
 
+  const [seasonsEnabled, setSeasonsEnabled] = useState(false);
+
   const { seasonsData = [] } = useSeasonsList({
-    enabled: true,
+    enabled: seasonsEnabled,
     page: 1,
     paginate: 100,
   });
@@ -98,7 +100,11 @@ const FinancialSummary = () => {
             <Col md={6}>
               <Form.Group>
                 <Form.Label>Sezon</Form.Label>
-                <Form.Select value={seasonId} onChange={e => setSeasonId(e.target.value)}>
+                <Form.Select
+                  value={seasonId}
+                  onChange={e => setSeasonId(e.target.value)}
+                  onFocus={() => !seasonsEnabled && setSeasonsEnabled(true)}
+                >
                   <option value="">Seçiniz</option>
                   {seasonsData.map(s => (
                     <option key={s.id} value={s.id}>{s.name}</option>


### PR DESCRIPTION
## Summary
- fetch season list only after interacting with the select

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_684a8720f3a4832cb0bb701bb8ef372c