### PR TITLE
Add detail icon and update form button

### DIFF
--- a/src/components/common/creditcard/crud.tsx
+++ b/src/components/common/creditcard/crud.tsx
@@ -138,7 +138,7 @@ const CreditCardModal: React.FC<CreditCardModalProps> = ({ show, onClose, onRefr
       fields={getFields()}
       initialValues={initialValues}
       onSubmit={handleSubmit}
-      confirmButtonLabel={mode === "add" ? "Ekle" : "Güncelle"}
+      confirmButtonLabel="Güncelle"
       cancelButtonLabel="Vazgeç"
       isLoading={loading}
       error={error || undefined}

--- a/src/components/common/creditcard/table.tsx
+++ b/src/components/common/creditcard/table.tsx
@@ -47,12 +47,18 @@ export default function CreditCardTable() {
           <>
             <button
               onClick={() => navigate(`/creditcardcrud/${row.id}`)}
-              className="btn btn-icon btn-sm btn-info-light rounded-pill"
+              className="btn btn-icon btn-sm btn-primary-light rounded-pill me-1"
+            >
+              <i className="ti ti-eye" />
+            </button>
+            <button
+              onClick={() => navigate(`/creditcardcrud/${row.id}`)}
+              className="btn btn-icon btn-sm btn-info-light rounded-pill me-1"
             >
               <i className="ti ti-pencil" />
             </button>
             <button
-              className="btn btn-icon btn-sm btn-danger-light rounded-pill ms-1"
+              className="btn btn-icon btn-sm btn-danger-light rounded-pill"
               onClick={() => openDeleteModal && openDeleteModal(row)}
             >
               <i className="ti ti-trash" />


### PR DESCRIPTION
## Summary
- add a detail (eye) button to the credit card table actions
- always show "Güncelle" on the credit card modal confirm button

## Testing
- `npm run build` *(fails: cannot find module 'vite' and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ab6bd2740832ca1f60f1aaef2c94e