### PR TITLE
Add credit card detail page

### DIFF
--- a/src/components/common/creditcard/detail.tsx
+++ b/src/components/common/creditcard/detail.tsx
@@ -1,0 +1,60 @@
+import { useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Modal, Table } from "react-bootstrap";
+import { useCreditCardShow } from "../../hooks/creditCard/useCreditCardShow";
+
+export default function CreditCardDetail() {
+  const { id } = useParams<{ id?: string }>();
+  const navigate = useNavigate();
+  const { creditCard, getCreditCard } = useCreditCardShow();
+
+  useEffect(() => {
+    if (id) {
+      getCreditCard(Number(id));
+    }
+  }, [id, getCreditCard]);
+
+  return (
+    <Modal show={true} onHide={() => navigate(-1)} centered>
+      <Modal.Header closeButton>
+        <Modal.Title>Kredi Kartı Detayı</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {creditCard ? (
+          <Table bordered>
+            <tbody>
+              <tr>
+                <th>Şube ID</th>
+                <td>{creditCard.branch_id}</td>
+              </tr>
+              <tr>
+                <th>Kart Sahibi</th>
+                <td>{creditCard.card_holder_name}</td>
+              </tr>
+              <tr>
+                <th>Kart Adı</th>
+                <td>{creditCard.description}</td>
+              </tr>
+              <tr>
+                <th>Kart No</th>
+                <td>{creditCard.card_number}</td>
+              </tr>
+              <tr>
+                <th>Son Kullanma</th>
+                <td>
+                  {creditCard.expire_month}/{creditCard.expire_year}
+                </td>
+              </tr>
+              <tr>
+                <th>Tutar</th>
+                <td>{creditCard.amount}</td>
+              </tr>
+            </tbody>
+          </Table>
+        ) : (
+          <div>Yükleniyor...</div>
+        )}
+      </Modal.Body>
+    </Modal>
+  );
+}

--- a/src/components/common/creditcard/table.tsx
+++ b/src/components/common/creditcard/table.tsx
@@ -47,8 +47,14 @@ export default function CreditCardTable() {
         render: (row, openDeleteModal) => (
           <>
             <button
+              onClick={() => navigate(`/creditcarddetail/${row.id}`)}
+              className="btn btn-icon btn-sm btn-primary-light rounded-pill"
+            >
+              <i className="ti ti-eye" />
+            </button>
+            <button
               onClick={() => navigate(`/creditcardcrud/${row.id}`)}
-              className="btn btn-icon btn-sm btn-info-light rounded-pill"
+              className="btn btn-icon btn-sm btn-info-light rounded-pill ms-1"
             >
               <i className="ti ti-pencil" />
             </button>

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -128,6 +128,9 @@ const CreditCardTable = lazy(
 const CreditCardCrud = lazy(
   () => import("../components/common/creditcard/crud")
 );
+const CreditCardDetail = lazy(
+  () => import("../components/common/creditcard/detail")
+);
 const SupplierList = lazy(() => import("../components/common/supplier/index"));
 const SupplierCrud = lazy(() => import("../components/common/supplier/crud"));
 const SupplierDetail = lazy(
@@ -631,6 +634,11 @@ export const Routedata = [
         }}
       />
     ),
+  },
+  {
+    id: 18,
+    path: `${import.meta.env.BASE_URL}creditcarddetail/:id?`,
+    element: <CreditCardDetail />,
   },
   {
     id: 2,


### PR DESCRIPTION
## Summary
- add a detail modal component for credit cards
- include route to creditcarddetail
- show an eye button in credit card table that links to detail view

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_684ab9766988832c93962165c4d8662d