### PR TITLE
Fix rent CRUD modal routing

### DIFF
--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -419,6 +419,7 @@ const DailyModule = lazy(() => import("../components/common/daily"));
 
 const RentDetailPage = lazy(() => import("../components/common/rent/RentDetail"));
 const RentDetailTable = lazy(() => import("../components/common/rent/table"));
+const RentCrud = lazy(() => import("../components/common/rent/crud"));
 const EstimatedBudgetTable = lazy(() => import("../components/common/estimatedBudget/table"));
 //assignmentStudents
 
@@ -1778,8 +1779,9 @@ export const Routedata = [
     element: <RentDetailTable />,
   },
   {
-    id: 2001,
-    path: "rentcrud/:id?",
+    id: 2002,
+    path: `${import.meta.env.BASE_URL}rentcrud/:id?`,
+    element: <RentCrud />,
   },
 
   {


### PR DESCRIPTION
## Summary
- include RentCrud component in routing data
- register the rentcrud route so add/edit modals show correctly

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails to compile due to missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684affeee5e0832c84caa341f4dcbfd5