### PR TITLE
Add modular tables for credit card details

### DIFF
--- a/src/components/common/creditcard/crud.tsx
+++ b/src/components/common/creditcard/crud.tsx
@@ -1,8 +1,7 @@
 import { FormikHelpers, FormikValues } from "formik";
 import { useEffect, useState, useMemo } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
-import { Modal, Row, Col, Card, Button } from "react-bootstrap";
-import ReusableTable, { ColumnDefinition } from "../ReusableTable";
+import { Modal } from "react-bootstrap";
 import ReusableModalForm, { FieldDefinition } from "../ReusableModalForm";
 import { useCreditCardAdd } from "../../hooks/creditCard/useCreditCardAdd";
 import { useCreditCardUpdate } from "../../hooks/creditCard/useCreditCardUpdate";
@@ -10,6 +9,7 @@ import { useCreditCardShow } from "../../hooks/creditCard/useCreditCardShow";
 import { useBranchTable } from "../../hooks/branch/useBranchList";
 import { CreditCardAddPayload } from "../../../types/creditCard/add";
 import { CreditCardUpdatePayload } from "../../../types/creditCard/update";
+import CreditCardDetailTables from "./service_management";
 
 interface CreditCardModalProps {
   show: boolean;
@@ -146,139 +146,14 @@ const CreditCardModal: React.FC<CreditCardModalProps> = ({ show, onClose, onRefr
     }
     navigate(-1);
   }
-  const [debts, setDebts] = useState<any[]>([
-      {
-        id: 1,
-        borc_tutari: 1000,
-        askeri_borc: 200,
-        due_date: "2025-06-01",
-        odenen: 300,
-        kalan: 700,
-        kullanici: "Admin",
-      },
-    ]);
-  const [payments, setPayments] = useState<Record<number, any[]>>({
-      1: [
-        {
-          id: 1,
-          tip: "Kısmi Ödeme",
-          tutar: 300,
-          turu: "Nakit",
-          banka: "-",
-          tarih: "2024-01-01",
-          kullanici: "Admin",
-        },
-      ],
-    });
-  const [selectedDebtId, setSelectedDebtId] = useState<number | null>(null);
-
   if (mode === "detail") {
-    const selectedPayments =
-      (selectedDebtId && payments[selectedDebtId]) || [];
-
-    const debtColumns: ColumnDefinition<any>[] = [
-      { key: "borc_tutari", label: "Borç Tutarı" },
-      { key: "askeri_borc", label: "Askeri Borç Tutarı" },
-      { key: "due_date", label: "Son Ödeme Tarihi" },
-      { key: "odenen", label: "Ödenen Tutar" },
-      { key: "kalan", label: "Kalan Tutar" },
-      { key: "kullanici", label: "Kullanıcı" },
-      {
-        key: "actions",
-        label: "İşlemler",
-        render: (row) => (
-          <>
-            <button
-              className="btn btn-icon btn-sm btn-primary-light rounded-pill"
-              onClick={() => setSelectedDebtId(row.id)}
-            >
-              <i className="ti ti-check" />
-            </button>
-            <button
-              className="btn btn-icon btn-sm btn-info-light rounded-pill ms-1"
-              onClick={() => alert("edit")}
-            >
-              <i className="ti ti-pencil" />
-            </button>
-            <button
-              className="btn btn-icon btn-sm btn-danger-light rounded-pill ms-1"
-              onClick={() =>
-                setDebts((d) => d.filter((item) => item.id !== row.id))
-              }
-            >
-              <i className="ti ti-trash" />
-            </button>
-          </>
-        ),
-      },
-    ];
-
-    const paymentColumns: ColumnDefinition<any>[] = [
-      { key: "tip", label: "Ödeme Tipi" },
-      { key: "tutar", label: "Ödenen Tutar" },
-      { key: "turu", label: "Ödeme Türü" },
-      { key: "banka", label: "Banka Hesabı" },
-      { key: "tarih", label: "Tarih" },
-      { key: "kullanici", label: "Kullanıcı" },
-      {
-        key: "actions",
-        label: "İşlemler",
-        render: () => (
-          <button
-            className="btn btn-icon btn-sm btn-info-light rounded-pill"
-            onClick={() => alert("edit")}
-          >
-            <i className="ti ti-pencil" />
-          </button>
-        ),
-      },
-    ];
-
     return (
       <Modal show={show} onHide={() => navigate(-1)} centered size="lg">
         <Modal.Header closeButton>
           <Modal.Title>Kredi Kartı Detayı</Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <Row>
-            <Col md={6}>
-              <Card>
-                <Card.Header className="d-flex justify-content-between align-items-center">
-                  <Card.Title className="mb-0">Kredi Kartı Borçları</Card.Title>
-                  <Button size="sm" onClick={() => alert("add")}>Ekle</Button>
-                </Card.Header>
-                <Card.Body>
-                  <ReusableTable
-                    tableMode="single"
-                    showExportButtons={false}
-                    data={debts}
-                    columns={debtColumns}
-                  />
-                </Card.Body>
-              </Card>
-            </Col>
-            <Col md={6}>
-              <Card>
-                <Card.Header className="d-flex justify-content-between align-items-center">
-                  <Card.Title className="mb-0">Ödemeler</Card.Title>
-                  <Button size="sm" onClick={() => alert("add")}>Ekle</Button>
-                </Card.Header>
-                <Card.Body>
-                  <ReusableTable
-                    tableMode="single"
-                    showExportButtons={false}
-                    data={selectedPayments}
-                    columns={paymentColumns}
-                    customFooter={
-                      selectedDebtId === null && (
-                        <div className="text-center p-2">Borç seçiniz</div>
-                      )
-                    }
-                  />
-                </Card.Body>
-              </Card>
-            </Col>
-          </Row>
+          <CreditCardDetailTables />
         </Modal.Body>
       </Modal>
     );

--- a/src/components/common/creditcard/service_management/debt/table.tsx
+++ b/src/components/common/creditcard/service_management/debt/table.tsx
@@ -1,0 +1,69 @@
+import ReusableTable, { ColumnDefinition } from "../../ReusableTable";
+
+export interface Debt {
+  id: number;
+  borc_tutari: number;
+  askeri_borc: number;
+  due_date: string;
+  odenen: number;
+  kalan: number;
+  kullanici: string;
+}
+
+interface DebtTableProps {
+  debts: Debt[];
+  onSelectDebt: (debt: Debt) => void;
+  onEditDebt?: (debt: Debt) => void;
+  onDeleteDebt?: (id: number) => void;
+}
+
+export default function DebtTable({
+  debts,
+  onSelectDebt,
+  onEditDebt,
+  onDeleteDebt,
+}: DebtTableProps) {
+  const columns: ColumnDefinition<Debt>[] = [
+    { key: "borc_tutari", label: "Borç Tutarı" },
+    { key: "askeri_borc", label: "Askeri Borç Tutarı" },
+    { key: "due_date", label: "Son Ödeme Tarihi" },
+    { key: "odenen", label: "Ödenen Tutar" },
+    { key: "kalan", label: "Kalan Tutar" },
+    { key: "kullanici", label: "Kullanıcı" },
+    {
+      key: "actions",
+      label: "İşlemler",
+      render: (row) => (
+        <>
+          <button
+            className="btn btn-icon btn-sm btn-primary-light rounded-pill"
+            onClick={() => onSelectDebt(row)}
+          >
+            <i className="ti ti-check" />
+          </button>
+          <button
+            className="btn btn-icon btn-sm btn-info-light rounded-pill ms-1"
+            onClick={() => onEditDebt && onEditDebt(row)}
+          >
+            <i className="ti ti-pencil" />
+          </button>
+          <button
+            className="btn btn-icon btn-sm btn-danger-light rounded-pill ms-1"
+            onClick={() => onDeleteDebt && onDeleteDebt(row.id)}
+          >
+            <i className="ti ti-trash" />
+          </button>
+        </>
+      ),
+    },
+  ];
+
+  return (
+    <ReusableTable<Debt>
+      tableMode="single"
+      showExportButtons={false}
+      data={debts}
+      columns={columns}
+    />
+  );
+}

--- a/src/components/common/creditcard/service_management/index.tsx
+++ b/src/components/common/creditcard/service_management/index.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { Row, Col, Card, Button } from "react-bootstrap";
+import DebtTable, { Debt } from "./debt/table";
+import PaymentTable, { Payment } from "./payment/table";
+
+export default function CreditCardDetailTables() {
+  const [debts, setDebts] = useState<Debt[]>([
+    {
+      id: 1,
+      borc_tutari: 1000,
+      askeri_borc: 200,
+      due_date: "2025-06-01",
+      odenen: 300,
+      kalan: 700,
+      kullanici: "Admin",
+    },
+  ]);
+
+  const [payments, setPayments] = useState<Record<number, Payment[]>>({
+    1: [
+      {
+        id: 1,
+        tip: "Kısmi Ödeme",
+        tutar: 300,
+        turu: "Nakit",
+        banka: "-",
+        tarih: "2024-01-01",
+        kullanici: "Admin",
+      },
+    ],
+  });
+
+  const [selectedDebtId, setSelectedDebtId] = useState<number | null>(null);
+
+  const selectedPayments =
+    (selectedDebtId && payments[selectedDebtId]) || [];
+
+  return (
+    <Row>
+      <Col md={6}>
+        <Card>
+          <Card.Header className="d-flex justify-content-between align-items-center">
+            <Card.Title className="mb-0">Kredi Kartı Borçları</Card.Title>
+            <Button size="sm" onClick={() => alert("add")}>Ekle</Button>
+          </Card.Header>
+          <Card.Body>
+            <DebtTable
+              debts={debts}
+              onSelectDebt={(d) => setSelectedDebtId(d.id)}
+              onEditDebt={() => alert("edit")}
+              onDeleteDebt={(id) =>
+                setDebts((ds) => ds.filter((item) => item.id !== id))
+              }
+            />
+          </Card.Body>
+        </Card>
+      </Col>
+      <Col md={6}>
+        <Card>
+          <Card.Header className="d-flex justify-content-between align-items-center">
+            <Card.Title className="mb-0">Ödemeler</Card.Title>
+            <Button size="sm" onClick={() => alert("add")}>Ekle</Button>
+          </Card.Header>
+          <Card.Body>
+            <PaymentTable
+              payments={selectedPayments}
+              onEditPayment={() => alert("edit")}
+              onDeletePayment={() => alert("delete")}
+              customFooter={
+                selectedDebtId === null && (
+                  <div className="text-center p-2">Borç seçiniz</div>
+                )
+              }
+            />
+          </Card.Body>
+        </Card>
+      </Col>
+    </Row>
+  );
+}

--- a/src/components/common/creditcard/service_management/payment/table.tsx
+++ b/src/components/common/creditcard/service_management/payment/table.tsx
@@ -1,0 +1,64 @@
+import ReusableTable, { ColumnDefinition } from "../../ReusableTable";
+
+export interface Payment {
+  id: number;
+  tip: string;
+  tutar: number;
+  turu: string;
+  banka: string;
+  tarih: string;
+  kullanici: string;
+}
+
+interface PaymentTableProps {
+  payments: Payment[];
+  onEditPayment?: (payment: Payment) => void;
+  onDeletePayment?: (id: number) => void;
+  customFooter?: React.ReactNode;
+}
+
+export default function PaymentTable({
+  payments,
+  onEditPayment,
+  onDeletePayment,
+  customFooter,
+}: PaymentTableProps) {
+  const columns: ColumnDefinition<Payment>[] = [
+    { key: "tip", label: "Ödeme Tipi" },
+    { key: "tutar", label: "Ödenen Tutar" },
+    { key: "turu", label: "Ödeme Türü" },
+    { key: "banka", label: "Banka Hesabı" },
+    { key: "tarih", label: "Tarih" },
+    { key: "kullanici", label: "Kullanıcı" },
+    {
+      key: "actions",
+      label: "İşlemler",
+      render: (row) => (
+        <>
+          <button
+            className="btn btn-icon btn-sm btn-info-light rounded-pill"
+            onClick={() => onEditPayment && onEditPayment(row)}
+          >
+            <i className="ti ti-pencil" />
+          </button>
+          <button
+            className="btn btn-icon btn-sm btn-danger-light rounded-pill ms-1"
+            onClick={() => onDeletePayment && onDeletePayment(row.id)}
+          >
+            <i className="ti ti-trash" />
+          </button>
+        </>
+      ),
+    },
+  ];
+
+  return (
+    <ReusableTable<Payment>
+      tableMode="single"
+      showExportButtons={false}
+      data={payments}
+      columns={columns}
+      customFooter={customFooter}
+    />
+  );
+}

--- a/src/components/common/creditcard/table.tsx
+++ b/src/components/common/creditcard/table.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
-import { Modal, Table as BTable, Button } from "react-bootstrap";
+
 import ReusableTable, { ColumnDefinition } from "../ReusableTable";
 import { useCreditCardTable } from "../../hooks/creditCard/useCreditCardList";
 import { useCreditCardDelete } from "../../hooks/creditCard/useCreditCardDelete";
@@ -10,7 +10,6 @@ import Pageheader from "../../page-header/pageheader";
 export default function CreditCardTable() {
   const navigate = useNavigate();
   const { removeCreditCard } = useCreditCardDelete();
-  const [detailRow, setDetailRow] = useState<CreditCardRow | null>(null);
 
   interface CreditCardRow extends ICreditCard {
     branch_name?: string;
@@ -49,7 +48,9 @@ export default function CreditCardTable() {
         render: (row, openDeleteModal) => (
           <>
             <button
-              onClick={() => setDetailRow(row)}
+              onClick={() =>
+                navigate(`/creditcardcrud/${row.id}`, { state: { mode: "detail" } })
+              }
               className="btn btn-icon btn-sm btn-primary-light rounded-pill"
             >
               <i className="ti ti-eye" />
@@ -97,45 +98,6 @@ export default function CreditCardTable() {
         exportFileName="creditcards"
         onDeleteRow={(row) => removeCreditCard(Number(row.id))}
       />
-
-      {detailRow && (
-        <Modal show={true} onHide={() => setDetailRow(null)} centered>
-          <Modal.Header closeButton>
-            <Modal.Title>Kredi Kartı Detayı</Modal.Title>
-          </Modal.Header>
-          <Modal.Body>
-            <BTable bordered size="sm">
-              <thead>
-                <tr>
-                  <th>Şube</th>
-                  <th>Kart Sahibi</th>
-                  <th>Kart Adı</th>
-                  <th>Kart No</th>
-                  <th>Son Kullanma</th>
-                  <th>Tutar</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>{(detailRow as any).branch_name || detailRow.branch_id}</td>
-                  <td>{detailRow.card_holder_name}</td>
-                  <td>{detailRow.description || '-'}</td>
-                  <td>{detailRow.card_number}</td>
-                  <td>
-                    {detailRow.expire_month}/{detailRow.expire_year}
-                  </td>
-                  <td>{detailRow.amount}</td>
-                </tr>
-              </tbody>
-            </BTable>
-          </Modal.Body>
-          <Modal.Footer>
-            <Button variant="secondary" onClick={() => setDetailRow(null)}>
-              Kapat
-            </Button>
-          </Modal.Footer>
-        </Modal>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- extract credit card detail view into separate debt and payment tables
- create `service_management` folder with `index`, `debt`, and `payment` components
- open detail view via `creditcardcrud` modal

## Testing
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_684be155dfa8832c9c8f291059c58294