### PR TITLE
Add credit card management modals

### DIFF
--- a/src/components/common/creditcard/service_management/debt/crud.tsx
+++ b/src/components/common/creditcard/service_management/debt/crud.tsx
@@ -1,0 +1,92 @@
+import { FormikHelpers, FormikValues } from "formik";
+import ReusableModalForm, { FieldDefinition } from "../../ReusableModalForm";
+
+export interface DebtFormValues extends FormikValues {
+  borc_tutari?: number;
+  askeri_borc?: number;
+  due_date?: string;
+  tip?: string;
+  tutar?: number;
+  turu?: string;
+  banka?: string;
+  tarih?: string;
+}
+
+interface Props {
+  show: boolean;
+  mode: "add" | "edit";
+  initialValues: DebtFormValues;
+  bankOptions: { label: string; value: string }[];
+  onSubmit: (
+    values: DebtFormValues,
+    helpers: FormikHelpers<DebtFormValues>
+  ) => void;
+  onClose: () => void;
+}
+
+export default function DebtCrud({
+  show,
+  mode,
+  initialValues,
+  bankOptions,
+  onSubmit,
+  onClose,
+}: Props) {
+  const addFields: FieldDefinition[] = [
+    { name: "borc_tutari", label: "Borç Tutarı", type: "currency", required: true },
+    { name: "askeri_borc", label: "Askeri Borç Tutarı", type: "currency", required: true },
+    { name: "due_date", label: "Son Ödeme Tarihi", type: "date", required: true },
+  ];
+
+  const getEditFields = (values: DebtFormValues): FieldDefinition[] => [
+    {
+      name: "tip",
+      label: "Ödeme Tipi",
+      type: "select",
+      required: true,
+      options: [
+        { value: "askeri", label: "Askeri Borç" },
+        { value: "kismi", label: "Kısmi Ödeme" },
+        { value: "tamam", label: "Tamamını" },
+      ],
+    },
+    { name: "tutar", label: "Ödenen Tutar", type: "currency", required: true },
+    {
+      name: "turu",
+      label: "Ödeme Türü",
+      type: "select",
+      required: true,
+      options: [
+        { value: "nakit", label: "Nakit" },
+        { value: "banka", label: "Banka Hesabı" },
+      ],
+    },
+    ...(values.turu === "banka"
+      ? [
+          {
+            name: "banka",
+            label: "Banka Hesabı",
+            type: "select",
+            required: true,
+            options: bankOptions,
+          },
+        ]
+      : []),
+    { name: "tarih", label: "Tarih", type: "date", required: true },
+  ];
+
+  const fields = mode === "add" ? addFields : getEditFields(initialValues);
+
+  return (
+    <ReusableModalForm<DebtFormValues>
+      show={show}
+      title={mode === "add" ? "Borç Ekle" : "Borç Düzenle"}
+      fields={fields}
+      initialValues={initialValues}
+      onSubmit={onSubmit}
+      confirmButtonLabel={mode === "add" ? "Ekle" : "Güncelle"}
+      cancelButtonLabel="Vazgeç"
+      onClose={onClose}
+    />
+  );
+}

--- a/src/components/common/creditcard/service_management/index.tsx
+++ b/src/components/common/creditcard/service_management/index.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { Row, Col, Card, Button } from "react-bootstrap";
 import DebtTable, { Debt } from "./debt/table";
 import PaymentTable, { Payment } from "./payment/table";
+import DebtCrud, { DebtFormValues } from "./debt/crud";
+import PaymentCrud, { PaymentFormValues } from "./payment/crud";
 
 export default function CreditCardDetailTables() {
   const [debts, setDebts] = useState<Debt[]>([
@@ -32,22 +34,115 @@ export default function CreditCardDetailTables() {
 
   const [selectedDebtId, setSelectedDebtId] = useState<number | null>(null);
 
+  const [showDebtModal, setShowDebtModal] = useState<{
+    mode: "add" | "edit";
+    data?: Debt;
+  } | null>(null);
+
+  const [showPaymentModal, setShowPaymentModal] = useState<{
+    mode: "add" | "edit";
+    data?: Payment;
+  } | null>(null);
+
+  const bankOptions = [
+    { value: "1", label: "Banka 1" },
+    { value: "2", label: "Banka 2" },
+  ];
+
   const selectedPayments =
     (selectedDebtId && payments[selectedDebtId]) || [];
 
+  const handleAddDebt = (values: DebtFormValues) => {
+    const newDebt: Debt = {
+      id: debts.length + 1,
+      borc_tutari: Number(values.borc_tutari) || 0,
+      askeri_borc: Number(values.askeri_borc) || 0,
+      due_date: values.due_date || "",
+      odenen: 0,
+      kalan: Number(values.borc_tutari) || 0,
+      kullanici: "Admin",
+    };
+    setDebts((d) => [...d, newDebt]);
+    setShowDebtModal(null);
+  };
+
+  const handleEditDebt = (values: DebtFormValues) => {
+    if (!showDebtModal?.data) return;
+    setDebts((ds) =>
+      ds.map((d) =>
+        d.id === showDebtModal.data!.id
+          ? {
+              ...d,
+              odenen: Number(values.tutar),
+              kalan: d.borc_tutari - Number(values.tutar),
+            }
+          : d
+      )
+    );
+    setShowDebtModal(null);
+  };
+
+  const handleAddPayment = (values: PaymentFormValues) => {
+    if (!selectedDebtId) return;
+    const newPayment: Payment = {
+      id: (payments[selectedDebtId]?.length || 0) + 1,
+      tip: values.tip,
+      tutar: Number(values.tutar),
+      turu: values.turu,
+      banka: values.banka || "-",
+      tarih: values.tarih,
+      kullanici: "Admin",
+    };
+    setPayments((p) => ({
+      ...p,
+      [selectedDebtId]: [...(p[selectedDebtId] || []), newPayment],
+    }));
+    setShowPaymentModal(null);
+  };
+
+  const handleEditPayment = (values: PaymentFormValues) => {
+    if (!selectedDebtId || !showPaymentModal?.data) return;
+    setPayments((p) => ({
+      ...p,
+      [selectedDebtId]: (p[selectedDebtId] || []).map((pm) =>
+        pm.id === showPaymentModal.data!.id
+          ? {
+              ...pm,
+              tip: values.tip,
+              tutar: Number(values.tutar),
+              turu: values.turu,
+              banka: values.banka || "-",
+              tarih: values.tarih,
+            }
+          : pm
+      ),
+    }));
+    setShowPaymentModal(null);
+  };
+
   return (
+    <>
     <Row>
       <Col md={6}>
         <Card>
           <Card.Header className="d-flex justify-content-between align-items-center">
             <Card.Title className="mb-0">Kredi Kartı Borçları</Card.Title>
-            <Button size="sm" onClick={() => alert("add")}>Ekle</Button>
+            <Button
+              size="sm"
+              onClick={() =>
+                setShowDebtModal({ mode: "add" })
+              }
+            >
+              Ekle
+            </Button>
           </Card.Header>
           <Card.Body>
             <DebtTable
               debts={debts}
               onSelectDebt={(d) => setSelectedDebtId(d.id)}
-              onEditDebt={() => alert("edit")}
+              onEditDebt={(d) =>
+                setShowDebtModal({ mode: "edit", data: d })
+              }
               onDeleteDebt={(id) =>
                 setDebts((ds) => ds.filter((item) => item.id !== id))
               }
@@ -59,13 +154,28 @@ export default function CreditCardDetailTables() {
         <Card>
           <Card.Header className="d-flex justify-content-between align-items-center">
             <Card.Title className="mb-0">Ödemeler</Card.Title>
-            <Button size="sm" onClick={() => alert("add")}>Ekle</Button>
+            <Button
+              size="sm"
+              onClick={() => setShowPaymentModal({ mode: "add" })}
+            >
+              Ekle
+            </Button>
           </Card.Header>
           <Card.Body>
             <PaymentTable
               payments={selectedPayments}
-              onEditPayment={() => alert("edit")}
-              onDeletePayment={() => alert("delete")}
+              onEditPayment={(p) =>
+                setShowPaymentModal({ mode: "edit", data: p })
+              }
+              onDeletePayment={(id) =>
+                selectedDebtId &&
+                setPayments((ps) => ({
+                  ...ps,
+                  [selectedDebtId]: (ps[selectedDebtId] || []).filter(
+                    (pm) => pm.id !== id
+                  ),
+                }))
+              }
               customFooter={
                 selectedDebtId === null && (
                   <div className="text-center p-2">Borç seçiniz</div>
@@ -76,5 +186,60 @@ export default function CreditCardDetailTables() {
         </Card>
       </Col>
     </Row>
+      {showDebtModal && (
+        <DebtCrud
+          show={true}
+          mode={showDebtModal.mode}
+          initialValues={
+            showDebtModal.mode === "add"
+              ? { borc_tutari: 0, askeri_borc: 0, due_date: "" }
+              : {
+                  tip: "kismi",
+                  tutar: showDebtModal.data?.odenen || 0,
+                  turu: "nakit",
+                  tarih: new Date().toISOString().split("T")[0],
+                }
+          }
+          bankOptions={bankOptions}
+          onSubmit={(vals, helpers) => {
+            if (showDebtModal.mode === "add") {
+              handleAddDebt(vals);
+            } else {
+              handleEditDebt(vals);
+            }
+            helpers.setSubmitting(false);
+          }}
+          onClose={() => setShowDebtModal(null)}
+        />
+      )}
+      {showPaymentModal && (
+        <PaymentCrud
+          show={true}
+          mode={showPaymentModal.mode}
+          initialValues={
+            showPaymentModal.mode === "add"
+              ? {
+                  tip: "kismi",
+                  tutar: 0,
+                  turu: "nakit",
+                  tarih: new Date().toISOString().split("T")[0],
+                }
+              : {
+                  ...showPaymentModal.data!,
+                }
+          }
+          bankOptions={bankOptions}
+          onSubmit={(vals, helpers) => {
+            if (showPaymentModal.mode === "add") {
+              handleAddPayment(vals);
+            } else {
+              handleEditPayment(vals);
+            }
+            helpers.setSubmitting(false);
+          }}
+          onClose={() => setShowPaymentModal(null)}
+        />
+      )}
+    </>
   );
 }

--- a/src/components/common/creditcard/service_management/payment/crud.tsx
+++ b/src/components/common/creditcard/service_management/payment/crud.tsx
@@ -1,0 +1,81 @@
+import { FormikHelpers, FormikValues } from "formik";
+import ReusableModalForm, { FieldDefinition } from "../../ReusableModalForm";
+
+export interface PaymentFormValues extends FormikValues {
+  tip: string;
+  tutar: number;
+  turu: string;
+  banka?: string;
+  tarih: string;
+}
+
+interface Props {
+  show: boolean;
+  mode: "add" | "edit";
+  initialValues: PaymentFormValues;
+  bankOptions: { label: string; value: string }[];
+  onSubmit: (
+    values: PaymentFormValues,
+    helpers: FormikHelpers<PaymentFormValues>
+  ) => void;
+  onClose: () => void;
+}
+
+export default function PaymentCrud({
+  show,
+  mode,
+  initialValues,
+  bankOptions,
+  onSubmit,
+  onClose,
+}: Props) {
+  const getFields = (values: PaymentFormValues): FieldDefinition[] => [
+    {
+      name: "tip",
+      label: "Ödeme Tipi",
+      type: "select",
+      required: true,
+      options: [
+        { value: "askeri", label: "Askeri Borç" },
+        { value: "kismi", label: "Kısmi Ödeme" },
+        { value: "tamam", label: "Tamamını" },
+      ],
+    },
+    { name: "tutar", label: "Ödenen Tutar", type: "currency", required: true },
+    {
+      name: "turu",
+      label: "Ödeme Türü",
+      type: "select",
+      required: true,
+      options: [
+        { value: "nakit", label: "Nakit" },
+        { value: "banka", label: "Banka Hesabı" },
+      ],
+    },
+    ...(values.turu === "banka"
+      ? [
+          {
+            name: "banka",
+            label: "Banka Hesabı",
+            type: "select",
+            required: true,
+            options: bankOptions,
+          },
+        ]
+      : []),
+    { name: "tarih", label: "Tarih", type: "date", required: true },
+  ];
+
+  return (
+    <ReusableModalForm<PaymentFormValues>
+      show={show}
+      title={mode === "add" ? "Ödeme Ekle" : "Ödemeyi Düzenle"}
+      fields={(values) => getFields(values as PaymentFormValues)}
+      initialValues={initialValues}
+      onSubmit={onSubmit}
+      confirmButtonLabel={mode === "add" ? "Ekle" : "Güncelle"}
+      cancelButtonLabel="Vazgeç"
+      onClose={onClose}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- create debt crud modal component
- create payment crud modal component
- integrate modals into credit card service management page

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: missing modules and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_684be423574c832cab46b2bd434469bd