### PR TITLE
Add finance notes table

### DIFF
--- a/src/components/common/financeNotes/table.tsx
+++ b/src/components/common/financeNotes/table.tsx
@@ -1,0 +1,165 @@
+import { useMemo, useState, useEffect } from 'react';
+import ReusableTable, { ColumnDefinition, FilterDefinition } from '../ReusableTable';
+import { useFinanceNotes } from '../../hooks/financeNotes/useFinanceNotes';
+import { FinanceNote } from '../../../types/financeNotes/list';
+import { useSeasonsList } from '../../hooks/season/useSeasonsList';
+import { useBranchTable } from '../../hooks/branch/useBranchList';
+import { useProgramsTable } from '../../hooks/program/useList';
+import { useLevelsTable } from '../../hooks/levels/useList';
+import { useClassroomList } from '../../hooks/classrooms/useList';
+
+export default function FinanceNotesTable() {
+  const [season, setSeason] = useState('');
+  const [branch, setBranch] = useState('');
+  const [programId, setProgramId] = useState('');
+  const [levelId, setLevelId] = useState('');
+  const [classId, setClassId] = useState('');
+  const [student, setStudent] = useState('');
+
+  const { seasonsData } = useSeasonsList({ enabled: true, page: 1, paginate: 100 });
+  const { branchData } = useBranchTable({ enabled: true });
+  const { programsData } = useProgramsTable({ enabled: !!branch, branch_id: branch ? Number(branch) : undefined });
+  const { levelsData } = useLevelsTable({ enabled: !!programId, program_id: programId ? Number(programId) : undefined });
+  const { classroomData } = useClassroomList({
+    enabled: !!levelId,
+    branchId: branch ? Number(branch) : undefined,
+    program_id: programId ? Number(programId) : undefined,
+    level_id: levelId ? Number(levelId) : undefined,
+    page: 1,
+    pageSize: 100,
+  });
+
+  const {
+    data,
+    error,
+    current_page,
+    total,
+    per_page,
+    setPage,
+    setPaginate,
+    setQuery,
+  } = useFinanceNotes();
+
+  useEffect(() => {
+    setQuery({
+      season_id: season,
+      branch_id: branch,
+      program_id: programId,
+      level_id: levelId,
+      classroom_id: classId,
+      search: student,
+    });
+  }, [season, branch, programId, levelId, classId, student, setQuery]);
+
+  const totalPages = Math.ceil(total / per_page);
+
+  const columns: ColumnDefinition<FinanceNote>[] = useMemo(
+    () => [
+      { key: 'sube', label: 'Şube', render: (r) => r.sube },
+      { key: 'okul_no', label: 'Okul No', render: (r) => r.okul_no || '-' },
+      { key: 'tc_kimlik_no', label: 'T.C. Kimlik No', render: (r) => r.tc_kimlik_no || '-' },
+      { key: 'adi_soyadi', label: 'Adı Soyadı', render: (r) => `${r.adi} ${r.soyadi}`.trim() },
+      { key: 'sinif_seviyesi', label: 'Sınıf Seviyesi', render: (r) => r.sinif_seviyesi || '-' },
+      { key: 'sinif_sube', label: 'Sınıf/Şube', render: (r) => r.sinif_sube || '-' },
+      { key: 'tarih', label: 'Tarih', render: (r) => r.tarih },
+      { key: 'note', label: 'Not', render: (r) => r.note },
+      { key: 'soz_verme_tarihi', label: 'Söz Verme Tarihi', render: (r) => r.soz_verme_tarihi || '-' },
+      { key: 'kullanici', label: 'Kullanıcı', render: (r) => r.kullanici },
+    ],
+    []
+  );
+
+  const filters: FilterDefinition[] = useMemo(
+    () => [
+      {
+        key: 'season',
+        label: 'Sezon',
+        type: 'select',
+        value: season,
+        options: (seasonsData || []).map((s: any) => ({ value: String(s.id), label: s.name })),
+        onChange: (val: string) => {
+          setSeason(val);
+          setPage(1);
+        },
+      },
+      {
+        key: 'branch',
+        label: 'Şube',
+        type: 'select',
+        value: branch,
+        options: (branchData || []).map((b: any) => ({ value: String(b.id), label: b.name })),
+        onChange: (val: string) => {
+          setBranch(val);
+          setPage(1);
+        },
+      },
+      {
+        key: 'program_id',
+        label: 'Okul Seviyesi',
+        type: 'select',
+        value: programId,
+        options: (programsData || []).map((p: any) => ({ value: String(p.id), label: p.name })),
+        onChange: (val: string) => {
+          setProgramId(val);
+          setPage(1);
+        },
+      },
+      {
+        key: 'level_id',
+        label: 'Sınıf Seviyesi',
+        type: 'select',
+        value: levelId,
+        options: (levelsData || []).map((l: any) => ({ value: String(l.id), label: l.name })),
+        onChange: (val: string) => {
+          setLevelId(val);
+          setPage(1);
+        },
+      },
+      {
+        key: 'classroom_id',
+        label: 'Sınıf/Şube',
+        type: 'select',
+        value: classId,
+        options: (classroomData || []).map((c: any) => ({ value: String(c.id), label: c.name })),
+        onChange: (val: string) => {
+          setClassId(val);
+          setPage(1);
+        },
+      },
+      {
+        key: 'search',
+        label: 'Öğrenci',
+        type: 'text',
+        value: student,
+        onChange: (val: string) => {
+          setStudent(val);
+          setPage(1);
+        },
+      },
+    ],
+    [season, branch, programId, levelId, classId, student, seasonsData, branchData, programsData, levelsData, classroomData, setPage]
+  );
+
+  return (
+    <div className="container-fluid mt-3">
+      <ReusableTable<FinanceNote>
+        tableMode="single"
+        showExportButtons={true}
+        columns={columns}
+        data={data}
+        error={error}
+        currentPage={current_page}
+        totalPages={totalPages}
+        totalItems={total}
+        pageSize={per_page}
+        onPageChange={(newPage) => setPage(newPage)}
+        onPageSizeChange={(size) => {
+          setPaginate(size);
+          setPage(1);
+        }}
+        filters={filters}
+        exportFileName="finance_notes"
+      />
+    </div>
+  );
+}

--- a/src/components/hooks/financeNotes/useFinanceNotes.tsx
+++ b/src/components/hooks/financeNotes/useFinanceNotes.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchFinanceNotes } from '../../../slices/financeNotes/list/thunk';
+import { RootState, AppDispatch } from '../../../store';
+
+export function useFinanceNotes(initialPage: number = 1, initialPaginate: number = 25) {
+  const dispatch = useDispatch<AppDispatch>();
+
+  const [page, setPage] = useState<number>(initialPage);
+  const [paginate, setPaginate] = useState<number>(initialPaginate);
+  const [query, setQuery] = useState<Record<string, any>>({});
+
+  const financeNotesState = useSelector((state: RootState) => state.financeNotes);
+
+  useEffect(() => {
+    dispatch(fetchFinanceNotes({ ...query, page, paginate }));
+  }, [dispatch, query, page, paginate]);
+
+  return {
+    ...financeNotesState,
+    page,
+    paginate,
+    setPage,
+    setPaginate,
+    query,
+    setQuery,
+  };
+}
+export default useFinanceNotes;

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -372,6 +372,9 @@ const Questionlabeling = lazy(
 );
 
 import OverduePaymentsPage from "../components/common/overduePayments/Table";
+const FinanceNotesTable = lazy(
+  () => import("../components/common/financeNotes/table")
+);
 import { IQuizTime } from "../types/quizTimes/list";
 import WorkSchedule from "../components/common/guidance/workSchedule";
 import AnnualPlanCrud from "../components/common/guidance/workSchedule/Tab1/annual-plan-List-filter/crud";
@@ -638,6 +641,11 @@ export const Routedata = [
     id: 2,
     path: `${import.meta.env.BASE_URL}OverduePayments`,
     element: <OverduePaymentsPage />,
+  },
+  {
+    id: 2,
+    path: `${import.meta.env.BASE_URL}finance-notes`,
+    element: <FinanceNotesTable />,
   },
   {
     id: 2,

--- a/src/slices/financeNotes/list/reducer.tsx
+++ b/src/slices/financeNotes/list/reducer.tsx
@@ -1,0 +1,49 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { fetchFinanceNotes } from './thunk';
+import { ListFinanceNotesResponse, FinanceNote } from '../../../types/financeNotes/list';
+
+interface FinanceNotesState {
+  data: FinanceNote[];
+  current_page: number;
+  total: number;
+  per_page: number;
+  status: 'idle' | 'loading' | 'succeeded' | 'failed';
+  error: string | null;
+}
+
+const initialState: FinanceNotesState = {
+  data: [],
+  current_page: 1,
+  total: 0,
+  per_page: 25,
+  status: 'idle',
+  error: null,
+};
+
+const financeNotesSlice = createSlice({
+  name: 'financeNotes',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(fetchFinanceNotes.pending, (state) => {
+      state.status = 'loading';
+      state.error = null;
+    });
+    builder.addCase(
+      fetchFinanceNotes.fulfilled,
+      (state, action: PayloadAction<ListFinanceNotesResponse>) => {
+        state.status = 'succeeded';
+        state.data = action.payload.data;
+        state.current_page = action.payload.current_page;
+        state.total = action.payload.total;
+        state.per_page = action.payload.per_page;
+      }
+    );
+    builder.addCase(fetchFinanceNotes.rejected, (state, action: PayloadAction<any>) => {
+      state.status = 'failed';
+      state.error = action.payload;
+    });
+  },
+});
+
+export default financeNotesSlice.reducer;

--- a/src/slices/financeNotes/list/thunk.tsx
+++ b/src/slices/financeNotes/list/thunk.tsx
@@ -1,0 +1,30 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import axiosInstance from '../../../services/axiosClient';
+import { ListFinanceNotesResponse } from '../../../types/financeNotes/list';
+
+interface FetchFinanceNotesArgs {
+  page?: number;
+  paginate?: number;
+  [key: string]: any;
+}
+
+export const fetchFinanceNotes = createAsyncThunk<
+  ListFinanceNotesResponse,
+  FetchFinanceNotesArgs
+>('financeNotes/fetch', async (args, { rejectWithValue }) => {
+  try {
+    const params = new URLSearchParams();
+    Object.entries(args).forEach(([key, val]) => {
+      if (val !== undefined && val !== null && val !== '') {
+        params.append(key, String(val));
+      }
+    });
+    const url = `/finance-notes?${params.toString()}`;
+    const response = await axiosInstance.get(url);
+    return response.data as ListFinanceNotesResponse;
+  } catch (err: any) {
+    return rejectWithValue(
+      err.response?.data?.message || 'Fetch finance notes failed'
+    );
+  }
+});

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -54,6 +54,7 @@ import supplierDeleteReducer from '../slices/suppliers/supplier/delete/reducer';
 import supplierListReducer from '../slices/suppliers/supplier/list/reducer';
 import supplierShowReducer from '../slices/suppliers/supplier/show/reducer';
 import overduePaymentsSlice from '../slices/overduePayments/list/reducer'; // Assuming you have a courseListSlice for listing courses
+import financeNotesSlice from '../slices/financeNotes/list/reducer';
 // Transfers
 import transferListSlice from '../slices/transfers/list/reducer'; // Assuming you have a courseListSlice for listing courses
 import transferAddSlice from '../slices/transfers/add/reducer'; // Assuming you have a courseListSlice for adding courses
@@ -630,6 +631,7 @@ const combinedReducer = combineReducers({
   debtList: DebtListSlice,
   discountStudentList: discountStudentListSlice,
   overduePayments: overduePaymentsSlice,
+  financeNotes: financeNotesSlice,
   // Transfers
   transferList: transferListSlice,
   transferAdd: transferAddSlice,

--- a/src/types/financeNotes/list.tsx
+++ b/src/types/financeNotes/list.tsx
@@ -1,0 +1,20 @@
+export interface FinanceNote {
+  sube: string;
+  okul_no?: string | null;
+  tc_kimlik_no?: string | null;
+  adi: string;
+  soyadi: string;
+  sinif_seviyesi?: string | null;
+  sinif_sube?: string | null;
+  tarih: string;
+  note: string;
+  soz_verme_tarihi?: string | null;
+  kullanici: string;
+}
+
+export interface ListFinanceNotesResponse {
+  current_page: number;
+  total: number;
+  per_page: number;
+  data: FinanceNote[];
+}


### PR DESCRIPTION
## Summary
- implement Finance Notes table with filter options
- add hook and Redux slice for finance notes
- register finance notes slice in root reducer
- route to Finance Notes page

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_684be726a964832cb92c473ceb24e03a