### PR TITLE
Update invoice table icons and modal

### DIFF
--- a/src/components/common/invoice/student_invoices.tsx
+++ b/src/components/common/invoice/student_invoices.tsx
@@ -1,66 +1,16 @@
 import { useState, useMemo } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
+import { Modal } from "react-bootstrap";
 import ReusableTable, { ColumnDefinition } from "../ReusableTable";
 import { useInvoiceList } from "../../hooks/invoice/useList";
 import { Invoice } from "../../../types/invoice/list";
-import { useBranchTable } from "../../hooks/branch/useBranchList";
-import { useLevelsTable } from "../../hooks/levels/useList";
 
-export default function StudentInvoiceTable() {
+export default function StudentInvoiceModal() {
   const { studentId } = useParams<{ studentId: string }>();
+  const navigate = useNavigate();
 
-  const [branch, setBranch] = useState("");
-  const [level, setLevel] = useState("");
-  const [invoiceFilter, setInvoiceFilter] = useState("");
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
-
-  const { branchData } = useBranchTable({ enabled: true });
-  const { levelsData } = useLevelsTable({ enabled: true });
-
-  const filters = useMemo(
-    () => [
-      {
-        key: "branch_id",
-        label: "Şube",
-        type: "select" as const,
-        value: branch,
-        options: (branchData || []).map((b) => ({
-          value: String(b.id),
-          label: b.name,
-        })),
-        onChange: (val: string) => setBranch(val),
-      },
-      {
-        key: "level_id",
-        label: "Sınıf Seviyesi",
-        type: "select" as const,
-        value: level,
-        options: (levelsData || []).map((l) => ({
-          value: String(l.id),
-          label: l.name,
-        })),
-        onChange: (val: string) => setLevel(val),
-      },
-      {
-        key: "invoice_filter",
-        label: "Fatura Filtre",
-        type: "select" as const,
-        value: invoiceFilter,
-        options: [
-          { label: "Tümü", value: "" },
-          { label: "Faturası Kesilmiş", value: "invoiced" },
-          { label: "Faturası Kesilmemiş", value: "not_invoiced" },
-          { label: "Hizmet Faturası Kesilmiş", value: "service_invoiced" },
-          { label: "Hizmet Faturası Kesilmemiş", value: "service_not_invoiced" },
-          { label: "Taksit Faturası Kesilmiş", value: "installment_invoiced" },
-          { label: "Taksit Faturası Kesilmemiş", value: "installment_not_invoiced" },
-        ],
-        onChange: (val: string) => setInvoiceFilter(val),
-      },
-    ],
-    [branchData, levelsData, branch, level, invoiceFilter]
-  );
 
   const queryParams = useMemo(
     () => ({
@@ -68,11 +18,8 @@ export default function StudentInvoiceTable() {
       page,
       per_page: pageSize,
       student_id: studentId ? Number(studentId) : undefined,
-      branch_id: branch ? Number(branch) : undefined,
-      level_id: level ? Number(level) : undefined,
-      invoice_filter: invoiceFilter || undefined,
     }),
-    [studentId, branch, level, invoiceFilter, page, pageSize]
+    [studentId, page, pageSize]
   );
 
   const { invoiceData, meta, loading, error, totalPages, totalItems } =
@@ -87,27 +34,38 @@ export default function StudentInvoiceTable() {
         label: "Tutar",
         render: (r) => `${parseFloat(r.payable_amount).toLocaleString()} ₺`,
       },
+      {
+        key: "gider_kalemi",
+        label: "Hizmet kalemi",
+        render: (r) => r.gider_kalemi || "-",
+      },
       { key: "invoice_type_code", label: "Tip", render: (r) => r.invoice_type_code },
     ],
     []
   );
 
   return (
-    <ReusableTable<Invoice>
-      columns={columns}
-      data={invoiceData || []}
-      loading={loading}
-      error={error}
-      filters={filters}
-      showModal={false}
-      showExportButtons={true}
-      tableMode="single"
-      totalPages={meta?.last_page ?? totalPages}
-      totalItems={meta?.total ?? totalItems}
-      pageSize={pageSize}
-      currentPage={page}
-      onPageChange={setPage}
-      onPageSizeChange={setPageSize}
-    />
+    <Modal show onHide={() => navigate(-1)} size="lg" centered>
+      <Modal.Header closeButton>
+        <Modal.Title>Öğrenci Faturaları</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <ReusableTable<Invoice>
+          columns={columns}
+          data={invoiceData || []}
+          loading={loading}
+          error={error}
+          showModal={false}
+          showExportButtons={true}
+          tableMode="single"
+          totalPages={meta?.last_page ?? totalPages}
+          totalItems={meta?.total ?? totalItems}
+          pageSize={pageSize}
+          currentPage={page}
+          onPageChange={setPage}
+          onPageSizeChange={setPageSize}
+        />
+      </Modal.Body>
+    </Modal>
   );
 }

--- a/src/components/common/invoice/table.tsx
+++ b/src/components/common/invoice/table.tsx
@@ -3,6 +3,10 @@ import { useNavigate, useLocation } from "react-router-dom";
 import ReusableTable, { ColumnDefinition } from "../ReusableTable";
 import { useInvoiceSummaryList } from "../../hooks/invoice/useInvoiceSummary";
 import { InvoiceSummary } from "../../../types/invoice/invoiceSummary";
+import invoiceIcon from "../../../assets/images/media/fatura.svg";
+import invoiceHoverIcon from "../../../assets/images/media/fatura-hover.svg";
+import batchIcon from "../../../assets/images/media/toplu-fatura.svg";
+import batchHoverIcon from "../../../assets/images/media/toplu-fatura-hover.svg";
 
 import { useBranchTable } from "../../hooks/branch/useBranchList";
 import { useLevelsTable } from "../../hooks/levels/useList";
@@ -201,16 +205,36 @@ export default function InvoiceSummaryTable() {
                         <button
                             onClick={() => navigate(`/invoicedetail/${r.id}`)}
                             className="btn btn-icon btn-sm btn-info-light rounded-pill"
-                            title="Düzenle"
+                            title="Fatura Oluştur"
                         >
-                            <i className="ti ti-pencil" />
+                            <img
+                                src={invoiceIcon}
+                                alt="Fatura"
+                                style={{ width: 24, height: 24 }}
+                                onMouseEnter={(e) =>
+                                    (e.currentTarget.src = invoiceHoverIcon)
+                                }
+                                onMouseLeave={(e) =>
+                                    (e.currentTarget.src = invoiceIcon)
+                                }
+                            />
                         </button>
                         <button
                             onClick={() => navigate(`/createinvoice/${r.id}`)}
                             className="btn btn-icon btn-sm btn-success-light rounded-pill"
-                            title="Fatura Oluştur"
+                            title="Toplu Fatura Oluştur"
                         >
-                            <i className="ti ti-plus" />
+                            <img
+                                src={batchIcon}
+                                alt="Toplu Fatura"
+                                style={{ width: 24, height: 24 }}
+                                onMouseEnter={(e) =>
+                                    (e.currentTarget.src = batchHoverIcon)
+                                }
+                                onMouseLeave={(e) =>
+                                    (e.currentTarget.src = batchIcon)
+                                }
+                            />
                         </button>
                     </>
 


### PR DESCRIPTION
## Summary
- swap second and third action icons in invoice table to use invoice-related SVGs
- show student invoices in a modal without filters

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684bef7a6b60832cb2d40888c0390592