### PR TITLE
Update invoice modals to return to table

### DIFF
--- a/src/components/common/invoice/auto_create_invoice.tsx
+++ b/src/components/common/invoice/auto_create_invoice.tsx
@@ -110,7 +110,7 @@ export default function AutoCreateInvoiceModal({
                 payable_amount: 0
             }).unwrap();
             onHide();
-            navigate(-1);
+            navigate("/invoice");
         } catch (e) {
             console.error(e);
             // TODO: toast.error("Batch invoice failed")
@@ -124,7 +124,7 @@ export default function AutoCreateInvoiceModal({
             show={show}
             onHide={() => {
                 onHide();
-                navigate(-1);
+                navigate("/invoice");
             }}
             size="lg"
             centered
@@ -227,7 +227,7 @@ export default function AutoCreateInvoiceModal({
                     variant="outline-secondary"
                     onClick={() => {
                         onHide();
-                        navigate(-1);
+                        navigate("/invoice");
                     }}
                 >
                     Kapat

--- a/src/components/common/invoice/detail.tsx
+++ b/src/components/common/invoice/detail.tsx
@@ -127,7 +127,7 @@ export default function InvoiceDetailModal({
                 }).unwrap();
             }
             onHide();
-            navigate(-1);
+            navigate("/invoice");
         } catch (e) {
             console.error(e);
             // TODO: toast.error(...)
@@ -140,8 +140,8 @@ export default function InvoiceDetailModal({
         <Modal
             show={show}
             onHide={() => {
-                onHide();
-                navigate(-1);
+            onHide();
+            navigate("/invoice");
             }}
             size="lg"
             centered
@@ -257,7 +257,7 @@ export default function InvoiceDetailModal({
                     variant="outline-secondary"
                     onClick={() => {
                         onHide();
-                        navigate(-1);
+                        navigate("/invoice");
                     }}
                 >
                     Kapat

--- a/src/components/common/invoice/student_invoices.tsx
+++ b/src/components/common/invoice/student_invoices.tsx
@@ -52,7 +52,7 @@ export default function StudentInvoiceTable() {
       loading={loading}
       error={error}
       showModal={true}
-      onCloseModal={() => navigate(-1)}
+      onCloseModal={() => navigate("/invoice")}
       modalTitle="Faturalar"
       showExportButtons={true}
       tableMode="single"


### PR DESCRIPTION
## Summary
- ensure invoice-related modals navigate back to the invoice table

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684bf6e4e4c0832c940d60ab597f5bd4