### PR TITLE
Implement invoice statistics table

### DIFF
--- a/src/components/common/invoiceStatistics/table.tsx
+++ b/src/components/common/invoiceStatistics/table.tsx
@@ -1,0 +1,181 @@
+import { useMemo, useState } from "react";
+import { Row, Col, Card, Form, Button, Modal } from "react-bootstrap";
+import ReusableTable, { ColumnDefinition } from "../ReusableTable";
+import Pageheader from "../page-header/pageheader";
+import { useInvoiceStatistics, InvoiceStatisticsItem } from "../../hooks/invoice/useInvoiceStatistics";
+import { useBranchTable } from "../../hooks/branch/useBranchList";
+import { useSeasonsList } from "../../hooks/season/useSeasonsList";
+
+interface StudentDetail {
+  branch_name: string;
+  tc_no: string;
+  full_name: string;
+  level: string;
+  classroom: string;
+  parent_name: string;
+  parent_relation: string;
+  parent_phone: string;
+  amount: number;
+}
+
+const monthsOptions = Array.from({ length: 12 }, (_, i) => ({
+  value: String(i + 1),
+  label: `${i + 1}`,
+}));
+
+const InvoiceStatisticsTable = () => {
+  const [branchId, setBranchId] = useState("");
+  const [seasonId, setSeasonId] = useState("");
+  const [months, setMonths] = useState<string[]>([]);
+
+  const [branchEnabled, setBranchEnabled] = useState(false);
+  const [seasonEnabled, setSeasonEnabled] = useState(false);
+
+  const { branchData = [] } = useBranchTable({ enabled: branchEnabled });
+  const { seasonsData = [] } = useSeasonsList({ enabled: seasonEnabled, page: 1, paginate: 100 });
+
+  const { data, loading } = useInvoiceStatistics({
+    enabled: true,
+    branch_id: branchId ? Number(branchId) : undefined,
+    season_id: seasonId ? Number(seasonId) : undefined,
+    months: months.map(Number),
+  });
+
+  const [selectedRow, setSelectedRow] = useState<InvoiceStatisticsItem | null>(null);
+  const [showDetail, setShowDetail] = useState(false);
+
+  const columns: ColumnDefinition<InvoiceStatisticsItem>[] = useMemo(
+    () => [
+      { key: "season_name", label: "Sezon", render: (r) => r.season_name },
+      { key: "branch_name", label: "Şube", render: (r) => r.branch_name },
+      { key: "month", label: "Tarih", render: (r) => r.month },
+      {
+        key: "total_amount",
+        label: "Fatura Tutarı",
+        render: (r) => `${r.total_amount.toLocaleString()} ₺`,
+      },
+      {
+        key: "actions",
+        label: "İşlemler",
+        render: (r) => (
+          <Button size="sm" onClick={() => { setSelectedRow(r); setShowDetail(true); }}>
+            Detay
+          </Button>
+        ),
+      },
+    ],
+    []
+  );
+
+  const total = data.reduce((a, b) => a + (b.total_amount || 0), 0);
+
+  const footer = (
+    <div className="d-flex justify-content-end fw-bold me-3">Toplam: {total.toLocaleString()} ₺</div>
+  );
+
+  const studentColumns: ColumnDefinition<StudentDetail>[] = useMemo(
+    () => [
+      { key: "branch_name", label: "Şube" },
+      { key: "tc_no", label: "T.C. Kimlik No" },
+      { key: "full_name", label: "Adı Soyadı" },
+      { key: "level", label: "Sınıf Seviyesi" },
+      { key: "classroom", label: "Sınıf/Şube" },
+      { key: "parent_name", label: "Veli Adı Soyadı" },
+      { key: "parent_relation", label: "Veli Yakınlığı" },
+      { key: "parent_phone", label: "Veli Telefon" },
+      {
+        key: "amount",
+        label: "Fatura Tutarı",
+        render: (r) => `${r.amount.toLocaleString()} ₺`,
+      },
+    ],
+    []
+  );
+
+  return (
+    <div className="container-fluid mt-3">
+      <Pageheader title="Faturalar" currentpage="Fatura İstatistikleri" />
+      <Card className="mb-4 glass-card">
+        <Card.Body>
+          <Row className="g-3">
+            <Col md={4}>
+              <Form.Group>
+                <Form.Label>Şube</Form.Label>
+                <Form.Select
+                  value={branchId}
+                  onChange={(e) => setBranchId(e.target.value)}
+                  onFocus={() => setBranchEnabled(true)}
+                >
+                  <option value="">Seçiniz</option>
+                  {branchData.map((b) => (
+                    <option key={b.id} value={b.id}>
+                      {b.name}
+                    </option>
+                  ))}
+                </Form.Select>
+              </Form.Group>
+            </Col>
+            <Col md={4}>
+              <Form.Group>
+                <Form.Label>Sezon</Form.Label>
+                <Form.Select
+                  value={seasonId}
+                  onChange={(e) => setSeasonId(e.target.value)}
+                  onFocus={() => setSeasonEnabled(true)}
+                >
+                  <option value="">Seçiniz</option>
+                  {seasonsData.map((s) => (
+                    <option key={s.id} value={s.id}>
+                      {s.name}
+                    </option>
+                  ))}
+                </Form.Select>
+              </Form.Group>
+            </Col>
+            <Col md={4}>
+              <Form.Group>
+                <Form.Label>Ay</Form.Label>
+                <Form.Select
+                  multiple
+                  value={months}
+                  onChange={(e) =>
+                    setMonths(Array.from(e.target.selectedOptions, (o) => o.value))
+                  }
+                >
+                  {monthsOptions.map((m) => (
+                    <option key={m.value} value={m.value}>
+                      {m.label}
+                    </option>
+                  ))}
+                </Form.Select>
+              </Form.Group>
+            </Col>
+          </Row>
+        </Card.Body>
+      </Card>
+      <ReusableTable<InvoiceStatisticsItem>
+        tableMode="single"
+        columns={columns}
+        data={data}
+        loading={loading}
+        showExportButtons
+        customFooter={footer}
+      />
+      <Modal size="lg" show={showDetail} onHide={() => setShowDetail(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>Detay</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <ReusableTable<StudentDetail>
+            tableMode="single"
+            columns={studentColumns}
+            data={(selectedRow?.students as StudentDetail[]) || []}
+            showExportButtons={false}
+          />
+        </Modal.Body>
+      </Modal>
+    </div>
+  );
+};
+
+export default InvoiceStatisticsTable;

--- a/src/components/hooks/invoice/useInvoiceStatistics.tsx
+++ b/src/components/hooks/invoice/useInvoiceStatistics.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import axiosInstance from "../../../services/axiosClient";
+
+export interface InvoiceStatisticsItem {
+  season_name: string;
+  branch_name: string;
+  month: string;
+  total_amount: number;
+  students?: any[];
+}
+
+export interface InvoiceStatisticsArgs {
+  enabled?: boolean;
+  season_id?: number;
+  branch_id?: number;
+  months?: number[];
+}
+
+export function useInvoiceStatistics(args: InvoiceStatisticsArgs) {
+  const { enabled = true, ...params } = args;
+  const [data, setData] = useState<InvoiceStatisticsItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const query = new URLSearchParams();
+    if (params.season_id) query.append("season_id", String(params.season_id));
+    if (params.branch_id) query.append("branch_id", String(params.branch_id));
+    if (params.months && params.months.length)
+      query.append("months", params.months.join(","));
+    const url = `/invoice/summery${query.toString() ? `?${query.toString()}` : ""}`;
+    setLoading(true);
+    axiosInstance
+      .get(url)
+      .then((resp) => {
+        setData(resp.data?.data || []);
+      })
+      .catch((err) => {
+        setError(err.response?.data?.message || "Fetch failed");
+      })
+      .finally(() => setLoading(false));
+  }, [enabled, params.season_id, params.branch_id, params.months]);
+
+  return { data, loading, error };
+}


### PR DESCRIPTION
## Summary
- add a hook for invoice statistics API
- implement InvoiceStatisticsTable with filters, table, and modal

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684c018a40ac832ca03ae09f71a06211