### PR TITLE
Fix invoice statistics routing

### DIFF
--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -322,6 +322,9 @@ const Invoicedetail = lazy(() => import("../components/common/invoice/detail"));
 const Createinvoice = lazy(
   () => import("../components/common/invoice/auto_create_invoice")
 );
+const InvoiceStatisticsTable = lazy(
+  () => import("../components/common/invoiceStatistics/table")
+);
 const RegisterIndex = lazy(
   () => import("../components/common/student/register")
 );
@@ -935,6 +938,11 @@ export const Routedata = [
     id: 23,
     path: `${import.meta.env.BASE_URL}invoice`,
     element: <InvoiceTable />,
+  },
+  {
+    id: 23,
+    path: `${import.meta.env.BASE_URL}invoice/stat`,
+    element: <InvoiceStatisticsTable />,
   },
   {
     id: 23,


### PR DESCRIPTION
## Summary
- add InvoiceStatisticsTable lazy component
- register `/invoice/stat` route

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c041aee4c832c961e871977bbef5e