### PR TITLE
Add invoice statistics pages

### DIFF
--- a/src/components/common/invoiceStatistics/crud.tsx
+++ b/src/components/common/invoiceStatistics/crud.tsx
@@ -1,0 +1,159 @@
+import { useMemo, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import ReusableTable, { ColumnDefinition } from "../ReusableTable";
+import { useInvoiceStatistics, InvoiceStatisticsItem } from "../../hooks/invoice/useInvoiceStatistics";
+import { InvoiceStatisticsStudent } from "../../../types/invoice/invoiceStatistics";
+
+interface StudentModalProps {
+  student: InvoiceStatisticsStudent;
+  onHide: () => void;
+}
+
+function StudentInvoicesModal({ student, onHide }: StudentModalProps) {
+  const services = useMemo(() => {
+    const set = new Set<string>();
+    student.invoices.forEach((i) => set.add(i.service_name));
+    return Array.from(set);
+  }, [student]);
+
+  const rows = useMemo(() => {
+    const map: Record<string, any> = {};
+    student.invoices.forEach((inv) => {
+      if (!map[inv.issue_date]) map[inv.issue_date] = { issue_date: inv.issue_date };
+      map[inv.issue_date][inv.service_name] = inv.amount;
+    });
+    return Object.values(map);
+  }, [student]);
+
+  const columns: ColumnDefinition<any>[] = useMemo(() => {
+    const base: ColumnDefinition<any>[] = [
+      { key: "issue_date", label: "Tarih", render: (r) => r.issue_date },
+    ];
+    services.forEach((s) => {
+      base.push({
+        key: s,
+        label: s,
+        render: (r) => (r[s] ? `${Number(r[s]).toLocaleString()} ₺` : "-")
+      });
+    });
+    return base;
+  }, [services]);
+
+  const footer = useMemo(() => {
+    const totals: Record<string, number> = {};
+    services.forEach((s) => {
+      totals[s] = student.invoices
+        .filter((i) => i.service_name === s)
+        .reduce((sum, i) => sum + i.amount, 0);
+    });
+    return (
+      <div className="d-flex justify-content-end fw-bold me-3 gap-3">
+        {services.map((s) => (
+          <span key={s}>{s}: {totals[s].toLocaleString()} ₺</span>
+        ))}
+      </div>
+    );
+  }, [services, student]);
+
+  return (
+    <ReusableTable<any>
+      showModal={true}
+      modalTitle={student.full_name}
+      columns={columns}
+      data={rows}
+      showExportButtons
+      tableMode="single"
+      customFooter={footer}
+      onCloseModal={onHide}
+    />
+  );
+}
+
+export default function InvoiceStatisticsDetail({
+  show,
+  onHide,
+}: { show: boolean; onHide: () => void }) {
+  const navigate = useNavigate();
+  const { search } = useLocation();
+  const params = new URLSearchParams(search);
+  const seasonId = params.get("season_id");
+  const branchId = params.get("branch_id");
+  const month = params.get("month");
+
+  const { data, loading, error } = useInvoiceStatistics({
+    enabled: true,
+    season_id: seasonId ? Number(seasonId) : undefined,
+    branch_id: branchId ? Number(branchId) : undefined,
+    months: month ? [Number(month)] : undefined,
+  });
+
+  const item: InvoiceStatisticsItem | null = data.length ? data[0] : null;
+  const [selectedStudent, setSelectedStudent] = useState<InvoiceStatisticsStudent | null>(null);
+
+  const columns: ColumnDefinition<InvoiceStatisticsStudent>[] = useMemo(
+    () => [
+      { key: "branch_name", label: "Şube", render: (r) => r.branch_name },
+      { key: "tc_no", label: "T.C. Kimlik No", render: (r) => r.tc_no },
+      { key: "full_name", label: "Adı Soyadı", render: (r) => r.full_name },
+      { key: "level_name", label: "Sınıf Seviyesi", render: (r) => r.level_name },
+      { key: "class_branch", label: "Sınıf/Şube", render: (r) => r.class_branch },
+      { key: "parent_name", label: "Veli Adı Soyadı", render: (r) => r.parent_name },
+      { key: "parent_relation", label: "Veli Yakınlığı", render: (r) => r.parent_relation },
+      { key: "parent_phone", label: "Veli Telefon", render: (r) => r.parent_phone },
+      {
+        key: "total_amount",
+        label: "Fatura Tutarı",
+        render: (r) => `${r.total_amount.toLocaleString()} ₺`,
+      },
+      {
+        key: "actions",
+        label: "İşlemler",
+        render: (r) => (
+          <button
+            className="btn btn-icon btn-sm btn-info-light rounded-pill"
+            onClick={() => setSelectedStudent(r)}
+          >
+            <i className="ti ti-eye" />
+          </button>
+        ),
+      },
+    ],
+    []
+  );
+
+  const totalAmount = useMemo(() => {
+    return item?.students?.reduce((sum, s) => sum + (s.total_amount || 0), 0) || 0;
+  }, [item]);
+
+  const footer = (
+    <div className="d-flex justify-content-end fw-bold me-3">
+      Toplam: {totalAmount.toLocaleString()} ₺
+    </div>
+  );
+
+  return (
+    <>
+      <ReusableTable<InvoiceStatisticsStudent>
+        showModal={true}
+        modalTitle="Fatura Detayı"
+        columns={columns}
+        data={item?.students || []}
+        loading={loading}
+        error={error}
+        tableMode="single"
+        showExportButtons
+        customFooter={footer}
+        onCloseModal={() => {
+          onHide();
+          navigate(-1);
+        }}
+      />
+      {selectedStudent && (
+        <StudentInvoicesModal
+          student={selectedStudent}
+          onHide={() => setSelectedStudent(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/common/invoiceStatistics/table.tsx
+++ b/src/components/common/invoiceStatistics/table.tsx
@@ -1,0 +1,154 @@
+import { useState, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { Card, Row, Col, Form } from "react-bootstrap";
+import ReusableTable, { ColumnDefinition } from "../ReusableTable";
+import Pageheader from "../page-header/pageheader";
+import { useBranchTable } from "../../hooks/branch/useBranchList";
+import { useSeasonsList } from "../../hooks/season/useSeasonsList";
+import { useInvoiceStatistics, InvoiceStatisticsItem } from "../../hooks/invoice/useInvoiceStatistics";
+
+const months = [
+  { value: "1", label: "Ocak" },
+  { value: "2", label: "Şubat" },
+  { value: "3", label: "Mart" },
+  { value: "4", label: "Nisan" },
+  { value: "5", label: "Mayıs" },
+  { value: "6", label: "Haziran" },
+  { value: "7", label: "Temmuz" },
+  { value: "8", label: "Ağustos" },
+  { value: "9", label: "Eylül" },
+  { value: "10", label: "Ekim" },
+  { value: "11", label: "Kasım" },
+  { value: "12", label: "Aralık" },
+];
+
+export default function InvoiceStatisticsTable() {
+  const navigate = useNavigate();
+  const [seasonId, setSeasonId] = useState("");
+  const [branchId, setBranchId] = useState("");
+  const [selectedMonths, setSelectedMonths] = useState<string[]>([]);
+
+  const { branchData } = useBranchTable({ enabled: true });
+  const { seasonsData } = useSeasonsList({ enabled: true });
+
+  const { data, loading, error } = useInvoiceStatistics({
+    enabled: true,
+    season_id: seasonId ? Number(seasonId) : undefined,
+    branch_id: branchId ? Number(branchId) : undefined,
+    months: selectedMonths.map(Number),
+  });
+
+  const columns: ColumnDefinition<InvoiceStatisticsItem>[] = useMemo(
+    () => [
+      { key: "season_name", label: "Sezon", render: (r) => r.season_name },
+      { key: "branch_name", label: "Şube", render: (r) => r.branch_name },
+      { key: "month", label: "Tarih", render: (r) => r.month },
+      {
+        key: "total_amount",
+        label: "Fatura Tutarı",
+        render: (r) => `${r.total_amount.toLocaleString()} ₺`,
+      },
+      {
+        key: "actions",
+        label: "İşlemler",
+        render: (r) => (
+          <button
+            className="btn btn-icon btn-sm btn-info-light rounded-pill"
+            onClick={() =>
+              navigate(
+                `/invoice/stat/detail?season_id=${seasonId}&branch_id=${branchId}&month=${r.month}`
+              )
+            }
+          >
+            <i className="ti ti-eye" />
+          </button>
+        ),
+      },
+    ],
+    [navigate, seasonId, branchId]
+  );
+
+  const totalAmount = useMemo(() => {
+    return data.reduce((sum, item) => sum + (item.total_amount || 0), 0);
+  }, [data]);
+
+  const footer = (
+    <div className="d-flex justify-content-end fw-bold me-3">
+      Toplam: {totalAmount.toLocaleString()} ₺
+    </div>
+  );
+
+  return (
+    <>
+      <Pageheader title="Fatura İstatistiği" currentpage="Fatura İstatistiği" />
+      <Card className="mb-3">
+        <Card.Body>
+          <Row className="g-3">
+            <Col md={4}>
+              <Form.Group>
+                <Form.Label>Şube</Form.Label>
+                <Form.Select
+                  value={branchId}
+                  onChange={(e) => setBranchId(e.target.value)}
+                >
+                  <option value="">Seçiniz</option>
+                  {branchData?.map((b) => (
+                    <option key={b.id} value={b.id}>
+                      {b.name}
+                    </option>
+                  ))}
+                </Form.Select>
+              </Form.Group>
+            </Col>
+            <Col md={4}>
+              <Form.Group>
+                <Form.Label>Sezon</Form.Label>
+                <Form.Select
+                  value={seasonId}
+                  onChange={(e) => setSeasonId(e.target.value)}
+                >
+                  <option value="">Seçiniz</option>
+                  {seasonsData?.map((s) => (
+                    <option key={s.id} value={s.id}>
+                      {s.name}
+                    </option>
+                  ))}
+                </Form.Select>
+              </Form.Group>
+            </Col>
+            <Col md={4}>
+              <Form.Group>
+                <Form.Label>Ay</Form.Label>
+                <Form.Select
+                  multiple
+                  value={selectedMonths}
+                  onChange={(e) =>
+                    setSelectedMonths(
+                      Array.from(e.target.selectedOptions, (o) => o.value)
+                    )
+                  }
+                >
+                  {months.map((m) => (
+                    <option key={m.value} value={m.value}>
+                      {m.label}
+                    </option>
+                  ))}
+                </Form.Select>
+              </Form.Group>
+            </Col>
+          </Row>
+        </Card.Body>
+      </Card>
+      <ReusableTable<InvoiceStatisticsItem>
+        columns={columns}
+        data={data}
+        loading={loading}
+        error={error}
+        showModal={false}
+        showExportButtons
+        tableMode="single"
+        customFooter={footer}
+      />
+    </>
+  );
+}

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -325,6 +325,9 @@ const Createinvoice = lazy(
 const InvoiceStatisticsTable = lazy(
   () => import("../components/common/invoiceStatistics/table")
 );
+const InvoiceStatisticsCrud = lazy(
+  () => import("../components/common/invoiceStatistics/crud")
+);
 const RegisterIndex = lazy(
   () => import("../components/common/student/register")
 );
@@ -946,6 +949,18 @@ export const Routedata = [
     id: 23,
     path: `${import.meta.env.BASE_URL}invoice/stat`,
     element: <InvoiceStatisticsTable />,
+  },
+  {
+    id: 23,
+    path: `${import.meta.env.BASE_URL}invoice/stat/detail`,
+    element: (
+      <InvoiceStatisticsCrud
+        show={true}
+        onHide={() => {
+          window.history.back();
+        }}
+      />
+    ),
   },
   {
     id: 23,

--- a/src/types/invoice/invoiceStatistics.tsx
+++ b/src/types/invoice/invoiceStatistics.tsx
@@ -1,0 +1,16 @@
+export interface InvoiceStatisticsStudent {
+  branch_name: string;
+  tc_no: string;
+  full_name: string;
+  level_name: string;
+  class_branch: string;
+  parent_name: string;
+  parent_relation: string;
+  parent_phone: string;
+  total_amount: number;
+  invoices: {
+    issue_date: string;
+    service_name: string;
+    amount: number;
+  }[];
+}


### PR DESCRIPTION
## Summary
- implement invoice statistics table with filters and totals
- add invoice statistics detail modal with nested student invoice table
- create type definitions for invoice statistics students
- register new routes for statistics pages

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684c1226b5d4832cb9eab8f173c705e3