### PR TITLE
Fix invoice statistics navigation

### DIFF
--- a/src/components/sidebar/nav.tsx
+++ b/src/components/sidebar/nav.tsx
@@ -313,8 +313,16 @@ export const MENUITEMS: any = [
         title: "Fatura Yönetimi",
         type: "sub",
         children: [
-          { title: "Fatura İşleme", path: "/invoice", type: "link" },
-          { title: "Fatura İstatistiği", path: "/invoice/stat", type: "link" },
+          {
+            title: "Fatura İşleme",
+            path: `${import.meta.env.BASE_URL}invoice`,
+            type: "link",
+          },
+          {
+            title: "Fatura İstatistiği",
+            path: `${import.meta.env.BASE_URL}invoice/stat`,
+            type: "link",
+          },
         ],
       },
       { title: "Kart Yönetimi", path: "/creditcards", type: "link" },


### PR DESCRIPTION
## Summary
- adjust invoice links to respect configured base URL

## Testing
- `npm run build` *(fails: Cannot find module 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_684c1708620c832cbb178b927ddb33a4