### PR TITLE
Add invoice statistics pages

### DIFF
--- a/src/components/common/ReusableTable.tsx
+++ b/src/components/common/ReusableTable.tsx
@@ -442,6 +442,31 @@ function ReusableTable<T extends { [key: string]: any }>({
                           </Form.Group>
                         </Col>
                       );
+                    } else if (filter.type === "multiselect") {
+                      return (
+                        <Col key={filter.key} md={colSize}>
+                          <Form.Group>
+                            <Form.Label>{filter.label}</Form.Label>
+                            <Form.Select
+                              multiple
+                              value={Array.isArray(filter.value) ? filter.value : []}
+                              onChange={(e) => {
+                                const selected = Array.from(
+                                  e.target.selectedOptions,
+                                  (opt) => opt.value
+                                );
+                                if (filter.onChange) filter.onChange(selected);
+                              }}
+                            >
+                              {filter.options?.map((opt) => (
+                                <option key={opt.value} value={opt.value}>
+                                  {opt.label}
+                                </option>
+                              ))}
+                            </Form.Select>
+                          </Form.Group>
+                        </Col>
+                      );
                     } // renderFiltersSingle fonksiyonu içindeki if-else bloklarına eklenecek
 
                     return (
@@ -781,6 +806,31 @@ function ReusableTable<T extends { [key: string]: any }>({
                           inputClass="form-control"
                         />
                       )}
+                    </Form.Group>
+                  </Col>
+                );
+              } else if (filter.type === "multiselect") {
+                return (
+                  <Col key={filter.key} md={6}>
+                    <Form.Group>
+                      <Form.Label>{filter.label}</Form.Label>
+                      <Form.Select
+                        multiple
+                        value={Array.isArray(filter.value) ? filter.value : []}
+                        onChange={(e) => {
+                          const selected = Array.from(
+                            e.target.selectedOptions,
+                            (opt) => opt.value
+                          );
+                          if (filter.onChange) filter.onChange(selected);
+                        }}
+                      >
+                        {filter.options?.map((opt) => (
+                          <option key={opt.value} value={opt.value}>
+                            {opt.label}
+                          </option>
+                        ))}
+                      </Form.Select>
                     </Form.Group>
                   </Col>
                 );

--- a/src/components/common/invoiceStatistics/crud.tsx
+++ b/src/components/common/invoiceStatistics/crud.tsx
@@ -1,0 +1,89 @@
+import { useState, useMemo } from "react";
+import { Button } from "react-bootstrap";
+import ReusableTable, { ColumnDefinition } from "../ReusableTable";
+import { InvoiceStatisticsItem } from "../../hooks/invoice/useInvoiceStatistics";
+import { InvoiceStatisticsStudent } from "../../../types/invoice/invoiceStatistics";
+import { formatCurrency, formatDate } from "../../../utils/formatters";
+
+interface Props {
+  show: boolean;
+  onHide: () => void;
+  item: InvoiceStatisticsItem;
+}
+
+export default function InvoiceStatisticsCrud({ show, onHide, item }: Props) {
+  const [selectedStudent, setSelectedStudent] = useState<InvoiceStatisticsStudent | null>(null);
+
+  const studentColumns: ColumnDefinition<InvoiceStatisticsStudent>[] = useMemo(
+    () => [
+      { key: "branch_name", label: "Şube", render: (r) => r.branch_name },
+      { key: "tc_no", label: "T.C. Kimlik No", render: (r) => r.tc_no },
+      { key: "full_name", label: "Adı Soyadı", render: (r) => r.full_name },
+      { key: "level_name", label: "Sınıf Seviyesi", render: (r) => r.level_name },
+      { key: "class_branch", label: "Sınıf/Şube", render: (r) => r.class_branch },
+      { key: "parent_name", label: "Veli Adı Soyadı", render: (r) => r.parent_name },
+      { key: "parent_relation", label: "Veli Yakınlığı", render: (r) => r.parent_relation },
+      { key: "parent_phone", label: "Veli Telefon", render: (r) => r.parent_phone },
+      { key: "total_amount", label: "Fatura Tutarı", render: (r) => formatCurrency(r.total_amount) },
+      {
+        key: "actions",
+        label: "İşlemler",
+        render: (r) => (
+          <Button
+            variant="primary-light"
+            size="sm"
+            className="btn-icon rounded-pill"
+            onClick={() => setSelectedStudent(r)}
+          >
+            <i className="ti ti-eye" />
+          </Button>
+        ),
+      },
+    ],
+    []
+  );
+
+  const invoiceColumns: ColumnDefinition<any>[] = useMemo(
+    () => [
+      { key: "issue_date", label: "Tarih", render: (r) => formatDate(r.issue_date) },
+      { key: "service_name", label: "Hizmet", render: (r) => r.service_name },
+      { key: "amount", label: "Tutar", render: (r) => formatCurrency(r.amount) },
+    ],
+    []
+  );
+
+  const total = useMemo(
+    () => (item.students || []).reduce((sum, s) => sum + (s.total_amount || 0), 0),
+    [item]
+  );
+
+  const footer = (
+    <div className="d-flex justify-content-end fw-bold me-3">Toplam: {formatCurrency(total)}</div>
+  );
+
+  return (
+    <>
+      <ReusableTable<InvoiceStatisticsStudent>
+        modalTitle="Fatura Detayları"
+        showModal={show}
+        onCloseModal={onHide}
+        columns={studentColumns}
+        data={item.students || []}
+        tableMode="single"
+        showExportButtons={true}
+        customFooter={footer}
+      />
+      {selectedStudent && (
+        <ReusableTable<any>
+          modalTitle={selectedStudent.full_name}
+          showModal={true}
+          onCloseModal={() => setSelectedStudent(null)}
+          columns={invoiceColumns}
+          data={selectedStudent.invoices || []}
+          tableMode="single"
+          showExportButtons={true}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/common/invoiceStatistics/table.tsx
+++ b/src/components/common/invoiceStatistics/table.tsx
@@ -1,0 +1,124 @@
+import { useState, useMemo } from "react";
+import { Button } from "react-bootstrap";
+import Pageheader from "../../page-header/pageheader";
+import ReusableTable, { ColumnDefinition, FilterDefinition } from "../ReusableTable";
+import { useInvoiceStatistics, InvoiceStatisticsItem } from "../../hooks/invoice/useInvoiceStatistics";
+import { useSeasonsList } from "../../hooks/season/useSeasonsList";
+import { useBranchTable } from "../../hooks/branch/useBranchList";
+import { formatCurrency } from "../../../utils/formatters";
+import InvoiceStatisticsCrud from "./crud";
+
+const MONTH_OPTIONS = [
+  { value: "1", label: "Ocak" },
+  { value: "2", label: "Şubat" },
+  { value: "3", label: "Mart" },
+  { value: "4", label: "Nisan" },
+  { value: "5", label: "Mayıs" },
+  { value: "6", label: "Haziran" },
+  { value: "7", label: "Temmuz" },
+  { value: "8", label: "Ağustos" },
+  { value: "9", label: "Eylül" },
+  { value: "10", label: "Ekim" },
+  { value: "11", label: "Kasım" },
+  { value: "12", label: "Aralık" },
+];
+
+export default function InvoiceStatisticsTable() {
+  const [season, setSeason] = useState("");
+  const [branch, setBranch] = useState("");
+  const [months, setMonths] = useState<string[]>([]);
+  const [detailItem, setDetailItem] = useState<InvoiceStatisticsItem | null>(null);
+
+  const { seasonsData } = useSeasonsList({ enabled: true, page: 1, paginate: 100 });
+  const { branchData } = useBranchTable({ enabled: true });
+
+  const { data, loading, error } = useInvoiceStatistics({
+    enabled: true,
+    season_id: season ? Number(season) : undefined,
+    branch_id: branch ? Number(branch) : undefined,
+    months: months.map((m) => Number(m)),
+  });
+
+  const filters: FilterDefinition[] = useMemo(
+    () => [
+      {
+        key: "season",
+        label: "Sezon",
+        type: "select",
+        value: season,
+        options: (seasonsData || []).map((s: any) => ({ value: String(s.id), label: s.name })),
+        onChange: setSeason,
+      },
+      {
+        key: "branch",
+        label: "Şube",
+        type: "select",
+        value: branch,
+        options: (branchData || []).map((b: any) => ({ value: String(b.id), label: b.name })),
+        onChange: setBranch,
+      },
+      {
+        key: "months",
+        label: "Ay",
+        type: "multiselect",
+        value: months,
+        options: MONTH_OPTIONS,
+        onChange: (vals: string[]) => setMonths(vals),
+      },
+    ],
+    [season, branch, months, seasonsData, branchData]
+  );
+
+  const columns: ColumnDefinition<InvoiceStatisticsItem>[] = useMemo(
+    () => [
+      { key: "season_name", label: "Sezon", render: (r) => r.season_name },
+      { key: "branch_name", label: "Şube", render: (r) => r.branch_name },
+      { key: "month", label: "Tarih", render: (r) => r.month },
+      { key: "total_amount", label: "Fatura Tutarı", render: (r) => formatCurrency(r.total_amount) },
+      {
+        key: "actions",
+        label: "İşlemler",
+        render: (r) => (
+          <Button
+            variant="primary-light"
+            size="sm"
+            className="btn-icon rounded-pill"
+            onClick={() => setDetailItem(r)}
+          >
+            <i className="ti ti-eye" />
+          </Button>
+        ),
+      },
+    ],
+    []
+  );
+
+  const total = useMemo(() => data.reduce((sum, d) => sum + (d.total_amount || 0), 0), [data]);
+
+  const footer = (
+    <div className="d-flex justify-content-end fw-bold me-3">Toplam: {formatCurrency(total)}</div>
+  );
+
+  return (
+    <>
+      <Pageheader title="Fatura Yönetimi" currentpage="Fatura İstatistiği" />
+      <ReusableTable<InvoiceStatisticsItem>
+        columns={columns}
+        data={data}
+        loading={loading}
+        error={error}
+        filters={filters}
+        tableMode="single"
+        showExportButtons={true}
+        customFooter={footer}
+      />
+      {detailItem && (
+        <InvoiceStatisticsCrud
+          show={true}
+          onHide={() => setDetailItem(null)}
+          item={detailItem}
+        />
+      )}
+    </>
+  );
+}

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -322,6 +322,9 @@ const Invoicedetail = lazy(() => import("../components/common/invoice/detail"));
 const Createinvoice = lazy(
   () => import("../components/common/invoice/auto_create_invoice")
 );
+const InvoiceStatisticsTable = lazy(
+  () => import("../components/common/invoiceStatistics/table")
+);
 
 const RegisterIndex = lazy(
   () => import("../components/common/student/register")
@@ -939,6 +942,11 @@ export const Routedata = [
     id: 23,
     path: `${import.meta.env.BASE_URL}invoice`,
     element: <InvoiceTable />,
+  },
+  {
+    id: 23,
+    path: `${import.meta.env.BASE_URL}invoice/stat`,
+    element: <InvoiceStatisticsTable />,
   },
 
   {


### PR DESCRIPTION
## Summary
- support `multiselect` filters in `ReusableTable`
- implement Invoice Statistics table and modal components
- register new route for Invoice Statistics

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: TS errors and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_684c1aca1cf8832cb0f1f0d3e1bfe7fe