### PR TITLE
Add detail and receipt for other income entries

### DIFF
--- a/src/components/common/otherIncome/detail.tsx
+++ b/src/components/common/otherIncome/detail.tsx
@@ -1,0 +1,82 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import { Modal, Button } from 'react-bootstrap';
+import ReusableTable, { ColumnDefinition } from '../ReusableTable';
+import { useOtherIncomeShow } from '../../hooks/otherIncome/useOtherIncomeShow';
+import { useOtherIncomeDelete } from '../../hooks/otherIncome/useOtherIncomeDelete';
+
+interface DetailModalProps {
+  show: boolean;
+  onClose: () => void;
+}
+
+export default function OtherIncomeDetail({ show, onClose }: DetailModalProps) {
+  const { id } = useParams<{ id?: string }>();
+  const navigate = useNavigate();
+  const { detail } = useOtherIncomeShow(Number(id));
+  const { remove } = useOtherIncomeDelete();
+
+  const columns: ColumnDefinition<any>[] = [
+    { key: 'date', label: 'Tarih', render: r => r.date || '-' },
+    {
+      key: 'amount',
+      label: 'Alınan Ödeme',
+      render: r => (r.amount ? `${Number(r.amount).toLocaleString()} ₺` : '-')
+    },
+    {
+      key: 'payment_method',
+      label: 'Ödeme Şekli',
+      render: r => r.payment_method || '-'
+    },
+    { key: 'income_item', label: 'Gelir Kalemi', render: r => r.income_item || '-' },
+    { key: 'description', label: 'Açıklama', render: r => r.description || '-' },
+    { key: 'id', label: 'Makbuz No', render: r => String(r.id) },
+    {
+      key: 'actions',
+      label: 'İşlemler',
+      render: r => (
+        <>
+          <Button
+            variant="primary-light"
+            className="btn btn-icon btn-sm rounded-pill me-1"
+            onClick={() => navigate(`/other-income/crud/${r.id}`)}
+            title="Düzenle"
+          >
+            <i className="ti ti-pencil" />
+          </Button>
+          <Button
+            variant="danger-light"
+            className="btn btn-icon btn-sm rounded-pill me-1"
+            onClick={() => remove(Number(r.id))}
+            title="Sil"
+          >
+            <i className="ti ti-trash" />
+          </Button>
+          <Button
+            variant="primary-light"
+            className="btn btn-icon btn-sm rounded-pill"
+            onClick={() => navigate(`/revenuesReceipt/${r.id}`)}
+            title="Makbuz"
+          >
+            <i className="ti ti-printer" />
+          </Button>
+        </>
+      )
+    }
+  ];
+
+  return (
+    <Modal show={show} onHide={onClose} size="lg" centered>
+      <Modal.Header closeButton>
+        <Modal.Title>Gelir Detayı</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <ReusableTable
+          tableMode="single"
+          columns={columns}
+          data={detail ? [detail] : []}
+          showExportButtons={false}
+        />
+      </Modal.Body>
+    </Modal>
+  );
+}

--- a/src/components/common/otherIncome/revenuesReceipt.tsx
+++ b/src/components/common/otherIncome/revenuesReceipt.tsx
@@ -1,0 +1,44 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import { Modal, Button } from 'react-bootstrap';
+import { useOtherIncomeShow } from '../../hooks/otherIncome/useOtherIncomeShow';
+
+export default function RevenuesReceipt() {
+  const { id } = useParams<{ id?: string }>();
+  const navigate = useNavigate();
+  const { detail } = useOtherIncomeShow(Number(id));
+
+  return (
+    <Modal show centered onHide={() => navigate(-1)}>
+      <Modal.Header closeButton>
+        <Modal.Title>Gelir Makbuzu</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {detail ? (
+          <>
+            <p><strong>Makbuz No:</strong> {detail.id}</p>
+            <p><strong>Tarih:</strong> {detail.date}</p>
+            <p><strong>Ödeme Şekli:</strong> {detail.payment_method}</p>
+            <p><strong>Gelir Kalemi:</strong> {detail.income_item}</p>
+            <p>
+              <strong>Alınan Ödeme:</strong>{' '}
+              {Number(detail.amount).toLocaleString('tr-TR')} ₺
+            </p>
+            {detail.description && (
+              <p><strong>Açıklama:</strong> {detail.description}</p>
+            )}
+          </>
+        ) : (
+          <p>Yükleniyor...</p>
+        )}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="outline-secondary" onClick={() => window.print()}>
+          Yazdır
+        </Button>
+        <Button variant="outline-secondary" onClick={() => navigate(-1)}>
+          Kapat
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/components/common/otherIncome/table.tsx
+++ b/src/components/common/otherIncome/table.tsx
@@ -64,11 +64,11 @@ export default function OtherIncomeTable() {
           <>
             <Button
               variant="primary-light"
-              onClick={() => navigate(`/other-income/crud/${row.id}`)}
+              onClick={() => navigate(`/other-income/detail/${row.id}`)}
               className="btn btn-icon btn-sm rounded-pill me-1"
-              title="Düzenle"
+              title="Detay"
             >
-              <i className="ti ti-pencil" />
+              <i className="ti ti-eye" />
             </Button>
 
             <Button

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -163,6 +163,12 @@ const OtherIncomeTable = lazy(
 const OtherIncomeCrud = lazy(
   () => import("../components/common/otherIncome/crud")
 );
+const OtherIncomeDetail = lazy(
+  () => import("../components/common/otherIncome/detail")
+);
+const RevenuesReceipt = lazy(
+  () => import("../components/common/otherIncome/revenuesReceipt")
+);
 // Meeting Crud Modal
 const MeetingCrud = lazy(
   () => import("../components/common/student/meetings/crud")
@@ -1772,6 +1778,21 @@ export const Routedata = [
         onRefresh={() => { }}
       />
     ),
+  },
+  {
+    id: 61,
+    path: `${import.meta.env.BASE_URL}other-income/detail/:id`,
+    element: (
+      <OtherIncomeDetail
+        show={true}
+        onClose={() => window.history.back()}
+      />
+    ),
+  },
+  {
+    id: 61,
+    path: `${import.meta.env.BASE_URL}revenuesReceipt/:id`,
+    element: <RevenuesReceipt />,
   },
   {
     id: 2000,


### PR DESCRIPTION
## Summary
- show details for other income items in a modal
- add receipt modal for other income payments
- replace edit button with eye icon to open detail
- wire new routes for detail and receipt

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684c5aa6a7b4832c88d90b3e9beab37c