### PR TITLE
Add modal for adding other income entries

### DIFF
--- a/src/components/common/customers/AddCustomerModal.tsx
+++ b/src/components/common/customers/AddCustomerModal.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { FormikHelpers } from 'formik';
+import ReusableModalForm, { FieldDefinition } from '../ReusableModalForm';
+
+interface CustomerFormValues {
+  name: string;
+  email?: string;
+  phone?: string;
+  iban?: string;
+  city?: string;
+  county?: string;
+  district?: string;
+  address?: string;
+  customer_type: 'tuzel' | 'gercek';
+  tax_number?: string;
+  tax_office?: string;
+  tc_no?: string;
+}
+
+interface AddCustomerModalProps {
+  show: boolean;
+  onClose: () => void;
+  onAdd: (customer: { id: number; name: string }) => void;
+}
+
+export default function AddCustomerModal({ show, onClose, onAdd }: AddCustomerModalProps) {
+  const initialValues: CustomerFormValues = {
+    name: '',
+    email: '',
+    phone: '',
+    iban: '',
+    city: '',
+    county: '',
+    district: '',
+    address: '',
+    customer_type: 'gercek',
+    tax_number: '',
+    tax_office: '',
+    tc_no: '',
+  };
+
+  const getFields = (values: CustomerFormValues): FieldDefinition[] => {
+    const base: FieldDefinition[] = [
+      { name: 'name', label: 'Firma/Kişi Adı', type: 'text', required: true },
+      { name: 'email', label: 'E-Posta', type: 'email' },
+      { name: 'phone', label: 'Telefon', type: 'phone' },
+      { name: 'iban', label: 'IBAN', type: 'iban' },
+      { name: 'city', label: 'İl', type: 'text' },
+      { name: 'county', label: 'İlçe', type: 'text' },
+      { name: 'district', label: 'Mahalle', type: 'text' },
+      { name: 'address', label: 'Adres', type: 'textarea' },
+      {
+        name: 'customer_type',
+        label: 'Müşteri Türü',
+        type: 'select',
+        options: [
+          { label: 'Tüzel Kişi', value: 'tuzel' },
+          { label: 'Gerçek Kişi', value: 'gercek' },
+        ],
+        required: true,
+      },
+    ];
+
+    if (values.customer_type === 'tuzel') {
+      base.push(
+        { name: 'tax_number', label: 'Vergi No', type: 'text', required: true },
+        { name: 'tax_office', label: 'Vergi Dairesi', type: 'text', required: true },
+      );
+    } else {
+      base.push({ name: 'tc_no', label: 'T.C. Kimlik No', type: 'text', required: true });
+    }
+
+    return base;
+  };
+
+  const handleSubmit = (
+    values: CustomerFormValues,
+    helpers: FormikHelpers<CustomerFormValues>,
+  ) => {
+    onAdd({ id: Date.now(), name: values.name });
+    helpers.setSubmitting(false);
+    onClose();
+  };
+
+  return (
+    <ReusableModalForm<CustomerFormValues>
+      show={show}
+      title="Müşteri Ekle"
+      fields={getFields}
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      onClose={onClose}
+      confirmButtonLabel="Kaydet"
+    />
+  );
+}

--- a/src/components/common/incomeItems/AddIncomeItemModal.tsx
+++ b/src/components/common/incomeItems/AddIncomeItemModal.tsx
@@ -1,0 +1,41 @@
+import { FormikHelpers } from 'formik';
+import ReusableModalForm, { FieldDefinition } from '../ReusableModalForm';
+
+interface IncomeItemFormValues {
+  name: string;
+}
+
+interface AddIncomeItemModalProps {
+  show: boolean;
+  onClose: () => void;
+  onAdd: (item: { id: number; name: string }) => void;
+}
+
+export default function AddIncomeItemModal({ show, onClose, onAdd }: AddIncomeItemModalProps) {
+  const initialValues: IncomeItemFormValues = { name: '' };
+
+  const fields: FieldDefinition[] = [
+    { name: 'name', label: 'Gelir Kalemi Adı', type: 'text', required: true },
+  ];
+
+  const handleSubmit = (
+    values: IncomeItemFormValues,
+    helpers: FormikHelpers<IncomeItemFormValues>,
+  ) => {
+    onAdd({ id: Date.now(), name: values.name });
+    helpers.setSubmitting(false);
+    onClose();
+  };
+
+  return (
+    <ReusableModalForm<IncomeItemFormValues>
+      show={show}
+      title="Gelir Kalemi Ekle"
+      fields={fields}
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      onClose={onClose}
+      confirmButtonLabel="Kaydet"
+    />
+  );
+}

--- a/src/components/common/otherIncome/AddOtherIncomeModal.tsx
+++ b/src/components/common/otherIncome/AddOtherIncomeModal.tsx
@@ -1,0 +1,148 @@
+import { useState } from 'react';
+import { FormikHelpers } from 'formik';
+import ReusableModalForm, { FieldDefinition } from '../ReusableModalForm';
+import { useSeasonsList } from '../../hooks/season/useSeasonsList';
+import { usePaymentMethodsList } from '../../hooks/paymentMethods/useList';
+import { useOtherIncomeAdd } from '../../hooks/otherIncome/useOtherIncomeAdd';
+import { OtherIncomeAddPayload } from '../../../types/otherIncome/add';
+import AddCustomerModal from '../customers/AddCustomerModal';
+import AddIncomeItemModal from '../incomeItems/AddIncomeItemModal';
+import { Button } from 'react-bootstrap';
+
+interface AddOtherIncomeModalProps {
+  show: boolean;
+  onClose: () => void;
+}
+
+export default function AddOtherIncomeModal({ show, onClose }: AddOtherIncomeModalProps) {
+  const { addNew, status, error } = useOtherIncomeAdd();
+  const { seasonsData } = useSeasonsList({ enabled: true, page: 1, paginate: 999 });
+  const { paymentMethodsData } = usePaymentMethodsList({ enabled: true });
+
+  const [customers, setCustomers] = useState<{ id: number; name: string }[]>([]);
+  const [incomeItems, setIncomeItems] = useState<{ id: number; name: string }[]>([]);
+
+  const [showCustomerModal, setShowCustomerModal] = useState(false);
+  const [showIncomeItemModal, setShowIncomeItemModal] = useState(false);
+
+  const initialValues: OtherIncomeAddPayload = {
+    season: '',
+    date: '',
+    customer_id: 0,
+    income_item: '',
+    payment_method: '',
+    amount: 0,
+    description: '',
+    other_income_category_id: undefined,
+  };
+
+  const getFields = (): FieldDefinition[] => [
+    {
+      name: 'season',
+      label: 'Sezon',
+      type: 'select',
+      options: seasonsData.map((s) => ({ label: s.name, value: s.name })),
+      required: true,
+    },
+    { name: 'date', label: 'Tarih', type: 'date', required: true },
+    {
+      name: 'customer_id',
+      label: 'Müşteri',
+      required: true,
+      renderForm: (formik) => (
+        <div style={{ display: 'flex' }}>
+          <select
+            className="form-select"
+            value={formik.values.customer_id}
+            onChange={(e) => formik.setFieldValue('customer_id', Number(e.target.value))}
+            style={{ flex: 1 }}
+          >
+            <option value="">Seçiniz</option>
+            {customers.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+          <Button variant="outline-secondary" onClick={() => setShowCustomerModal(true)} style={{ marginLeft: 8 }}>
+            <i className="ti ti-plus" />
+          </Button>
+        </div>
+      ),
+    },
+    {
+      name: 'income_item',
+      label: 'Gelir Kalemi',
+      required: true,
+      renderForm: (formik) => (
+        <div style={{ display: 'flex' }}>
+          <select
+            className="form-select"
+            value={formik.values.income_item}
+            onChange={(e) => formik.setFieldValue('income_item', e.target.value)}
+            style={{ flex: 1 }}
+          >
+            <option value="">Seçiniz</option>
+            {incomeItems.map((i) => (
+              <option key={i.id} value={i.name}>
+                {i.name}
+              </option>
+            ))}
+          </select>
+          <Button variant="outline-secondary" onClick={() => setShowIncomeItemModal(true)} style={{ marginLeft: 8 }}>
+            <i className="ti ti-plus" />
+          </Button>
+        </div>
+      ),
+    },
+    {
+      name: 'payment_method',
+      label: 'Ödeme Şekli',
+      type: 'select',
+      options: paymentMethodsData.map((pm) => ({ label: pm.name, value: pm.name })),
+    },
+    { name: 'amount', label: 'Tutar', type: 'currency', required: true },
+    { name: 'description', label: 'Açıklama', type: 'textarea' },
+  ];
+
+  const handleSubmit = async (
+    values: OtherIncomeAddPayload,
+    helpers: FormikHelpers<OtherIncomeAddPayload>,
+  ) => {
+    await addNew(values);
+    helpers.setSubmitting(false);
+    onClose();
+  };
+
+  return (
+    <>
+      <ReusableModalForm<OtherIncomeAddPayload>
+        show={show}
+        title="Farklı Gelir Ekle"
+        fields={getFields}
+        initialValues={initialValues}
+        onSubmit={handleSubmit}
+        onClose={onClose}
+        confirmButtonLabel="Kaydet"
+        isLoading={status === 'LOADING'}
+        error={error}
+      />
+
+      {showCustomerModal && (
+        <AddCustomerModal
+          show={showCustomerModal}
+          onClose={() => setShowCustomerModal(false)}
+          onAdd={(c) => setCustomers((prev) => [...prev, c])}
+        />
+      )}
+
+      {showIncomeItemModal && (
+        <AddIncomeItemModal
+          show={showIncomeItemModal}
+          onClose={() => setShowIncomeItemModal(false)}
+          onAdd={(i) => setIncomeItems((prev) => [...prev, i])}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/common/otherIncome/table.tsx
+++ b/src/components/common/otherIncome/table.tsx
@@ -10,12 +10,14 @@ import odemeAl from '../../../assets/images/media/ödeme-al.svg';
 import odemeAlHover from '../../../assets/images/media/ödeme-al-hover.svg';
 import { Button } from 'react-bootstrap';
 import GetPaidModal from './getPaid';
+import AddOtherIncomeModal from './AddOtherIncomeModal';
 
 export default function OtherIncomeTable() {
   const navigate = useNavigate();
   const { remove } = useOtherIncomeDelete();
 
   const [showPaymentModal, setShowPaymentModal] = useState(false);
+  const [showAddModal, setShowAddModal] = useState(false);
 
   const {
     otherIncomeData,
@@ -110,7 +112,7 @@ export default function OtherIncomeTable() {
     <div className="container-fluid mt-3">
       <Pageheader title="Gelirler" currentpage="Farklı Gelirler" />
       <ReusableTable<OtherIncomeData>
-        // ⛔ "onAdd" butonu kaldırıldı (ekle butonu)
+        onAdd={() => setShowAddModal(true)}
         columns={columns}
         data={otherIncomeData}
         loading={loading}
@@ -132,6 +134,13 @@ export default function OtherIncomeTable() {
         <GetPaidModal
           show={showPaymentModal}
           onClose={() => setShowPaymentModal(false)}
+        />
+      )}
+
+      {showAddModal && (
+        <AddOtherIncomeModal
+          show={showAddModal}
+          onClose={() => setShowAddModal(false)}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- implement `AddOtherIncomeModal` with season, customer, income item, payment, amount and description fields
- add supporting modals for creating customers and income items
- hook up add modal to `OtherIncomeTable`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: TypeScript errors due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684c64172d1c832cb77442c2cdaa29c8