### PR TITLE
Update other income modals

### DIFF
--- a/src/components/common/otherIncome/table.tsx
+++ b/src/components/common/otherIncome/table.tsx
@@ -127,6 +127,7 @@ export default function OtherIncomeTable() {
           setPaginate(newSize);
           setPage(1);
         }}
+        showExportButtons
         exportFileName="other-income"
       />
 


### PR DESCRIPTION
## Summary
- enable export buttons for OtherIncome table
- redesign OtherIncome CRUD modal with selectable fields and nested modals

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684c7614834c832c9fb9ab67b14040aa