### PR TITLE
Add incoming checks table and CRUD modals

### DIFF
--- a/src/components/common/incomingChecks/crud.tsx
+++ b/src/components/common/incomingChecks/crud.tsx
@@ -1,0 +1,259 @@
+import { useState } from "react";
+import { Modal, Button, Table } from "react-bootstrap";
+import { FormikHelpers, FormikValues } from "formik";
+import ReusableModalForm, { FieldDefinition } from "../ReusableModalForm";
+import { IncomingCheck } from "./table";
+
+interface FormValues extends FormikValues {
+  paymentTarget: "student" | "customer";
+  branch: string;
+  student: string;
+  creditor: string;
+  type: string;
+  date: string;
+  bank: string;
+  documentNo: string;
+  amountDue: number | string;
+  amountPaid: number | string;
+  remaining: number | string;
+  status: string;
+  swapCheckType: string;
+  swapBuyer: string;
+  description: string;
+  image: string;
+}
+
+export function IncomingCheckFormModal({
+  show,
+  onClose,
+  onSubmit,
+  initialValues,
+}: {
+  show: boolean;
+  onClose: () => void;
+  onSubmit: (val: IncomingCheck) => void;
+  initialValues?: IncomingCheck;
+}) {
+  const defaults: FormValues = {
+    paymentTarget: "student",
+    branch: "",
+    student: "",
+    creditor: "",
+    type: "Çek",
+    date: new Date().toISOString().split("T")[0],
+    bank: "",
+    documentNo: "",
+    amountDue: "",
+    amountPaid: "",
+    remaining: "",
+    status: "",
+    swapCheckType: "",
+    swapBuyer: "",
+    description: "",
+    image: "",
+    ...(initialValues || {}),
+  } as any;
+
+  const getFields = (values: FormValues): FieldDefinition[] => {
+    const fields: FieldDefinition[] = [
+      {
+        name: "paymentTarget",
+        label: "Ödeme Tipi",
+        type: "select",
+        options: [
+          { value: "student", label: "Öğrenci Ödeme" },
+          { value: "customer", label: "Müşteri" },
+        ],
+      },
+      { name: "branch", label: "Şube", type: "text", required: true },
+    ];
+    if (values.paymentTarget === "student") {
+      fields.push({ name: "student", label: "Öğrenci", type: "text", required: true });
+    }
+    fields.push(
+      { name: "creditor", label: "Verecekli", type: "text", required: true },
+      { name: "type", label: "Türü", type: "select", options: [ {value: "Çek", label: "Çek"}, {value: "Senet", label: "Senet"} ], required: true },
+      { name: "date", label: "Tarih", type: "date", required: true },
+      { name: "bank", label: "Alıcı Banka", type: "text" },
+      { name: "documentNo", label: "Belge No", type: "text" },
+      { name: "amountDue", label: "Ödenecek Tutar", type: "currency", required: true },
+      { name: "amountPaid", label: "Ödenen Tutar", type: "currency" },
+      { name: "remaining", label: "Kalan Tutar", type: "currency" },
+      {
+        name: "status",
+        label: "Durum",
+        type: "select",
+        options: [
+          { value: "paid", label: "Ödendi" },
+          { value: "not_paid", label: "Ödenmedi" },
+          { value: "pending", label: "Beklemede" },
+          { value: "cashed", label: "Bozduruldu" },
+          { value: "swapped", label: "Swap Edildi" },
+        ],
+      }
+    );
+    if (values.status === "swapped") {
+      fields.push(
+        { name: "swapCheckType", label: "Çek Türü", type: "text" },
+        { name: "swapBuyer", label: "Alıcı", type: "text" },
+      );
+    }
+    fields.push({ name: "description", label: "Açıklama", type: "textarea" });
+    fields.push({ name: "image", label: "Görüntü", type: "file" });
+    return fields;
+  };
+
+  const handleSubmit = (values: FormValues, helpers: FormikHelpers<FormValues>) => {
+    const val: IncomingCheck = {
+      id: initialValues?.id || Date.now(),
+      company: values.paymentTarget === "student" ? values.student : values.branch,
+      creditor: values.creditor,
+      type: values.type,
+      date: values.date,
+      bank: values.bank,
+      amountDue: Number(values.amountDue) || 0,
+      amountPaid: Number(values.amountPaid) || 0,
+      remaining: Number(values.remaining) || 0,
+      description: values.description,
+      status: values.status,
+    };
+    onSubmit(val);
+    helpers.setSubmitting(false);
+  };
+
+  return (
+    <ReusableModalForm<FormValues>
+      show={show}
+      title={initialValues ? "Düzenle" : "Ekle"}
+      fields={getFields}
+      initialValues={defaults}
+      onSubmit={handleSubmit}
+      onClose={onClose}
+      confirmButtonLabel="Kaydet"
+    />
+  );
+}
+
+export function IncomingCheckDetailModal({ show, onClose, check }: { show: boolean; onClose: () => void; check: IncomingCheck; }) {
+  return (
+    <Modal show={show} onHide={onClose} centered>
+      <Modal.Header closeButton>
+        <Modal.Title>Detay</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Table bordered size="sm">
+          <tbody>
+            <tr><th>Firma</th><td>{check.company}</td></tr>
+            <tr><th>Verecekli</th><td>{check.creditor}</td></tr>
+            <tr><th>Türü</th><td>{check.type}</td></tr>
+            <tr><th>Tarih</th><td>{check.date}</td></tr>
+            <tr><th>Alıcı Banka</th><td>{check.bank}</td></tr>
+            <tr><th>Ödenecek</th><td>{check.amountDue}</td></tr>
+            <tr><th>Ödenen</th><td>{check.amountPaid}</td></tr>
+            <tr><th>Kalan</th><td>{check.remaining}</td></tr>
+            <tr><th>Açıklama</th><td>{check.description}</td></tr>
+            <tr><th>Durum</th><td>{check.status}</td></tr>
+          </tbody>
+        </Table>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={onClose}>Kapat</Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}
+
+export function IncomingCheckCashModal({ show, onClose }: { show: boolean; onClose: () => void }) {
+  const [mode, setMode] = useState<"cash" | "bank">("cash");
+  const fields: FieldDefinition[] = mode === "cash" ? [
+    { name: "amount", label: "Tutar", type: "currency", required: true },
+    { name: "expense", label: "Gider", type: "currency" },
+    { name: "transactionNo", label: "İşlem No", type: "text" },
+    { name: "safe", label: "Kasa", type: "text" },
+    { name: "date", label: "Tarih", type: "date" },
+    { name: "description", label: "Açıklama", type: "textarea" },
+  ] : [
+    { name: "amount", label: "Tutar", type: "currency", required: true },
+    { name: "expense", label: "Gider", type: "currency" },
+    { name: "transactionNo", label: "İşlem No", type: "text" },
+    { name: "bankAccount", label: "Banka Hesabı", type: "text" },
+    { name: "date", label: "Tarih", type: "date" },
+    { name: "description", label: "Açıklama", type: "textarea" },
+  ];
+
+  return (
+    <Modal show={show} onHide={onClose} centered size="lg">
+      <Modal.Header closeButton>
+        <Modal.Title>Bozdur</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <div className="mb-3">
+          <label className="me-3">
+            <input type="radio" checked={mode === "cash"} onChange={() => setMode("cash")}/> Nakit
+          </label>
+          <label>
+            <input type="radio" checked={mode === "bank"} onChange={() => setMode("bank")}/> Banka Hesabına
+          </label>
+        </div>
+        <ReusableModalForm<FormikValues>
+          show={true}
+          title=""
+          fields={fields}
+          initialValues={{}}
+          onSubmit={() => {}}
+          onClose={onClose}
+          confirmButtonLabel="Kaydet"
+          hideButtons
+        />
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={onClose}>Kapat</Button>
+        <Button variant="primary" onClick={onClose}>Kaydet</Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}
+
+export function IncomingCheckPaymentModal({ show, onClose }: { show: boolean; onClose: () => void }) {
+  const [payments, setPayments] = useState<any[]>([]);
+
+  const addPayment = (p: any) => setPayments((prev) => [...prev, p]);
+
+  return (
+    <Modal show={show} onHide={onClose} centered size="lg">
+      <Modal.Header closeButton>
+        <Modal.Title>Ödeme</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Button className="mb-2" onClick={() => addPayment({ id: Date.now(), date: new Date().toISOString().split("T")[0], amount: 0 })}>Ekle</Button>
+        <Table bordered size="sm">
+          <thead>
+            <tr>
+              <th>Tarih</th>
+              <th>Ödenen Tutar</th>
+              <th>Ödeme Yapan</th>
+              <th>Makbuz No</th>
+              <th>Kullanıcı</th>
+              <th>Açıklama</th>
+            </tr>
+          </thead>
+          <tbody>
+            {payments.map((p) => (
+              <tr key={p.id}>
+                <td>{p.date}</td>
+                <td>{p.amount}</td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td></td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={onClose}>Kapat</Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/components/common/incomingChecks/table.tsx
+++ b/src/components/common/incomingChecks/table.tsx
@@ -1,0 +1,166 @@
+import { useState, useMemo } from "react";
+import { Button } from "react-bootstrap";
+import ReusableTable, { ColumnDefinition, FilterDefinition } from "../ReusableTable";
+import { IncomingCheckFormModal, IncomingCheckDetailModal, IncomingCheckCashModal, IncomingCheckPaymentModal } from "./crud";
+
+export interface IncomingCheck {
+  id: number;
+  company: string;
+  creditor: string;
+  type: string;
+  date: string;
+  bank: string;
+  amountDue: number;
+  amountPaid: number;
+  remaining: number;
+  description: string;
+  status: string;
+}
+
+const dummyData: IncomingCheck[] = [
+  {
+    id: 1,
+    company: "ABC Ltd",
+    creditor: "John Doe",
+    type: "Çek",
+    date: "2024-01-01",
+    bank: "Ziraat",
+    amountDue: 1000,
+    amountPaid: 300,
+    remaining: 700,
+    description: "",
+    status: "Beklemede",
+  },
+];
+
+export default function IncomingChecksTable() {
+  const [data, setData] = useState<IncomingCheck[]>(dummyData);
+  const [selected, setSelected] = useState<IncomingCheck | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [showDetail, setShowDetail] = useState(false);
+  const [showCash, setShowCash] = useState(false);
+  const [showPayment, setShowPayment] = useState(false);
+
+  const [filterCompany, setFilterCompany] = useState("");
+  const [filterCreditor, setFilterCreditor] = useState("");
+  const [filterType, setFilterType] = useState("");
+  const [filterBank, setFilterBank] = useState("");
+
+  const filteredData = useMemo(() => {
+    return data.filter((row) =>
+      (!filterCompany || row.company.includes(filterCompany)) &&
+      (!filterCreditor || row.creditor.includes(filterCreditor)) &&
+      (!filterType || row.type === filterType) &&
+      (!filterBank || row.bank.includes(filterBank))
+    );
+  }, [data, filterCompany, filterCreditor, filterType, filterBank]);
+
+  const columns: ColumnDefinition<IncomingCheck>[] = useMemo(
+    () => [
+      { key: "company", label: "Firma" },
+      { key: "creditor", label: "Verecekli" },
+      { key: "type", label: "Türü" },
+      { key: "date", label: "Tarih" },
+      { key: "bank", label: "Alıcı Banka" },
+      {
+        key: "amountDue",
+        label: "Ödenecek",
+        render: (row) => row.amountDue.toLocaleString(),
+      },
+      {
+        key: "amountPaid",
+        label: "Ödenen",
+        render: (row) => row.amountPaid.toLocaleString(),
+      },
+      {
+        key: "remaining",
+        label: "Kalan",
+        render: (row) => row.remaining.toLocaleString(),
+      },
+      { key: "description", label: "Açıklama" },
+      { key: "status", label: "Durum" },
+      {
+        key: "actions",
+        label: "İşlemler",
+        render: (row) => (
+          <>
+            <Button size="sm" variant="primary" onClick={() => {setSelected(row);setShowDetail(true);}}>
+              Detay
+            </Button>{" "}
+            <Button size="sm" variant="success" onClick={() => {setSelected(row);setShowCash(true);}}>
+              Bozdur
+            </Button>{" "}
+            <Button size="sm" variant="warning" onClick={() => {setSelected(row);setShowPayment(true);}}>
+              Ödeme
+            </Button>{" "}
+            <Button size="sm" variant="info" onClick={() => {setSelected(row);setShowForm(true);}}>
+              Düzenle
+            </Button>{" "}
+            <Button size="sm" variant="danger" onClick={() => setData(d=>d.filter(x=>x.id!==row.id))}>
+              Sil
+            </Button>
+          </>
+        ),
+      },
+    ],
+    []
+  );
+
+  const filters: FilterDefinition[] = [
+    { key: "company", label: "Firma", type: "text", value: filterCompany, onChange: setFilterCompany },
+    { key: "creditor", label: "Verecekli", type: "text", value: filterCreditor, onChange: setFilterCreditor },
+    {
+      key: "type",
+      label: "Türü",
+      type: "select",
+      value: filterType,
+      onChange: setFilterType,
+      options: [
+        { value: "Çek", label: "Çek" },
+        { value: "Senet", label: "Senet" },
+      ],
+    },
+    { key: "bank", label: "Alıcı Banka", type: "text", value: filterBank, onChange: setFilterBank },
+  ];
+
+  return (
+    <div className="container-fluid mt-3">
+      <ReusableTable<IncomingCheck>
+        columns={columns}
+        data={filteredData}
+        filters={filters}
+        onAdd={() => { setSelected(null); setShowForm(true); }}
+        addButtonText="Ekle"
+        tableMode="single"
+      />
+
+      {showForm && (
+        <IncomingCheckFormModal
+          show={showForm}
+          onClose={() => setShowForm(false)}
+          initialValues={selected || undefined}
+          onSubmit={(val) => {
+            if (selected) {
+              setData((prev) => prev.map((d) => (d.id === selected.id ? { ...val, id: selected.id } : d)));
+            } else {
+              setData((prev) => [...prev, { ...val, id: Date.now() }]);
+            }
+            setShowForm(false);
+          }}
+        />
+      )}
+
+      {showDetail && selected && (
+        <IncomingCheckDetailModal check={selected} show={showDetail} onClose={() => setShowDetail(false)} />
+      )}
+
+      {showCash && selected && (
+        <IncomingCheckCashModal show={showCash} onClose={() => setShowCash(false)} />
+      )}
+
+      {showPayment && selected && (
+        <IncomingCheckPaymentModal show={showPayment} onClose={() => setShowPayment(false)} />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create incoming checks table with filters and actions
- implement modal forms for adding/editing incoming checks
- add detail, cash and payment placeholder modals

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684d16bc81d8832c99c63781c8067630