### PR TITLE
Add incoming checks routes

### DIFF
--- a/src/components/sidebar/nav.tsx
+++ b/src/components/sidebar/nav.tsx
@@ -264,7 +264,7 @@ export const MENUITEMS: any = [
         title: "Çek Yönetimi",
         type: "sub",
         children: [
-          { title: "Gelen", path: "/checksandpromissory", type: "link" },
+          { title: "Gelen", path: "/incomingChecks", type: "link" },
           { title: "Giden", path: "/checksandpromissory", type: "link" },
         ],
       },

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -79,6 +79,10 @@ const SchoolTypeModal = lazy(
 const Checksandpromissory = lazy(
   () => import("../components/common/checksandpromissory/crud")
 );
+import IncomingChecksTable from "../components/common/incomingChecks/table";
+const IncomingChecksCrud = lazy(
+  () => import("../components/common/incomingChecks/crud")
+);
 
 const OverduePaymentDetailPage = lazy(
   () => import("../components/common/overduePayments/detail")
@@ -1747,6 +1751,24 @@ export const Routedata = [
     id: 67,
     path: `${import.meta.env.BASE_URL}checksandpromissory`,
     element: <ChecksAndPromissoryTable />,
+  },
+
+  {
+    id: 67,
+    path: `${import.meta.env.BASE_URL}incomingChecks`,
+    element: <IncomingChecksTable />,
+  },
+
+  {
+    id: 61,
+    path: `${import.meta.env.BASE_URL}incomingChecksCrud/:id?`,
+    element: (
+      <IncomingChecksCrud
+        show={true}
+        onClose={() => window.history.back()}
+        onRefresh={() => {}}
+      />
+    ),
   },
 
   {


### PR DESCRIPTION
## Summary
- show incomingChecks table from sidebar
- register incomingChecks pages in routing

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: ts errors, missing declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684d233ad8ac832c9a284fa511c4a527