### PR TITLE
Fix address error in other income table

### DIFF
--- a/src/types/otherIncome/list.tsx
+++ b/src/types/otherIncome/list.tsx
@@ -5,6 +5,7 @@ export interface OtherIncomeCustomer {
   name: string;
   email?: string;
   phone?: string;
+  address?: string;
 }
 
 export interface OtherIncomeData {


### PR DESCRIPTION
## Summary
- add `address` field to `OtherIncomeCustomer` interface

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684d38306808832caecd7ca2a327581c