### PR TITLE
Add supplier detail modal for expenses

### DIFF
--- a/src/components/common/expences/main/table.tsx
+++ b/src/components/common/expences/main/table.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import SupplierDetailModal from "../../supplier/supplierDetail/DetailModal";
 import ReusableTable, {
   ColumnDefinition,
 } from "../../ReusableTable";
@@ -37,6 +38,9 @@ export default function ExpenseListPage() {
     category: false,
     supplier: false,
   });
+
+  const [showSupplierModal, setShowSupplierModal] = useState(false);
+  const [selectedSupplier, setSelectedSupplier] = useState<number | null>(null);
 
   const { seasonsData } = useSeasonsList({ enabled: filtersEnabled.season, page: 1, paginate: 100 });
   const { branchData } = useBranchTable({ enabled: filtersEnabled.branch });
@@ -137,7 +141,10 @@ export default function ExpenseListPage() {
         render: (row, openDeleteModal) => (
           <>
             <button
-              onClick={() => navigate(`/supplierdetail/${row.supplier_id}`)}
+              onClick={() => {
+                setSelectedSupplier(row.supplier_id);
+                setShowSupplierModal(true);
+              }}
               className="btn btn-icon btn-sm btn-primary-light rounded-pill"
             >
               <i className="ti ti-eye" />
@@ -275,6 +282,11 @@ export default function ExpenseListPage() {
         onDeleteRow={(row) => {
           removeExpence(Number(row.id));
         }}
+      />
+      <SupplierDetailModal
+        show={showSupplierModal}
+        supplierId={selectedSupplier || undefined}
+        onClose={() => setShowSupplierModal(false)}
       />
     </div>
   );

--- a/src/components/common/supplier/supplierDetail/DetailModal.tsx
+++ b/src/components/common/supplier/supplierDetail/DetailModal.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { Modal } from "react-bootstrap";
+import TabsContainer from "../../guidance/components/organisms/TabsContainer";
+import SupplierOverviewTab from "./tabs/supplierSummery";
+import SupplierInvoiceTab from "./tabs/invoice/table";
+import SupplierDebtTab from "./tabs/debts/table";
+import SupplierRefundTab from "./tabs/refunds/table";
+import SupplierPaymentTab from "./tabs/payments/table";
+import SupplierNotesTab from "./tabs/notes/table";
+import { useSupplierShow } from "../../../hooks/suppliers/useSuppliersShow";
+
+interface SupplierDetailModalProps {
+  show: boolean;
+  supplierId?: number;
+  onClose: () => void;
+}
+
+export default function SupplierDetailModal({
+  show,
+  supplierId,
+  onClose,
+}: SupplierDetailModalProps) {
+  const { id } = useParams<{ id?: string }>();
+  const { supplier: fetchedSupplier, getSupplier } = useSupplierShow();
+  const [activeTab, setActiveTab] = useState<number>(0);
+
+  const finalId = id || (supplierId ? String(supplierId) : undefined);
+
+  useEffect(() => {
+    if (finalId) {
+      getSupplier(finalId);
+    }
+  }, [finalId, getSupplier]);
+
+  const numericId = finalId ? Number(finalId) : 0;
+
+  const tabsConfig = [
+    {
+      label: "Finansal Özet",
+      content: <SupplierOverviewTab supplierId={numericId} />,
+      activeBgColor: "#5C67F7",
+      activeTextColor: "#FFFFFF",
+      passiveBgColor: "#5C67F726",
+      passiveTextColor: "#5C67F7",
+    },
+    {
+      label: "Fatura",
+      content: (
+        <SupplierInvoiceTab supplierId={numericId} enabled={activeTab === 1} />
+      ),
+      activeBgColor: "#5C67F7",
+      activeTextColor: "#FFFFFF",
+      passiveBgColor: "#5C67F726",
+      passiveTextColor: "#5C67F7",
+    },
+    {
+      label: "Borçlar",
+      content: <SupplierDebtTab supplierId={numericId} enabled={activeTab === 2} />,
+      activeBgColor: "#5C67F7",
+      activeTextColor: "#FFFFFF",
+      passiveBgColor: "#5C67F726",
+      passiveTextColor: "#5C67F7",
+    },
+    {
+      label: "İadeler",
+      content: (
+        <SupplierRefundTab supplierId={numericId} enabled={activeTab === 3} />
+      ),
+      activeBgColor: "#5C67F7",
+      activeTextColor: "#FFFFFF",
+      passiveBgColor: "#5C67F726",
+      passiveTextColor: "#5C67F7",
+    },
+    {
+      label: "Ödemeler",
+      content: (
+        <SupplierPaymentTab supplierId={numericId} enabled={activeTab === 4} />
+      ),
+      activeBgColor: "#5C67F7",
+      activeTextColor: "#FFFFFF",
+      passiveBgColor: "#5C67F726",
+      passiveTextColor: "#5C67F7",
+    },
+    {
+      label: "Notlar",
+      content: <SupplierNotesTab supplierId={numericId} enabled={activeTab === 5} />,
+      activeBgColor: "#5C67F7",
+      activeTextColor: "#FFFFFF",
+      passiveBgColor: "#5C67F726",
+      passiveTextColor: "#5C67F7",
+    },
+  ];
+
+  return (
+    <Modal show={show} onHide={onClose} size="lg" centered>
+      <Modal.Header closeButton>
+        <Modal.Title>{fetchedSupplier?.name || ""}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <TabsContainer
+          tabs={tabsConfig}
+          onTabChange={(pIndex) => setActiveTab(pIndex)}
+        />
+      </Modal.Body>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary
- create `SupplierDetailModal` component
- show supplier detail modal when clicking view button in expenses table

## Testing
- `npm run build` *(fails: cannot find module 'vite')*
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_684d3cb634f8832c91beff379370fef4