### PR TITLE
Add check management tabs

### DIFF
--- a/src/components/common/checkManagement/index.tsx
+++ b/src/components/common/checkManagement/index.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import TabsContainer from '../daily/component/organisms/TabsContainer';
+import Pageheader from '../../page-header/pageheader';
+import IncomingChecksTable from '../incomingChecks/table';
+import ChecksAndPromissoryTable from '../checksandpromissory/table';
+
+const CheckManagementIndex: React.FC = () => {
+  const [activeIdx, setActiveIdx] = useState<number>(0);
+
+  const tabs = [
+    {
+      label: 'Gelen Çekler',
+      content: <IncomingChecksTable />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#5C67F726',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Giden Çekler',
+      content: <ChecksAndPromissoryTable />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#5C67F726',
+      passiveTextColor: '#5C67F7',
+    },
+  ];
+
+  return (
+    <div className="px-4">
+      <Pageheader title="Çek Yönetimi" currentpage={tabs[activeIdx].label} />
+      <TabsContainer tabs={tabs} onTabChange={(idx) => setActiveIdx(idx)} />
+    </div>
+  );
+};
+
+export default CheckManagementIndex;

--- a/src/components/sidebar/nav.tsx
+++ b/src/components/sidebar/nav.tsx
@@ -262,11 +262,8 @@ export const MENUITEMS: any = [
       },
       {
         title: "Çek Yönetimi",
-        type: "sub",
-        children: [
-          { title: "Gelen", path: "/incomingChecks", type: "link" },
-          { title: "Giden", path: "/checksandpromissory", type: "link" },
-        ],
+        path: "/checkManagement",
+        type: "link",
       },
       {
         title: "Personel Yönetimi",

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -84,6 +84,10 @@ const IncomingChecksCrud = lazy(
   () => import("../components/common/incomingChecks/crud")
 );
 
+const CheckManagementIndex = lazy(
+  () => import("../components/common/checkManagement")
+);
+
 const OverduePaymentDetailPage = lazy(
   () => import("../components/common/overduePayments/detail")
 );
@@ -1746,6 +1750,11 @@ export const Routedata = [
     id: 67,
     path: `${import.meta.env.BASE_URL}assignmentsCount/index`,
     element: <AssignmentsCountPage />,
+  },
+  {
+    id: 67,
+    path: `${import.meta.env.BASE_URL}checkManagement`,
+    element: <CheckManagementIndex />,
   },
   {
     id: 67,


### PR DESCRIPTION
## Summary
- combine incoming and outgoing checks under new Check Management tab page
- link new page from sidebar
- expose new route for Check Management

## Testing
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_684d42de5900832ca92a87bdc8757380