### PR TITLE
Add checks and promissory table

### DIFF
--- a/src/Route/routingdata.tsx
+++ b/src/Route/routingdata.tsx
@@ -314,6 +314,9 @@ const SeasonsListPage = lazy(
   () => import("../components/common/seasons/table")
 );
 const SeasonModal = lazy(() => import("../components/common/seasons/crud"));
+const ChecksPromissoryTable = lazy(
+  () => import("../components/common/checksandpromissory/table")
+);
 
 //assignmentStudents 
 
@@ -511,6 +514,11 @@ export const Routedata = [
     id: 2,
     path: `${import.meta.env.BASE_URL}OverduePayments`,
     element: <OverduePaymentsPage />,
+  },
+  {
+    id: 16,
+    path: `${import.meta.env.BASE_URL}checks-promissory`,
+    element: <ChecksPromissoryTable />,
   },
   {
     id: 2,

--- a/src/components/common/checksandpromissory/crud.tsx
+++ b/src/components/common/checksandpromissory/crud.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import ReusableModalForm, { FieldDefinition } from "../ReusableModalForm";
+import { CheckRecord } from "../../../types/checksandpromissory/list";
+
+interface CheckCrudProps {
+  show: boolean;
+  onClose: () => void;
+  onSave: (record: CheckRecord) => void;
+  record?: CheckRecord | null;
+}
+
+export default function CheckCrud({ show, onClose, onSave, record }: CheckCrudProps) {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id?: string }>();
+  const isEdit = Boolean(id);
+
+  const [initialValues, setInitialValues] = useState<CheckRecord>({
+    id: 0,
+    check_type: "",
+    owner: "",
+    company: "",
+    debtor: "",
+    creditor: "",
+    creditor_phone: "",
+    kind: "",
+    date: new Date().toISOString().split("T")[0],
+    recipient_bank: "",
+    document_no: "",
+    payable_amount: 0,
+    paid_amount: 0,
+    remaining_amount: 0,
+    status: "Beklemede",
+    description: "",
+    image: null,
+    payments: [],
+  });
+
+  useEffect(() => {
+    if (record) {
+      setInitialValues(record);
+    }
+  }, [record]);
+
+  const fields: FieldDefinition[] = [
+    { name: "check_type", label: "Çek Türü", type: "text", required: true },
+    { name: "owner", label: "Çek Sahibi", type: "text", required: true },
+    { name: "company", label: "Firma", type: "text" },
+    { name: "debtor", label: "Verecekli", type: "text" },
+    { name: "creditor", label: "Alacaklı", type: "text" },
+    { name: "creditor_phone", label: "Alacaklı Tel", type: "phone" },
+    { name: "kind", label: "Türü", type: "text" },
+    { name: "date", label: "Tarih", type: "date", required: true },
+    { name: "recipient_bank", label: "Alıcı Banka", type: "text" },
+    { name: "document_no", label: "Belge No", type: "text" },
+    { name: "payable_amount", label: "Ödenecek Tutar", type: "number" },
+    { name: "paid_amount", label: "Ödenen Tutar", type: "number" },
+    { name: "remaining_amount", label: "Kalan Tutar", type: "number" },
+    {
+      name: "status",
+      label: "Durum",
+      type: "select",
+      options: [
+        { label: "Ödendi", value: "Ödendi" },
+        { label: "Ödenmedi", value: "Ödenmedi" },
+        { label: "Beklemede", value: "Beklemede" },
+      ],
+    },
+    { name: "description", label: "Açıklama", type: "textarea" },
+    { name: "image", label: "Görüntü", type: "file" },
+  ];
+
+  const handleSubmit = (values: CheckRecord) => {
+    const newRecord: CheckRecord = {
+      ...values,
+      id: record ? record.id : Date.now(),
+      payments: record ? record.payments : [],
+    };
+    onSave(newRecord);
+    onClose();
+    navigate(-1);
+  };
+
+  return (
+    <ReusableModalForm<CheckRecord>
+      show={show}
+      title={isEdit ? "Güncelle" : "Ekle"}
+      fields={fields}
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      confirmButtonLabel={isEdit ? "Güncelle" : "Ekle"}
+      cancelButtonLabel="Kapat"
+      onClose={() => {
+        onClose();
+        navigate(-1);
+      }}
+      autoGoBackOnModalClose
+      mode="single"
+    />
+  );
+}

--- a/src/components/common/checksandpromissory/detail.tsx
+++ b/src/components/common/checksandpromissory/detail.tsx
@@ -1,0 +1,55 @@
+import { Modal, Button, Table } from "react-bootstrap";
+import { CheckRecord } from "../../../types/checksandpromissory/list";
+
+interface DetailProps {
+  show: boolean;
+  onClose: () => void;
+  record: CheckRecord | null;
+}
+
+export default function CheckDetail({ show, onClose, record }: DetailProps) {
+  if (!record) return null;
+
+  const rows = [
+    ["Çek Türü", record.check_type],
+    ["Çek Sahibi", record.owner],
+    ["Firma", record.company],
+    ["Verecekli", record.debtor],
+    ["Alacaklı", record.creditor],
+    ["Alacaklı Tel", record.creditor_phone],
+    ["Türü", record.kind],
+    ["Tarih", record.date],
+    ["Alıcı Banka", record.recipient_bank],
+    ["Belge No", record.document_no],
+    ["Ödenecek Tutar", String(record.payable_amount)],
+    ["Ödenen Tutar", String(record.paid_amount)],
+    ["Kalan Tutar", String(record.remaining_amount)],
+    ["Durum", record.status],
+    ["Açıklama", record.description],
+  ];
+
+  return (
+    <Modal show={show} onHide={onClose} size="lg" centered>
+      <Modal.Header closeButton>
+        <Modal.Title>Detay</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Table bordered>
+          <tbody>
+            {rows.map(([label, value]) => (
+              <tr key={label as string}>
+                <th>{label}</th>
+                <td>{value}</td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={onClose}>
+          Kapat
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/components/common/checksandpromissory/paymentCrud.tsx
+++ b/src/components/common/checksandpromissory/paymentCrud.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import ReusableModalForm, { FieldDefinition } from "../ReusableModalForm";
+import { PaymentRecord } from "../../../types/checksandpromissory/list";
+
+interface PaymentCrudProps {
+  show: boolean;
+  onClose: () => void;
+  onSave: (payment: PaymentRecord) => void;
+  payment?: PaymentRecord | null;
+}
+
+export default function PaymentCrud({ show, onClose, onSave, payment }: PaymentCrudProps) {
+  const [initialValues, setInitialValues] = useState<PaymentRecord>({
+    id: 0,
+    date: new Date().toISOString().split("T")[0],
+    amount_paid: 0,
+    payer: "",
+    receipt_no: "",
+    user: "",
+    description: "",
+  });
+
+  useEffect(() => {
+    if (payment) setInitialValues(payment);
+  }, [payment]);
+
+  const fields: FieldDefinition[] = [
+    { name: "date", label: "Tarih", type: "date", required: true },
+    { name: "amount_paid", label: "Ödenen Tutar", type: "number", required: true },
+    { name: "payer", label: "Ödeme Yapan", type: "text" },
+    { name: "receipt_no", label: "Makbuz No", type: "text" },
+    { name: "user", label: "Kullanıcı", type: "text" },
+    { name: "description", label: "Açıklama", type: "textarea" },
+  ];
+
+  const handleSubmit = (values: PaymentRecord) => {
+    const newPayment: PaymentRecord = {
+      ...values,
+      id: payment ? payment.id : Date.now(),
+    };
+    onSave(newPayment);
+    onClose();
+  };
+
+  return (
+    <ReusableModalForm<PaymentRecord>
+      show={show}
+      title={payment ? "Güncelle" : "Ekle"}
+      fields={fields}
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      confirmButtonLabel={payment ? "Güncelle" : "Ekle"}
+      cancelButtonLabel="Kapat"
+      onClose={onClose}
+      mode="single"
+    />
+  );
+}

--- a/src/components/common/checksandpromissory/paymentModal.tsx
+++ b/src/components/common/checksandpromissory/paymentModal.tsx
@@ -1,0 +1,105 @@
+import { useMemo, useState } from "react";
+import { Modal, Button } from "react-bootstrap";
+import ReusableTable, { ColumnDefinition } from "../ReusableTable";
+import { PaymentRecord } from "../../../types/checksandpromissory/list";
+import PaymentCrud from "./paymentCrud";
+
+interface PaymentModalProps {
+  show: boolean;
+  payments: PaymentRecord[];
+  onClose: () => void;
+  onChange: (payments: PaymentRecord[]) => void;
+}
+
+export default function PaymentModal({ show, payments, onClose, onChange }: PaymentModalProps) {
+  const [data, setData] = useState<PaymentRecord[]>(payments);
+  const [showCrud, setShowCrud] = useState(false);
+  const [editing, setEditing] = useState<PaymentRecord | null>(null);
+
+  const columns: ColumnDefinition<PaymentRecord>[] = useMemo(
+    () => [
+      { key: "date", label: "Tarih" },
+      { key: "amount_paid", label: "Ödenen Tutar" },
+      { key: "payer", label: "Ödeme Yapan" },
+      { key: "receipt_no", label: "Makbuz No" },
+      { key: "user", label: "Kullanıcı" },
+      { key: "description", label: "Açıklama" },
+      {
+        key: "actions",
+        label: "İşlemler",
+        render: (row) => (
+          <>
+            <button
+              className="btn btn-icon btn-sm btn-info-light rounded-pill"
+              onClick={() => {
+                setEditing(row);
+                setShowCrud(true);
+              }}
+            >
+              <i className="ti ti-pencil" />
+            </button>
+            <button
+              className="btn btn-icon btn-sm btn-danger-light rounded-pill"
+              onClick={() => handleDelete(row.id)}
+            >
+              <i className="ti ti-trash" />
+            </button>
+          </>
+        ),
+      },
+    ],
+    []
+  );
+
+  const handleDelete = (id: number) => {
+    if (!window.confirm("Silmek istediğinize emin misiniz?")) return;
+    const newData = data.filter((p) => p.id !== id);
+    setData(newData);
+    onChange(newData);
+  };
+
+  const handleSave = (payment: PaymentRecord) => {
+    let newData = [] as PaymentRecord[];
+    if (editing) {
+      newData = data.map((p) => (p.id === payment.id ? payment : p));
+    } else {
+      newData = [...data, payment];
+    }
+    setData(newData);
+    onChange(newData);
+  };
+
+  return (
+    <>
+      <Modal show={show} onHide={onClose} size="lg" centered>
+        <Modal.Header closeButton>
+          <Modal.Title>Ödeme Kayıtları</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <ReusableTable<PaymentRecord>
+            tableMode="single"
+            columns={columns}
+            data={data}
+            onAdd={() => {
+              setEditing(null);
+              setShowCrud(true);
+            }}
+          />
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={onClose}>
+            Kapat
+          </Button>
+        </Modal.Footer>
+      </Modal>
+      {showCrud && (
+        <PaymentCrud
+          show={showCrud}
+          onClose={() => setShowCrud(false)}
+          onSave={handleSave}
+          payment={editing || undefined}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/common/checksandpromissory/table.tsx
+++ b/src/components/common/checksandpromissory/table.tsx
@@ -1,0 +1,153 @@
+import { useMemo, useState } from "react";
+import ReusableTable, { ColumnDefinition } from "../ReusableTable";
+import { CheckRecord } from "../../../types/checksandpromissory/list";
+import CheckCrud from "./crud";
+import CheckDetail from "./detail";
+import PaymentModal from "./paymentModal";
+
+export default function ChecksAndPromissoryTable() {
+  const [data, setData] = useState<CheckRecord[]>([
+    {
+      id: 1,
+      check_type: "Çek",
+      owner: "Ali Yılmaz",
+      company: "ABC AŞ",
+      debtor: "Mehmet",
+      creditor: "Veli",
+      creditor_phone: "05001112233",
+      kind: "Senet",
+      date: "2024-01-01",
+      recipient_bank: "Banka 1",
+      document_no: "DOC001",
+      payable_amount: 1000,
+      paid_amount: 200,
+      remaining_amount: 800,
+      status: "Beklemede",
+      description: "Örnek kayıt",
+      image: null,
+      payments: [],
+    },
+  ]);
+  const [showCrud, setShowCrud] = useState(false);
+  const [editing, setEditing] = useState<CheckRecord | null>(null);
+  const [showDetail, setShowDetail] = useState(false);
+  const [detailRecord, setDetailRecord] = useState<CheckRecord | null>(null);
+  const [showPayments, setShowPayments] = useState(false);
+  const [paymentRecord, setPaymentRecord] = useState<CheckRecord | null>(null);
+
+  const columns: ColumnDefinition<CheckRecord>[] = useMemo(
+    () => [
+      { key: "check_type", label: "Çek Türü" },
+      { key: "owner", label: "Çek Sahibi" },
+      { key: "company", label: "Firma" },
+      { key: "creditor", label: "Alacaklı" },
+      { key: "date", label: "Tarih" },
+      { key: "payable_amount", label: "Ödenecek Tutar" },
+      { key: "paid_amount", label: "Ödenen Tutar" },
+      { key: "remaining_amount", label: "Kalan Tutar" },
+      { key: "status", label: "Durum" },
+      {
+        key: "actions",
+        label: "İşlemler",
+        render: (row) => (
+          <>
+            <button
+              className="btn btn-icon btn-sm btn-primary-light rounded-pill"
+              onClick={() => {
+                setDetailRecord(row);
+                setShowDetail(true);
+              }}
+            >
+              <i className="ti ti-eye" />
+            </button>
+            <button
+              className="btn btn-icon btn-sm btn-warning-light rounded-pill"
+              onClick={() => {
+                setPaymentRecord(row);
+                setShowPayments(true);
+              }}
+            >
+              <i className="ti ti-currency-dollar" />
+            </button>
+            <button
+              className="btn btn-icon btn-sm btn-info-light rounded-pill"
+              onClick={() => {
+                setEditing(row);
+                setShowCrud(true);
+              }}
+            >
+              <i className="ti ti-pencil" />
+            </button>
+            <button
+              className="btn btn-icon btn-sm btn-danger-light rounded-pill"
+              onClick={() => handleDelete(row.id)}
+            >
+              <i className="ti ti-trash" />
+            </button>
+          </>
+        ),
+      },
+    ],
+    []
+  );
+
+  const handleDelete = (id: number) => {
+    if (!window.confirm("Silmek istediğinize emin misiniz?")) return;
+    setData((prev) => prev.filter((d) => d.id !== id));
+  };
+
+  const handleSave = (rec: CheckRecord) => {
+    setData((prev) => {
+      const exists = prev.find((d) => d.id === rec.id);
+      if (exists) {
+        return prev.map((d) => (d.id === rec.id ? rec : d));
+      }
+      return [...prev, rec];
+    });
+  };
+
+  const handlePaymentChange = (payments: PaymentRecord[]) => {
+    if (!paymentRecord) return;
+    setData((prev) =>
+      prev.map((d) => (d.id === paymentRecord.id ? { ...d, payments } : d))
+    );
+  };
+
+  return (
+    <div className="container mt-3">
+      <ReusableTable<CheckRecord>
+        pageTitle="Çek / Senet"
+        tableMode="single"
+        onAdd={() => {
+          setEditing(null);
+          setShowCrud(true);
+        }}
+        columns={columns}
+        data={data}
+      />
+      {showCrud && (
+        <CheckCrud
+          show={showCrud}
+          onClose={() => setShowCrud(false)}
+          onSave={handleSave}
+          record={editing || undefined}
+        />
+      )}
+      {showDetail && (
+        <CheckDetail
+          show={showDetail}
+          onClose={() => setShowDetail(false)}
+          record={detailRecord}
+        />
+      )}
+      {showPayments && paymentRecord && (
+        <PaymentModal
+          show={showPayments}
+          payments={paymentRecord.payments}
+          onClose={() => setShowPayments(false)}
+          onChange={handlePaymentChange}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/types/checksandpromissory/list.tsx
+++ b/src/types/checksandpromissory/list.tsx
@@ -1,0 +1,30 @@
+export interface PaymentRecord {
+  id: number;
+  date: string;
+  amount_paid: number;
+  payer: string;
+  receipt_no: string;
+  user: string;
+  description: string;
+}
+
+export interface CheckRecord {
+  id: number;
+  check_type: string;
+  owner: string;
+  company: string;
+  debtor: string;
+  creditor: string;
+  creditor_phone: string;
+  kind: string;
+  date: string;
+  recipient_bank: string;
+  document_no: string;
+  payable_amount: number;
+  paid_amount: number;
+  remaining_amount: number;
+  status: string;
+  description: string;
+  image?: string | null;
+  payments: PaymentRecord[];
+}


### PR DESCRIPTION
## Summary
- create `checksandpromissory` module with CRUD modals
- add local payment management modal
- expose a table page that uses reusable components
- register the new page in routing data

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: TypeScript errors due to missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_684d59a74c20832c8c9c309c1fe91cd0