### PR TITLE
Implement filterable checks/promissory table

### DIFF
--- a/src/components/common/checksandpromissory/table.tsx
+++ b/src/components/common/checksandpromissory/table.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
-import ReusableTable, { ColumnDefinition } from "../ReusableTable";
-import { CheckRecord } from "../../../types/checksandpromissory/list";
+import ReusableTable, { ColumnDefinition, FilterDefinition } from "../ReusableTable";
+import { CheckRecord, PaymentRecord } from "../../../types/checksandpromissory/list";
 import CheckCrud from "./crud";
 import CheckDetail from "./detail";
 import PaymentModal from "./paymentModal";
@@ -28,6 +28,11 @@ export default function ChecksAndPromissoryTable() {
       payments: [],
     },
   ]);
+
+  const [filterCheckType, setFilterCheckType] = useState("");
+  const [filterOwner, setFilterOwner] = useState("");
+  const [filterCompany, setFilterCompany] = useState("");
+  const [filterCreditor, setFilterCreditor] = useState("");
   const [showCrud, setShowCrud] = useState(false);
   const [editing, setEditing] = useState<CheckRecord | null>(null);
   const [showDetail, setShowDetail] = useState(false);
@@ -40,11 +45,15 @@ export default function ChecksAndPromissoryTable() {
       { key: "check_type", label: "Çek Türü" },
       { key: "owner", label: "Çek Sahibi" },
       { key: "company", label: "Firma" },
+      { key: "debtor", label: "Verecekli" },
       { key: "creditor", label: "Alacaklı" },
+      { key: "creditor_phone", label: "Alacaklı Tel" },
       { key: "date", label: "Tarih" },
-      { key: "payable_amount", label: "Ödenecek Tutar" },
-      { key: "paid_amount", label: "Ödenen Tutar" },
-      { key: "remaining_amount", label: "Kalan Tutar" },
+      { key: "recipient_bank", label: "Alıcı Banka" },
+      { key: "payable_amount", label: "Ödenecek" },
+      { key: "paid_amount", label: "Ödenen" },
+      { key: "remaining_amount", label: "Kalan" },
+      { key: "description", label: "Açıklama" },
       { key: "status", label: "Durum" },
       {
         key: "actions",
@@ -113,6 +122,49 @@ export default function ChecksAndPromissoryTable() {
     );
   };
 
+  const filters: FilterDefinition[] = useMemo(
+    () => [
+      {
+        key: "check_type",
+        label: "Çek Türü",
+        type: "text",
+        value: filterCheckType,
+        onChange: setFilterCheckType,
+      },
+      {
+        key: "owner",
+        label: "Çek Sahibi",
+        type: "text",
+        value: filterOwner,
+        onChange: setFilterOwner,
+      },
+      {
+        key: "company",
+        label: "Firma",
+        type: "text",
+        value: filterCompany,
+        onChange: setFilterCompany,
+      },
+      {
+        key: "creditor",
+        label: "Alıcı",
+        type: "text",
+        value: filterCreditor,
+        onChange: setFilterCreditor,
+      },
+    ],
+    [filterCheckType, filterOwner, filterCompany, filterCreditor]
+  );
+
+  const filteredData = useMemo(() => {
+    return data.filter((d) =>
+      (!filterCheckType || d.check_type.toLowerCase().includes(filterCheckType.toLowerCase())) &&
+      (!filterOwner || d.owner.toLowerCase().includes(filterOwner.toLowerCase())) &&
+      (!filterCompany || d.company.toLowerCase().includes(filterCompany.toLowerCase())) &&
+      (!filterCreditor || d.creditor.toLowerCase().includes(filterCreditor.toLowerCase()))
+    );
+  }, [data, filterCheckType, filterOwner, filterCompany, filterCreditor]);
+
   return (
     <div className="container mt-3">
       <ReusableTable<CheckRecord>
@@ -123,7 +175,8 @@ export default function ChecksAndPromissoryTable() {
           setShowCrud(true);
         }}
         columns={columns}
-        data={data}
+        filters={filters}
+        data={filteredData}
       />
       {showCrud && (
         <CheckCrud


### PR DESCRIPTION
## Summary
- expand checks/promissory table columns
- add filter fields for check type, owner, company and receiver
- filter table rows locally based on filter values

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails to compile due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684d5c0cf424832ca0039547071cd380