### PR TITLE
Use modals for daily financial summary tables

### DIFF
--- a/src/components/common/daily/dailyTransactionsFinancialSummary/index.tsx
+++ b/src/components/common/daily/dailyTransactionsFinancialSummary/index.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Row, Col, Card, Form } from 'react-bootstrap';
+import { Row, Col, Card, Form, Button } from 'react-bootstrap';
 import ReusableTable, { ColumnDefinition } from '../../ReusableTable';
 import SpkFlatpickr from '../../../../@spk-reusable-components/reusable-plugins/spk-flatpicker';
 import darkcontrol from '../../../../utils/darkmodecontroller';
@@ -17,6 +17,8 @@ const DailyTransactionsFinancialSummary: React.FC = () => {
   const [seasonId, setSeasonId] = useState('');
   const [date, setDate] = useState('');
   const [seasonsEnabled, setSeasonsEnabled] = useState(false);
+  const [showLiquidModal, setShowLiquidModal] = useState(false);
+  const [showLiabilityModal, setShowLiabilityModal] = useState(false);
 
   const { seasonsData = [] } = useSeasonsList({
     enabled: seasonsEnabled,
@@ -125,44 +127,49 @@ const DailyTransactionsFinancialSummary: React.FC = () => {
         </Card.Body>
       </Card>
 
-      {/* Tables */}
+      {/* Buttons to open tables in modals */}
       <Row className="g-4">
         <Col xs={12} lg={6}>
-          <Card className="glass-card h-100">
-            <Card.Header as="h5" className="fw-semibold">
-              Likit Varlıklar
-            </Card.Header>
-            <Card.Body className="p-0">
-              <ReusableTable<RowData>
-                tableMode="single"
-                columns={columns}
-                data={liquidRows}
-                loading={loading}
-                showExportButtons={false}
-                customFooter={liquidFooter}
-              />
-            </Card.Body>
-          </Card>
+          <Button
+            variant="outline-secondary"
+            onClick={() => setShowLiquidModal(true)}
+          >
+            Likit Varlıklar
+          </Button>
         </Col>
-
         <Col xs={12} lg={6}>
-          <Card className="glass-card h-100">
-            <Card.Header as="h5" className="fw-semibold">
-              Borçlar
-            </Card.Header>
-            <Card.Body className="p-0">
-              <ReusableTable<RowData>
-                tableMode="single"
-                columns={columns}
-                data={liabilityRows}
-                loading={loading}
-                showExportButtons={false}
-                customFooter={liabilitiesFooter}
-              />
-            </Card.Body>
-          </Card>
+          <Button
+            variant="outline-secondary"
+            onClick={() => setShowLiabilityModal(true)}
+          >
+            Borçlar
+          </Button>
         </Col>
       </Row>
+
+      <ReusableTable<RowData>
+        tableMode="single"
+        columns={columns}
+        data={liquidRows}
+        loading={loading}
+        showExportButtons={false}
+        customFooter={liquidFooter}
+        modalTitle="Likit Varlıklar"
+        showModal={showLiquidModal}
+        onCloseModal={() => setShowLiquidModal(false)}
+      />
+
+      <ReusableTable<RowData>
+        tableMode="single"
+        columns={columns}
+        data={liabilityRows}
+        loading={loading}
+        showExportButtons={false}
+        customFooter={liabilitiesFooter}
+        modalTitle="Borçlar"
+        showModal={showLiabilityModal}
+        onCloseModal={() => setShowLiabilityModal(false)}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- remove Card headers/bodies wrapping the tables
- provide buttons to open Liquid Assets and Liabilities tables in modals

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` *(fails: TypeScript errors due to missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_684d7697f004832c8b917e4efc293edd