### PR TITLE
Fix finance notes filter integration

### DIFF
--- a/src/components/common/financeNotes/table.tsx
+++ b/src/components/common/financeNotes/table.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import ReusableTable, { ColumnDefinition } from '../ReusableTable';
-import FilterGroup, { FilterDefinition } from './component/organisms/SearchFilters';
+import ReusableTable, { ColumnDefinition, FilterDefinition } from '../ReusableTable';
 import Pageheader from '../../page-header/pageheader';
 import { useFinanceNotes } from '../../hooks/financeNotes/useFinanceNotes';
 import { FinanceNote } from '../../../types/financeNotes/list';
@@ -153,8 +152,8 @@ export default function FinanceNotesTable() {
     return (
         <div className="container-fluid mt-3">
             <Pageheader title="Finans ve Muhasebe" currentpage="Finans Notları" />
-            <FilterGroup filters={filters} navigate={navigate} columnsPerRow={4} />
             <ReusableTable<FinanceNote>
+                filters={filters}
                 tableMode="single"
                 showExportButtons={true}
                 columns={columns}


### PR DESCRIPTION
## Summary
- use ReusableTable filters in finance notes table

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684d86c1d120832c86c9d94b4af9c0f9