### PR TITLE
Fix dashboard components for missing data

### DIFF
--- a/src/components/common/dashboard/components/CurrentBulletin.tsx
+++ b/src/components/common/dashboard/components/CurrentBulletin.tsx
@@ -7,7 +7,7 @@ interface CurrentBulletinProps {
 }
 
 const CurrentBulletin: React.FC<CurrentBulletinProps> = ({
-  daily_bulletins,
+  daily_bulletins = [],
 }) => {
   // Card style with fixed height
   const cardStyle = {

--- a/src/components/common/dashboard/components/InternalExternalRecordByMonth.tsx
+++ b/src/components/common/dashboard/components/InternalExternalRecordByMonth.tsx
@@ -4,7 +4,7 @@ import { NumberOfInternalAndExternalRecordsByMonth } from "../type.ts";
 import Spkapexcharts from "../../../../@spk-reusable-components/reusable-plugins/spk-apexcharts.tsx";
 
 interface InternalExternalRecordByMonthProps {
-  Number_of_internal_and_external_records_by_monthData: NumberOfInternalAndExternalRecordsByMonth;
+  Number_of_internal_and_external_records_by_monthData: NumberOfInternalAndExternalRecordsByMonth | any;
 }
 
 const InternalExternalRecordByMonth: React.FC<
@@ -29,28 +29,25 @@ const InternalExternalRecordByMonth: React.FC<
     (month) => months[month as keyof typeof months]
   );
 
+  let monthlyData: any = {};
+  if (Array.isArray(Number_of_internal_and_external_records_by_monthData)) {
+    Number_of_internal_and_external_records_by_monthData.forEach((item: any) => {
+      if (item.month) {
+        const date = new Date(item.month + '-01');
+        const name = date.toLocaleString('en', { month: 'long' }).toLowerCase();
+        monthlyData[name] = { internal: item.internal, external: item.external };
+      }
+    });
+  } else {
+    monthlyData = Number_of_internal_and_external_records_by_monthData || {};
+  }
+
   const internalData = Object.keys(months).map((month) =>
-    Number_of_internal_and_external_records_by_monthData[
-      month as keyof NumberOfInternalAndExternalRecordsByMonth
-    ]?.internal
-      ? parseInt(
-          Number_of_internal_and_external_records_by_monthData[
-            month as keyof NumberOfInternalAndExternalRecordsByMonth
-          ].internal
-        )
-      : 0
+    monthlyData[month]?.internal ? parseInt(monthlyData[month].internal) : 0
   );
 
   const externalData = Object.keys(months).map((month) =>
-    Number_of_internal_and_external_records_by_monthData[
-      month as keyof NumberOfInternalAndExternalRecordsByMonth
-    ]?.external
-      ? parseInt(
-          Number_of_internal_and_external_records_by_monthData[
-            month as keyof NumberOfInternalAndExternalRecordsByMonth
-          ].external
-        )
-      : 0
+    monthlyData[month]?.external ? parseInt(monthlyData[month].external) : 0
   );
 
   const chartOptions = {

--- a/src/components/common/dashboard/components/PeriodicComparison.tsx
+++ b/src/components/common/dashboard/components/PeriodicComparison.tsx
@@ -5,7 +5,7 @@ import { useSelector } from "react-redux";
 import { RootState } from "../../../../store";
 
 interface PeriodicComparisonProps {
-  periodicComprassion: PeriodicComparison;
+  periodicComprassion: PeriodicComparison | any;
 }
 
 const PeriodicComparisonTable: React.FC<PeriodicComparisonProps> = ({
@@ -17,18 +17,20 @@ const PeriodicComparisonTable: React.FC<PeriodicComparisonProps> = ({
 
   console.log("isDark", isDark);
 
-  const renderTableData = (data: any[]) => {
+  const renderTableData = (data: any[] = []) => {
     const tableData = [...data];
 
-    const percentageRow = {
-      seasson: "Değişim",
-      number: periodicComprassion.totalChange.numberChange,
-      endorsement: periodicComprassion.totalChange.endorsementChange,
-      avarage: periodicComprassion.totalChange.avarageChange,
-      isPercentageRow: true,
-    };
+    if (periodicComprassion?.totalChange) {
+      const percentageRow = {
+        seasson: "Değişim",
+        number: periodicComprassion.totalChange.numberChange,
+        endorsement: periodicComprassion.totalChange.endorsementChange,
+        avarage: periodicComprassion.totalChange.avarageChange,
+        isPercentageRow: true,
+      };
 
-    tableData.push(percentageRow);
+      tableData.push(percentageRow);
+    }
 
     // If less than 5 rows, add empty rows to maintain height
     if (tableData.length < 5) {
@@ -152,7 +154,7 @@ const PeriodicComparisonTable: React.FC<PeriodicComparisonProps> = ({
                         { title: "Ortalama" },
                       ]}
                     >
-                      {renderTableData(periodicComprassion.total)}
+                      {renderTableData(periodicComprassion?.total || [])}
                     </SpkTablescomponent>
                   </div>
                 </div>
@@ -170,7 +172,7 @@ const PeriodicComparisonTable: React.FC<PeriodicComparisonProps> = ({
                         { title: "Ortalama" },
                       ]}
                     >
-                      {renderTableData(periodicComprassion.Anaokulu)}
+                      {renderTableData(periodicComprassion?.Anaokulu || [])}
                     </SpkTablescomponent>
                   </div>
                 </div>
@@ -188,7 +190,7 @@ const PeriodicComparisonTable: React.FC<PeriodicComparisonProps> = ({
                         { title: "Ortalama" },
                       ]}
                     >
-                      {renderTableData(periodicComprassion.ilkokul)}
+                      {renderTableData(periodicComprassion?.ilkokul || [])}
                     </SpkTablescomponent>
                   </div>
                 </div>
@@ -206,7 +208,7 @@ const PeriodicComparisonTable: React.FC<PeriodicComparisonProps> = ({
                         { title: "Ortalama" },
                       ]}
                     >
-                      {renderTableData(periodicComprassion.ortaokul)}
+                      {renderTableData(periodicComprassion?.ortaokul || [])}
                     </SpkTablescomponent>
                   </div>
                 </div>
@@ -224,7 +226,7 @@ const PeriodicComparisonTable: React.FC<PeriodicComparisonProps> = ({
                         { title: "Ortalama" },
                       ]}
                     >
-                      {renderTableData(periodicComprassion.anadolu_lisesi)}
+                      {renderTableData(periodicComprassion?.anadolu_lisesi || [])}
                     </SpkTablescomponent>
                   </div>
                 </div>
@@ -242,7 +244,7 @@ const PeriodicComparisonTable: React.FC<PeriodicComparisonProps> = ({
                         { title: "Ortalama" },
                       ]}
                     >
-                      {renderTableData(periodicComprassion.fen_lisesi)}
+                      {renderTableData(periodicComprassion?.fen_lisesi || [])}
                     </SpkTablescomponent>
                   </div>
                 </div>

--- a/src/components/common/dashboard/components/PersonnelTaskDistribution.tsx
+++ b/src/components/common/dashboard/components/PersonnelTaskDistribution.tsx
@@ -8,7 +8,7 @@ interface PresonelTaskDistributionProps {
 }
 
 const PersonnelTaskDistribution: React.FC<PresonelTaskDistributionProps> = ({
-  personnelTaskDistribution,
+  personnelTaskDistribution = [],
 }) => {
   // Fixed height table container style
   const tableContainerStyle = {
@@ -42,7 +42,9 @@ const PersonnelTaskDistribution: React.FC<PresonelTaskDistributionProps> = ({
   
   // Prepare table data with empty rows if needed
   const prepareTableData = () => {
-    const taskData = [...personnelTaskDistribution];
+    const taskData = Array.isArray(personnelTaskDistribution)
+      ? [...personnelTaskDistribution]
+      : [];
     
     // If less than 5 rows, add empty rows to maintain height
     if (taskData.length < 5) {

--- a/src/components/common/dashboard/components/StaffLeaveTrackingTable.tsx
+++ b/src/components/common/dashboard/components/StaffLeaveTrackingTable.tsx
@@ -10,7 +10,7 @@ interface StaffLeaveTrackingTableProps {
 }
 
 const StaffLeaveTrackingTableRow: React.FC<StaffLeaveTrackingTableProps> = ({
-  staffLeaveTracking,
+  staffLeaveTracking = [],
 }) => {
   // Period filter state
   const [selectedPeriod, setSelectedPeriod] = useState<'today' | 'week' | 'month'>('today');
@@ -63,7 +63,9 @@ const StaffLeaveTrackingTableRow: React.FC<StaffLeaveTrackingTableProps> = ({
   
   // Prepare table data with empty rows if needed
   const prepareTableData = () => {
-    const data = [...staffLeaveTracking];
+    const data = Array.isArray(staffLeaveTracking)
+      ? [...staffLeaveTracking]
+      : [];
     
     // If less than 5 rows, add empty rows to maintain height
     if (data.length < 5) {

--- a/src/components/common/dashboard/components/TrialExamScoreDistributionChart.tsx
+++ b/src/components/common/dashboard/components/TrialExamScoreDistributionChart.tsx
@@ -4,29 +4,38 @@ import { TrialExamScoreDistribution } from "../type.ts";
 import Spkapexcharts from "../../../../@spk-reusable-components/reusable-plugins/spk-apexcharts.tsx";
 
 interface TrialExamScoreDistributionProps {
-  data: TrialExamScoreDistribution[];
+  data: TrialExamScoreDistribution[] | any;
 }
 
-const TrialExamScoreDistributionChart: React.FC<TrialExamScoreDistributionProps> = ({ data }) => {
-  const categories = data.map((exam) => exam.name);
+const TrialExamScoreDistributionChart: React.FC<TrialExamScoreDistributionProps> = ({ data = [] }) => {
+  const categories = (data || []).map((exam: any, idx: number) => exam.name || `Quiz ${exam.quiz_id ?? idx+1}`);
   
-  const examSeries = [
-    {
-      name : "Kurum",
-      type: "column",
-      data: data.map((exam) => exam.branch),
-    },
-    {
-      name : "Genel",
-      type: "line",
-      data: data.map((exam) => exam.gneral),
-    },
-    {
-      name : "Zirve",
-      type: "line",
-      data: data.map((exam) => exam.peak),
-    },
-  ];
+  const hasDetailedFields = data.length && data[0].branch !== undefined;
+  const examSeries = hasDetailedFields
+    ? [
+        {
+          name: "Kurum",
+          type: "column",
+          data: data.map((exam: any) => exam.branch),
+        },
+        {
+          name: "Genel",
+          type: "line",
+          data: data.map((exam: any) => exam.gneral),
+        },
+        {
+          name: "Zirve",
+          type: "line",
+          data: data.map((exam: any) => exam.peak),
+        },
+      ]
+    : [
+        {
+          name: "Ortalama",
+          type: "line",
+          data: data.map((exam: any) => Number(exam.avg) || 0),
+        },
+      ];
 
   const discreteMarkers = [];
   for (let seriesIndex = 1; seriesIndex <= 2; seriesIndex++) {

--- a/src/components/common/dashboard/components/WeeklyFoodMenuRow.tsx
+++ b/src/components/common/dashboard/components/WeeklyFoodMenuRow.tsx
@@ -28,8 +28,8 @@ const WeeklyFoodMenuRow: React.FC<WeeklyFoodMenuRowProps> = ({
 
   // Helper function to ensure consistent row count (minimum 5 rows)
   const ensureMinimumRows = (dayData: any, day: string) => {
-    const breakfast = [...dayData.breakfast];
-    const lunch = [...dayData.lunch];
+    const breakfast = [...(dayData?.breakfast ?? [])];
+    const lunch = [...(dayData?.lunch ?? [])];
 
     console.log(`Processing ${day} menu:`, { breakfast, lunch });
 
@@ -50,7 +50,7 @@ const WeeklyFoodMenuRow: React.FC<WeeklyFoodMenuRowProps> = ({
 
   // Render a day's menu with consistent row count
   const renderDayMenu = (dayData: any, day: string) => {
-    const { breakfast, lunch } = ensureMinimumRows(dayData, day);
+    const { breakfast, lunch } = ensureMinimumRows(dayData || {}, day);
 
     return breakfast.map((breakfastItem: string, index: number) => (
       <tr
@@ -80,7 +80,7 @@ const WeeklyFoodMenuRow: React.FC<WeeklyFoodMenuRowProps> = ({
                     tBodyClass="table-group-divider"
                     header={[{ title: "Kahvaltı" }, { title: "Öğle Yemeği" }]}
                   >
-                    {renderDayMenu(weeklyFoodsMenu.monday, "monday")}
+                    {renderDayMenu(weeklyFoodsMenu?.monday, "monday")}
                   </SpkTablescomponent>
                 </div>
               </div>
@@ -97,7 +97,7 @@ const WeeklyFoodMenuRow: React.FC<WeeklyFoodMenuRowProps> = ({
                     tBodyClass="table-group-divider"
                     header={[{ title: "Kahvaltı" }, { title: "Öğle Yemeği" }]}
                   >
-                    {renderDayMenu(weeklyFoodsMenu.tuesday, "tuesday")}
+                    {renderDayMenu(weeklyFoodsMenu?.tuesday, "tuesday")}
                   </SpkTablescomponent>
                 </div>
               </div>
@@ -114,7 +114,7 @@ const WeeklyFoodMenuRow: React.FC<WeeklyFoodMenuRowProps> = ({
                     tBodyClass="table-group-divider"
                     header={[{ title: "Kahvaltı" }, { title: "Öğle Yemeği" }]}
                   >
-                    {renderDayMenu(weeklyFoodsMenu.wednesday, "wednesday")}
+                    {renderDayMenu(weeklyFoodsMenu?.wednesday, "wednesday")}
                   </SpkTablescomponent>
                 </div>
               </div>
@@ -131,7 +131,7 @@ const WeeklyFoodMenuRow: React.FC<WeeklyFoodMenuRowProps> = ({
                     tBodyClass="table-group-divider"
                     header={[{ title: "Kahvaltı" }, { title: "Öğle Yemeği" }]}
                   >
-                    {renderDayMenu(weeklyFoodsMenu.Thursday, "thursday")}
+                    {renderDayMenu(weeklyFoodsMenu?.Thursday, "thursday")}
                   </SpkTablescomponent>
                 </div>
               </div>
@@ -148,7 +148,7 @@ const WeeklyFoodMenuRow: React.FC<WeeklyFoodMenuRowProps> = ({
                     tBodyClass="table-group-divider"
                     header={[{ title: "Kahvaltı" }, { title: "Öğle Yemeği" }]}
                   >
-                    {renderDayMenu(weeklyFoodsMenu.Friday, "friday")}
+                    {renderDayMenu(weeklyFoodsMenu?.Friday, "friday")}
                   </SpkTablescomponent>
                 </div>
               </div>
@@ -165,7 +165,7 @@ const WeeklyFoodMenuRow: React.FC<WeeklyFoodMenuRowProps> = ({
                     tBodyClass="table-group-divider"
                     header={[{ title: "Kahvaltı" }, { title: "Öğle Yemeği" }]}
                   >
-                    {renderDayMenu(weeklyFoodsMenu.Saturday, "saturday")}
+                    {renderDayMenu(weeklyFoodsMenu?.Saturday, "saturday")}
                   </SpkTablescomponent>
                 </div>
               </div>
@@ -182,7 +182,7 @@ const WeeklyFoodMenuRow: React.FC<WeeklyFoodMenuRowProps> = ({
                     tBodyClass="table-group-divider"
                     header={[{ title: "Kahvaltı" }, { title: "Öğle Yemeği" }]}
                   >
-                    {renderDayMenu(weeklyFoodsMenu.sunday, "sunday")}
+                    {renderDayMenu(weeklyFoodsMenu?.sunday, "sunday")}
                   </SpkTablescomponent>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- guard against missing `periodic_comparison` data
- make weekly food menu resilient to undefined days
- handle array form for monthly internal/external records
- allow empty lists for bulletins, staff tables and task distribution
- support alternative fields for trial exam chart

## Testing
- `npm run lint` *(fails: ESLint configuration missing)*
- `npm run build` *(fails: TypeScript errors and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_684ebc346200832caf8a839982bcb17e