### PR TITLE
Fix dashboard object handling

### DIFF
--- a/src/components/common/dashboard/components/ParentFeedbackPanelTable.tsx
+++ b/src/components/common/dashboard/components/ParentFeedbackPanelTable.tsx
@@ -3,7 +3,7 @@ import SpkTablescomponent from "../../../../@spk-reusable-components/reusable-ta
 import { ParentFeedbackPanel } from "../type.ts";
 
 interface ParentFeedbackPanelTableProps {
-  data: ParentFeedbackPanel[];
+  data?: ParentFeedbackPanel[];
 }
 
 const ParentFeedbackPanelTable: React.FC<ParentFeedbackPanelTableProps> = ({ data }) => {
@@ -30,7 +30,7 @@ const ParentFeedbackPanelTable: React.FC<ParentFeedbackPanelTableProps> = ({ dat
   
   // Prepare table data with empty rows if needed
   const prepareTableData = () => {
-    const feedbackData = [...data];
+    const feedbackData = [...(data || [])];
     
     // If less than 5 rows, add empty rows to maintain height
     if (feedbackData.length < 5) {

--- a/src/components/common/dashboard/fields/PDRDashboard/sections/index.tsx
+++ b/src/components/common/dashboard/fields/PDRDashboard/sections/index.tsx
@@ -31,7 +31,9 @@ const Row5Component: React.FC<Row5Props> = ({ data }) => {
   const localVariable = useSelector((state: RootState) => state.ui);
   const isDark = localVariable.dataThemeMode === "dark";
 
-  const firstItem = data?.data?.[0];
+  const firstItem = Array.isArray(data?.data)
+    ? data?.data[0]
+    : data?.data;
 
   const images = {
     teacher: teacher,

--- a/src/components/common/dashboard/fields/StudentAffairsDashboard/sections/index.tsx
+++ b/src/components/common/dashboard/fields/StudentAffairsDashboard/sections/index.tsx
@@ -33,7 +33,9 @@ const Row6Component: React.FC<Row6Props> = ({ data }) => {
   const localVariable = useSelector((state: RootState) => state.ui);
   const isDark = localVariable.dataThemeMode === "dark";
 
-  const firstItem = data?.data?.[0];
+  const firstItem = Array.isArray(data?.data)
+    ? data?.data[0]
+    : data?.data;
 
   const images = {
     teacher: teacher,

--- a/src/components/common/dashboard/fields/TeachersDashboard/sections/index.tsx
+++ b/src/components/common/dashboard/fields/TeachersDashboard/sections/index.tsx
@@ -29,7 +29,9 @@ const Row4Component: React.FC<Row3Props> = ({ data }) => {
   const localVariable = useSelector((state: RootState) => state.ui);
   const isDark = localVariable.dataThemeMode === "dark";
 
-  const firstItem = data?.data?.[0];
+  const firstItem = Array.isArray(data?.data)
+    ? data?.data[0]
+    : data?.data;
 
   const images = {
     teacher: teacher,

--- a/src/components/common/dashboard/fields/corporateDashboard/sections/index.tsx
+++ b/src/components/common/dashboard/fields/corporateDashboard/sections/index.tsx
@@ -35,7 +35,9 @@ const Row2Component: React.FC<Row1Props> = (props) => {
   const localVariable = useSelector((state: RootState) => state.ui);
   const isDark = localVariable.dataThemeMode === "dark";
 
-  const firstItem = props.data?.data?.[0];
+  const firstItem = Array.isArray(props.data?.data)
+    ? props.data?.data[0]
+    : props.data?.data;
 
 
   const images = {

--- a/src/components/common/dashboard/fields/financeOfficerDashboard/sections/index.tsx
+++ b/src/components/common/dashboard/fields/financeOfficerDashboard/sections/index.tsx
@@ -33,7 +33,9 @@ interface Row7Props {
 const Row7Component: React.FC<Row7Props> = ({ data }) => {
   const localVariable = useSelector((state: RootState) => state.ui);
   const isDark = localVariable.dataThemeMode === "dark";
-  const firstItem = data?.data?.[0];
+  const firstItem = Array.isArray(data?.data)
+    ? data?.data[0]
+    : data?.data;
 
   const images = {
     teacher: teacher,

--- a/src/components/common/dashboard/fields/foundingDirectorDashboard/sections/index.tsx
+++ b/src/components/common/dashboard/fields/foundingDirectorDashboard/sections/index.tsx
@@ -42,7 +42,9 @@ const Row1Component: React.FC<Row1Props> = (props) => {
     science: bigGirl2,
     total: free,
   };
-  const firstItem = props.data?.data?.[0];
+  const firstItem = Array.isArray(props.data?.data)
+    ? props.data?.data[0]
+    : props.data?.data;
 
   const Cardsdata = generateFoundingDirectorCardData(props.data);
 

--- a/src/components/common/dashboard/fields/managementDashboard/sections/index.tsx
+++ b/src/components/common/dashboard/fields/managementDashboard/sections/index.tsx
@@ -33,7 +33,9 @@ interface Row3Props {
 const Row3Component: React.FC<Row3Props> = ({ data }) => {
   const localVariable = useSelector((state: RootState) => state.ui);
   const isDark = localVariable.dataThemeMode === "dark";
-  const firstItem = data?.data?.[0];
+  const firstItem = Array.isArray(data?.data)
+    ? data?.data[0]
+    : data?.data;
 
   const images = {
     teacher: teacher,

--- a/src/components/common/dashboard/fields/parentGuardianDashboard/sections/index.tsx
+++ b/src/components/common/dashboard/fields/parentGuardianDashboard/sections/index.tsx
@@ -32,7 +32,9 @@ const Row11Component: React.FC<Row11Props> = ({ data }) => {
   const localVariable = useSelector((state: RootState) => state.ui);
   const isDark = localVariable.dataThemeMode === "dark";
 
-  const firstItem = data?.data?.[0];
+  const firstItem = Array.isArray(data?.data)
+    ? data?.data[0]
+    : data?.data;
   const images = {
     teacher: teacher,
     staff: person,

--- a/src/components/common/dashboard/fields/serviceDriverDashboard/sections/index.tsx
+++ b/src/components/common/dashboard/fields/serviceDriverDashboard/sections/index.tsx
@@ -28,7 +28,9 @@ interface Row9Props {
 const Row9Component: React.FC<Row9Props> = ({ data }) => {
   const localVariable = useSelector((state: RootState) => state.ui);
   const isDark = localVariable.dataThemeMode === "dark";
-  const firstItem = data?.data?.[0];
+  const firstItem = Array.isArray(data?.data)
+    ? data?.data[0]
+    : data?.data;
 
   const images = {
     teacher: teacher,

--- a/src/components/common/dashboard/fields/serviceManagerDashboard/sections/index.tsx
+++ b/src/components/common/dashboard/fields/serviceManagerDashboard/sections/index.tsx
@@ -32,7 +32,9 @@ interface Row10Props {
 const Row10Component: React.FC<Row10Props> = ({ data }) => {
   const localVariable = useSelector((state: RootState) => state.ui);
   const isDark = localVariable.dataThemeMode === "dark";
-  const firstItem = data?.data?.[0];
+  const firstItem = Array.isArray(data?.data)
+    ? data?.data[0]
+    : data?.data;
 
   const images = {
     teacher: teacher,

--- a/src/components/common/dashboard/fields/studentDashboard/sections/index.tsx
+++ b/src/components/common/dashboard/fields/studentDashboard/sections/index.tsx
@@ -28,7 +28,9 @@ const Row12Component: React.FC<Row12Props> = ({ data }) => {
   const localVariable = useSelector((state: RootState) => state.ui);
   const isDark = localVariable.dataThemeMode === "dark";
 
-  const firstItem = data?.data?.[0];
+  const firstItem = Array.isArray(data?.data)
+    ? data?.data[0]
+    : data?.data;
 
   const images = {
     teacher: teacher,

--- a/src/components/common/dashboard/fields/supportStaffDashboard/sections/index.tsx
+++ b/src/components/common/dashboard/fields/supportStaffDashboard/sections/index.tsx
@@ -33,7 +33,9 @@ const Row7Component: React.FC<Row8Props> = ({ data }) => {
   const localVariable = useSelector((state: RootState) => state.ui);
   const isDark = localVariable.dataThemeMode === "dark";
 
-  const firstItem = data?.data?.[0];
+  const firstItem = Array.isArray(data?.data)
+    ? data?.data[0]
+    : data?.data;
 
   const images = {
     teacher: teacher,

--- a/src/components/common/dashboard/type.ts
+++ b/src/components/common/dashboard/type.ts
@@ -1,5 +1,9 @@
 export interface DashboardResponseType {
-  data: Daum[];
+  /**
+   * API may return either an object or an array under the `data` key.
+   * Allow both shapes to keep the consumer code resilient.
+   */
+  data: Daum | Daum[];
 }
 
 export interface Daum {

--- a/src/utils/cardDataGeneratorFoundingDirrector.ts
+++ b/src/utils/cardDataGeneratorFoundingDirrector.ts
@@ -16,18 +16,19 @@ export interface CardDataItem {
 }
 
     export function generateFoundingDirectorCardData(data: any): CardDataItem[] {
+      const item = Array.isArray(data?.data) ? data.data[0] : data?.data;
       return [
         {
           id: 1,
           title: "Kayıt Sayıları",
           values: [
-            { label: "Hedef", value: String(data?.data?.[0]?.register_number?.target || "0") },
-            { label: "Gerçekleşen", value: String(data?.data?.[0]?.register_number?.default || "0") }
+            { label: "Hedef", value: String(item?.register_number?.target || "0") },
+            { label: "Gerçekleşen", value: String(item?.register_number?.default || "0") }
           ],
           change: {
             label: "Değişim",
-            value: data?.data?.[0]?.register_number?.rate || "0%",
-            color: data?.data?.[0]?.register_number?.rate?.includes("-") ? "" : "success"
+            value: item?.register_number?.rate || "0%",
+            color: item?.register_number?.rate?.includes("-") ? "" : "success"
           },
           iconClass: "ti ti-users",
           backgroundColor: "primary"
@@ -36,9 +37,9 @@ export interface CardDataItem {
           id: 2,
           title: "Taksit Takibi",
           values: [
-            { label: "Ciro", value: `₺${data?.data?.[0]?.installment_truck?.total || "0"}` },
-            { label: "Ödenen", value: `₺${data?.data?.[0]?.installment_truck?.payed || "0"}` },
-            { label: "Geciken", value: `₺${data?.data?.[0]?.installment_truck?.delayed || "0"}` }
+            { label: "Ciro", value: `₺${item?.installment_truck?.total || "0"}` },
+            { label: "Ödenen", value: `₺${item?.installment_truck?.payed || "0"}` },
+            { label: "Geciken", value: `₺${item?.installment_truck?.delayed || "0"}` }
           ],
           iconClass: "ti ti-credit-card",
           backgroundColor: "primary1"
@@ -47,10 +48,10 @@ export interface CardDataItem {
           id: 3,
           title: "Bugünkü Kasa Durumu",
           values: [
-            { label: "Gelir", value: `₺${data?.data?.[0]?.today_account_status?.income?.cash || "0"}`, prefix: "Nakit" },
-            { label: "Gider", value: `₺${data?.data?.[0]?.today_account_status?.expense?.cash || "0"}`, prefix: "Nakit" },
-            { label: "Gelir", value: `₺${data?.data?.[0]?.today_account_status?.income?.bank || "0"}`, prefix: "Banka" },
-            { label: "Gider", value: `₺${data?.data?.[0]?.today_account_status?.expense?.bank || "0"}`, prefix: "Banka" }
+            { label: "Gelir", value: `₺${item?.today_account_status?.income?.cash || "0"}`, prefix: "Nakit" },
+            { label: "Gider", value: `₺${item?.today_account_status?.expense?.cash || "0"}`, prefix: "Nakit" },
+            { label: "Gelir", value: `₺${item?.today_account_status?.income?.bank || "0"}`, prefix: "Banka" },
+            { label: "Gider", value: `₺${item?.today_account_status?.expense?.bank || "0"}`, prefix: "Banka" }
           ],
           iconClass: "ti ti-wallet",
           backgroundColor: "primary2"
@@ -59,9 +60,9 @@ export interface CardDataItem {
           id: 4,
           title: "Finansal Durum",
           values: [
-            { label: "Varlıklar", value: `₺${data?.data?.[0]?.finance_status?.entity || "0"}` },
-            { label: "Borçlar", value: `₺${data?.data?.[0]?.finance_status?.debt || "0"}` },
-            { label: "Net", value: `₺${data?.data?.[0]?.finance_status?.net || "0"}` }
+            { label: "Varlıklar", value: `₺${item?.finance_status?.entity || "0"}` },
+            { label: "Borçlar", value: `₺${item?.finance_status?.debt || "0"}` },
+            { label: "Net", value: `₺${item?.finance_status?.net || "0"}` }
           ],
           iconClass: "ti ti-chart-line",
           backgroundColor: "primary3"

--- a/src/utils/generateChartSeries.ts
+++ b/src/utils/generateChartSeries.ts
@@ -1,14 +1,15 @@
 import { DashboardResponseType } from "../components/common/dashboard/type";
 
 export function generateChartSeries(data: DashboardResponseType): any[] {
-  if (!data?.data?.[0]?.monthly_installment_status) {
+  const item = Array.isArray(data?.data) ? data.data[0] : data?.data;
+  if (!item?.monthly_installment_status) {
     return [
       { name: 'Ödenen', type: "column", data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] },
       { name: 'Ödenmesi Gereken', type: "line", data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
     ];
   }
-  
-  const installmentStatus = data.data[0].monthly_installment_status;
+
+  const installmentStatus = item.monthly_installment_status;
   
   return [
     {

--- a/src/utils/generateManagementCardData.ts
+++ b/src/utils/generateManagementCardData.ts
@@ -16,18 +16,19 @@ export interface CardDataItem {
 }
 
     export function generateManagementCardData(data: any): CardDataItem[] {
+      const item = Array.isArray(data?.data) ? data.data[0] : data?.data;
       return [
         {
           id: 1,
           title: "Kayıt Sayıları",
           values: [
-            { label: "Hedef", value: String(data?.data?.[0]?.register_number?.target || "0") },
-            { label: "Gerçekleşen", value: String(data?.data?.[0]?.register_number?.default || "0") }
+            { label: "Hedef", value: String(item?.register_number?.target || "0") },
+            { label: "Gerçekleşen", value: String(item?.register_number?.default || "0") }
           ],
           change: {
             label: "Değişim",
-            value: data?.data?.[0]?.register_number?.rate || "0%",
-            color: data?.data?.[0]?.register_number?.rate?.includes("-") ? "danger" : "success"
+            value: item?.register_number?.rate || "0%",
+            color: item?.register_number?.rate?.includes("-") ? "danger" : "success"
           },
           iconClass: "ti ti-users",
           backgroundColor: "primary"
@@ -36,9 +37,9 @@ export interface CardDataItem {
           id: 2,
           title: "Genel Bilgiler",
           values: [
-            { label: "Sınıf", value: `${data?.data?.[0]?.general_information?.class || "0"}` },
-            { label: "Öğrenci", value: `${data?.data?.[0]?.general_information?.student || "0"}` },
-            { label: "Öğretmen", value: `${data?.data?.[0]?.general_information?.teacher || "0"}` },
+            { label: "Sınıf", value: `${item?.general_information?.class || "0"}` },
+            { label: "Öğrenci", value: `${item?.general_information?.student || "0"}` },
+            { label: "Öğretmen", value: `${item?.general_information?.teacher || "0"}` },
           ],
           iconClass: "bi bi-info-circle",
           backgroundColor: "primary1"
@@ -47,9 +48,9 @@ export interface CardDataItem {
           id: 3,
           title: "Veli Görüşme Sayıları",
           values: [
-            { label: "Geçen Hafta", value: `${data?.data?.[0]?.number_of_parent_meetings?.last_week || "0"}`},
-            { label: "Bu Hafta", value: `${data?.data?.[0]?.number_of_parent_meetings?.this_week || "0"}`},
-            { label: "Sezon", value: `${data?.data?.[0]?.number_of_parent_meetings?.seasson || "0"}`},
+            { label: "Geçen Hafta", value: `${item?.number_of_parent_meetings?.last_week || "0"}`},
+            { label: "Bu Hafta", value: `${item?.number_of_parent_meetings?.this_week || "0"}`},
+            { label: "Sezon", value: `${item?.number_of_parent_meetings?.seasson || "0"}`},
           ],
           iconClass: "ti ti-heart-handshake",
           backgroundColor: "primary2"
@@ -58,12 +59,12 @@ export interface CardDataItem {
           id: 4,
           title: "Günlük Yoklama İzleme",
           values: [
-            { label: "Derslik Sayısı", value: `${data?.data?.[0]?.daily_attendance_monitoring?.class || "0"}` },
-            { label: "Allınan Yoklama", value: `${data?.data?.[0]?.daily_attendance_monitoring?.lesson_learned || "0"}` },
-            { label: "Eksik Yoklama", value: `${data?.data?.[0]?.daily_attendance_monitoring?.lesson_not_learned || "0"}` }
-          ],
-          iconClass: "bi bi-list-check",
-          backgroundColor: "primary3"
-        }
+            { label: "Derslik Sayısı", value: `${item?.daily_attendance_monitoring?.class || "0"}` },
+            { label: "Allınan Yoklama", value: `${item?.daily_attendance_monitoring?.lesson_learned || "0"}` },
+            { label: "Eksik Yoklama", value: `${item?.daily_attendance_monitoring?.lesson_not_learned || "0"}` }
+        ],
+        iconClass: "bi bi-list-check",
+        backgroundColor: "primary3"
+      }
       ];
     }


### PR DESCRIPTION
## Summary
- support dashboard responses that return a single object instead of an array
- guard dashboard table data handling
- adapt multiple dashboard sections to work with new response shape
- update utility functions to extract the first item

## Testing
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f131e2870832cac073959c6afd6fa