### PR TITLE
Fix dashboard runtime errors

### DIFF
--- a/src/authentication/login/LoginForm.tsx
+++ b/src/authentication/login/LoginForm.tsx
@@ -87,6 +87,7 @@ export default function LoginForm() {
                         placeholder="user name"
                         value={loginData.email}
                         onChange={handleChange}
+                        autoComplete="username"
                       />
                     </Col>
 
@@ -112,6 +113,7 @@ export default function LoginForm() {
                           className="create-password-input"
                           id="signin-password"
                           placeholder="password"
+                          autoComplete="current-password"
                         />
                         <Link
                           to="#!"

--- a/src/components/common/dashboard/components/CourseSuccessAnalysisChart.tsx
+++ b/src/components/common/dashboard/components/CourseSuccessAnalysisChart.tsx
@@ -18,8 +18,13 @@ interface ProgramData {
 const CourseSuccessAnalysisChart: React.FC<CourseSuccessAnalysisChartProps> = ({ courseSuccessAnalysis }) => {
     const [activeProgram, setActiveProgram] = useState<string>("ilkokul");
 
-    const activeProgramData = courseSuccessAnalysis.find(program =>
-        program.program.toLowerCase() === activeProgram.toLowerCase()) || courseSuccessAnalysis[0];
+    const activeProgramData = courseSuccessAnalysis.find(program => {
+        const programName = (program as any).program;
+        return (
+            typeof programName === "string" &&
+            programName.toLowerCase() === activeProgram.toLowerCase()
+        );
+    }) || courseSuccessAnalysis[0];
 
     const lessonNames = activeProgramData?.lessons.map(lesson => {
         const name = lesson.name.charAt(0).toUpperCase() + lesson.name.slice(1);

--- a/src/components/common/dashboard/fields/managementDashboard/sections/index.tsx
+++ b/src/components/common/dashboard/fields/managementDashboard/sections/index.tsx
@@ -58,7 +58,7 @@ const Row3Component: React.FC<Row3Props> = ({ data }) => {
     images
   );
 
-  const weeklyFoodsMenu = firstItem?.weekly_foods_menu[0];
+  const weeklyFoodsMenu = firstItem?.weekly_foods_menu?.[0];
 
   // Ödemeler (supplier) verisi
   const supplierPayments = firstItem?.payments?.suppliers || [];


### PR DESCRIPTION
## Summary
- prevent crash if weekly food menu data missing
- handle course success data without `program` property
- add autocomplete hints to login form

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_684f176577b0832c9e044207228f2c34