### PR TITLE
Fix preregister modal issues

### DIFF
--- a/src/components/common/ReusableModalForm.tsx
+++ b/src/components/common/ReusableModalForm.tsx
@@ -1259,6 +1259,7 @@ export function renderField(
           type={f.type === "textarea" ? undefined : f.type}
           name={f.name}
           className="form-control"
+          disabled={f.disabled}
           placeholder={f.placeholder || ""}
           onChange={(
             e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>

--- a/src/components/common/student/pre-register/crud.tsx
+++ b/src/components/common/student/pre-register/crud.tsx
@@ -7,6 +7,7 @@ import { useShowStudent } from "../../../hooks/student/useShowStudent";
 import { useAddStudent } from "../../../hooks/student/useAddStudent";
 import { getPreRegisterFields } from "./crudField";
 import { useRegisterNo } from "../../../hooks/student/useRegisterNo";
+import { formatDateForApi } from "../../../utils/formatters";
 interface StudentModalProps {
   show: boolean;
   onClose: () => void;
@@ -23,6 +24,8 @@ interface IStudentForm extends FormikValues {
   nationality_id?: number;
   email?: string;
   branche_id?: number;
+  register_no?: string;
+  register_date?: string;
   birthday?: string;
   additional_information_1?: string;
   additional_information_2: string;
@@ -78,6 +81,8 @@ const StudentModal: React.FC<StudentModalProps> = ({ onClose, onRefresh }) => {
     phone: "",
     email: "",
     branche_id: 0,
+    register_no: "",
+    register_date: formatDateForApi(new Date()),
     birthday: "",
     additional_information_2: "",
     financial_status: "",
@@ -98,7 +103,7 @@ const StudentModal: React.FC<StudentModalProps> = ({ onClose, onRefresh }) => {
       is_parent: false,
       kinship_id: 0,
       kinship: "",
-      identification_no: 0,
+      identification_no: "",
       full_name: "",
       phone: "",
     },
@@ -134,6 +139,10 @@ const StudentModal: React.FC<StudentModalProps> = ({ onClose, onRefresh }) => {
         email: fetchedStudentDetails.email || "",
         nationality_id: fetchedStudentDetails.nationality_id || 0,
         branche_id: fetchedStudentDetails.branche_id || 0,
+        register_no: fetchedStudentDetails.register_no || "",
+        register_date:
+          formatDateForApi(fetchedStudentDetails.register_date) ||
+          formatDateForApi(new Date()),
         birthday: fetchedStudentDetails.birthday || "",
         nationality: fetchedStudentDetails.nationality || "",
         additional_information_2:
@@ -157,7 +166,7 @@ const StudentModal: React.FC<StudentModalProps> = ({ onClose, onRefresh }) => {
           kinship_id: fetchedStudentDetails.guardian?.kinship_id || 0,
           kinship: fetchedStudentDetails.guardian?.kinship || "",
           identification_no:
-            fetchedStudentDetails?.guardian?.identification_no || 0,
+            fetchedStudentDetails?.guardian?.identification_no || "",
           full_name: fetchedStudentDetails.guardian?.full_name || "",
           phone: fetchedStudentDetails.guardian?.phone || "",
         },
@@ -207,7 +216,7 @@ const StudentModal: React.FC<StudentModalProps> = ({ onClose, onRefresh }) => {
       mode={"single"}
       initialValues={initialValues}
       onSubmit={handleSubmit}
-      confirmButtonLabel={mode === "add" ? "Ekle" : "Güncelle"}
+      confirmButtonLabel={mode === "add" ? "Kaydet" : "Güncelle"}
       cancelButtonLabel="Vazgeç"
       isLoading={loading}
       error={error || null}

--- a/src/components/common/student/pre-register/crudField/addressFields.tsx
+++ b/src/components/common/student/pre-register/crudField/addressFields.tsx
@@ -82,25 +82,20 @@ export const getAddressFields = (): FieldDefinition[] => {
   }, [countriesData]);
 
   const cityOptions = useMemo(() => {
-    return allCities.map((c) => ({
-      label: c.name,
-      value: c.id,
-    }));
+    return allCities
+      .map((c) => ({ label: c.name, value: c.id }))
+      .sort((a, b) => a.label.localeCompare(b.label));
   }, [allCities]);
 
   const countyOptions = useMemo(() => {
-    return (allCounties || []).map((c: { name: any; id: any }) => ({
-      label: c.name,
-      value: c.id,
-    }));
+    return (allCounties || [])
+      .map((c: { name: any; id: any }) => ({ label: c.name, value: c.id }))
+      .sort((a, b) => a.label.localeCompare(b.label));
   }, [allCounties]);
   const districtOptions = useMemo(() => {
-    return (Array.isArray(allDistricts) ? allDistricts : []).map(
-      (d: { name: any; id: any }) => ({
-        label: d.name,
-        value: d.id,
-      })
-    );
+    return (Array.isArray(allDistricts) ? allDistricts : [])
+      .map((d: { name: any; id: any }) => ({ label: d.name, value: d.id }))
+      .sort((a, b) => a.label.localeCompare(b.label));
   }, [allDistricts]);
 
   return [
@@ -129,14 +124,14 @@ export const getAddressFields = (): FieldDefinition[] => {
         formik.setFieldValue("address.county_id", "");
         formik.setFieldValue("address.district_id", "");
       },
-      options: [{ label: "Seçiniz", value: "" }, ...countryOptions],
+      options: countryOptions,
     },
     {
       name: "address.city_id",
       label: "İl",
       type: "select",
       onClick: () => setEnableCities(true),
-      options: [{ label: "Seçiniz", value: "" }, ...cityOptions],
+      options: cityOptions,
       onChange: (val, formik) => {
         formik.setFieldValue("address.city_id", val);
 
@@ -153,7 +148,7 @@ export const getAddressFields = (): FieldDefinition[] => {
       label: "İlçe",
       type: "select",
       onClick: () => setEnableCounties(true),
-      options: [{ label: "Seçiniz", value: "" }, ...countyOptions],
+      options: countyOptions,
       onChange: (val, formik) => {
         formik.setFieldValue("address.county_id", val);
 
@@ -168,7 +163,7 @@ export const getAddressFields = (): FieldDefinition[] => {
       label: "Mahalle",
       type: "select",
       onClick: () => setEnableDistricts(true),
-      options: [{ label: "Seçiniz", value: "" }, ...districtOptions],
+      options: districtOptions,
       onChange: (val, formik) => {
         formik.setFieldValue("address.district_id", val);
       },

--- a/src/components/common/student/pre-register/crudField/guardianFields.tsx
+++ b/src/components/common/student/pre-register/crudField/guardianFields.tsx
@@ -38,6 +38,13 @@ export const getGuardianFields = (): FieldDefinition[] => {
       type: "text",
       required: true,
       placeholder: "11 haneli",
+      minLength: 11,
+      maxLength: 11,
+      pattern: /^\d{11}$/,
+      onChange: (val, formik) => {
+        const sanitized = val.replace(/\D/g, "").slice(0, 11);
+        formik.setFieldValue("guardian.identification_no", sanitized);
+      },
     },
     {
       name: "guardian.phone",
@@ -57,6 +64,12 @@ export const getGuardianFields = (): FieldDefinition[] => {
       label: "Özel Bilgi",
       type: "text",
       placeholder: "Özel Bilgi 1",
+    },
+    {
+      name: "additional_information_2",
+      label: "Açıklama",
+      type: "textarea",
+      placeholder: "Açıklama yazınız",
     },
   ];
 };

--- a/src/components/common/student/pre-register/crudField/studentAndSchoolFields.tsx
+++ b/src/components/common/student/pre-register/crudField/studentAndSchoolFields.tsx
@@ -75,13 +75,12 @@ export const getStudentAndSchoolFields = (): FieldDefinition[] => {
 
   // Select options
   const branchOptions = useMemo(() => {
-    const list =
+    return (
       branchData?.map((b) => ({
         label: b.name,
         value: b.id,
-      })) || [];
-    list.unshift({ label: "Seçiniz", value: 0 });
-    return list;
+      })) || []
+    );
   }, [branchData]);
 
   const authorized_personOptions = useMemo(
@@ -108,36 +107,6 @@ export const getStudentAndSchoolFields = (): FieldDefinition[] => {
   // Alan tanımları
   return [
     {
-      name: "branch_id",
-      label: "Şube",
-      type: "select",
-      required: true,
-      onClick: () => {
-        setFiltersEnabled((prev) => ({ ...prev, branch_id: true }));
-      },
-      options: branchOptions,
-      onChange: async (selectedValue, formik) => {
-        formik.setFieldValue("branch_id", selectedValue);
-
-        // Şube seçilmezse register_no sıfırla
-        if (!selectedValue) {
-          formik.setFieldValue("register_no", "");
-          return;
-        }
-
-        // Şube seçildiyse register_no’yu getir
-        const branchId = Number(selectedValue);
-        const resp = await getRegisterNo(0, branchId);
-
-        if (resp && resp.data?.register_no) {
-          // API örneği: { "data": { "register_no": 10000 } }
-          formik.setFieldValue("register_no", resp.data.register_no);
-        } else {
-          formik.setFieldValue("register_no", "");
-        }
-      },
-    },
-    {
       name: "created_by",
       label: "Kayıt Eden",
       type: "select",
@@ -157,6 +126,7 @@ export const getStudentAndSchoolFields = (): FieldDefinition[] => {
       label: "Kayıt No",
       type: "text",
       required: false,
+      disabled: true,
     },
     {
       name: "register_date",
@@ -164,15 +134,30 @@ export const getStudentAndSchoolFields = (): FieldDefinition[] => {
       type: "date",
     },
     {
-      name: "branche_id",
-      label: "Şube (Tekrar)",
+      name: "branch_id",
+      label: "Şube",
       type: "select",
-      options: branchData.map((branch) => ({
-        value: branch.id,
-        label: branch.name,
-      })),
+      required: true,
+      options: branchOptions,
       onClick: () => {
         setFiltersEnabled((prev) => ({ ...prev, branch_id: true }));
+      },
+      onChange: async (selectedValue, formik) => {
+        formik.setFieldValue("branch_id", selectedValue);
+
+        if (!selectedValue) {
+          formik.setFieldValue("register_no", "");
+          return;
+        }
+
+        const branchId = Number(selectedValue);
+        const resp = await getRegisterNo(0, branchId);
+
+        if (resp && resp.data?.register_no) {
+          formik.setFieldValue("register_no", resp.data.register_no);
+        } else {
+          formik.setFieldValue("register_no", "");
+        }
       },
     },
     {
@@ -180,23 +165,34 @@ export const getStudentAndSchoolFields = (): FieldDefinition[] => {
       label: "TC Kimlik No",
       type: "text",
       placeholder: "11 haneli",
+      required: true,
+      minLength: 11,
+      maxLength: 11,
+      pattern: /^\d{11}$/,
+      onChange: (val, formik) => {
+        const sanitized = val.replace(/\D/g, "").slice(0, 11);
+        formik.setFieldValue("identification_no", sanitized);
+      },
     },
     {
       name: "first_name",
       label: "Ad",
       type: "text",
       placeholder: "Ör: Abuzer",
+      required: true,
     },
     {
       name: "last_name",
       label: "Soyad",
       type: "text",
       placeholder: "Ör: Kömürcü",
+      required: true,
     },
     {
       name: "gender_id",
       label: "Cinsiyet",
       type: "select",
+      required: true,
       options: [
         { value: 1, label: "Erkek" },
         { value: 2, label: "Kadın" },
@@ -206,6 +202,7 @@ export const getStudentAndSchoolFields = (): FieldDefinition[] => {
       name: "birthday",
       label: "Doğum Tarihi",
       type: "date",
+      required: true,
     },
     {
       name: "email",
@@ -217,20 +214,13 @@ export const getStudentAndSchoolFields = (): FieldDefinition[] => {
       name: "phone",
       label: "Telefon",
       type: "phone",
+      required: true,
     },
     {
       name: "mobile_phone",
       label: "Öğr. Cep",
       type: "phone",
-    },
-    {
-      name: "status",
-      label: "Durum",
-      type: "select",
-      options: [
-        { value: 0, label: "Pasif" },
-        { value: 1, label: "Aktif" },
-      ],
+      required: true,
     },
     {
       name: "program",


### PR DESCRIPTION
## Summary
- ensure form fields are validated and cleaned up
- add today as default register date
- adjust branch selection and register number logic
- enhance guardian fields with validation and description
- remove duplicate placeholders in address selectors
- support disabled text fields

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: TS errors and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_684fbd3de220832cad5a977e9b7a43b6