### PR TITLE
Fix navigation to student meetings

### DIFF
--- a/src/components/common/student/appointments/index.tsx
+++ b/src/components/common/student/appointments/index.tsx
@@ -132,7 +132,7 @@ export default function QuestionLabeling() {
     query.set("Appointment", String(params.Appointment));
     query.set("Appointment_time", String(params.Appointment_time));
     query.set("Program_id", String(params.Program_id));
-    query.set("Class_level", String(params.Chapters));
+    query.set("Class_level", String(params.Class_level));
     query.set("pageSize", String(params.pageSize));
     query.set("enabled", String(params.enabled));
     query.set("student_id", String(params.student_id));
@@ -371,7 +371,9 @@ export default function QuestionLabeling() {
               variant="warning-light"
               size="sm"
               className="btn-icon rounded-pill"
-              onClick={() => navigate(`/studentmeetings?student_id=${row.id}`)}
+              onClick={() =>
+                navigate(`/studentmeetings?student_id=${row.student_id}`)
+              }
             >
               <i className="ti ti-message"></i>
             </Button>{" "}

--- a/src/components/common/student/appointments/student_table.tsx
+++ b/src/components/common/student/appointments/student_table.tsx
@@ -96,7 +96,9 @@ export default function QuestionLabeling() {
             <Button
               variant=""
               size="sm"
-              onClick={() => navigate(`/studentmeetings?student_id=/${row.id}`)}
+              onClick={() =>
+                navigate(`/studentmeetings?student_id=${row.student_id}`)
+              }
             >
               <img
                 src={appoipmentButton}


### PR DESCRIPTION
## Summary
- ensure appointment actions link to the selected student's meeting page
- fix query parameter key when updating Class_level

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_684fd76c9258832caa28b9e9809660f2