### PR TITLE
Fix meeting action buttons

### DIFF
--- a/src/components/common/student/meetings/table.tsx
+++ b/src/components/common/student/meetings/table.tsx
@@ -464,7 +464,7 @@ export default function MeetingListPage() {
               title="Not"
               content={row.meeting_note || "-"}
             >
-              <Button variant="link">
+              <Button variant="link" onClick={() => handleShowModal(row)}>
                 <img
                   src={info}
                   alt="Seç"
@@ -482,7 +482,9 @@ export default function MeetingListPage() {
               variant="warning-light"
               size="sm"
               className="btn-icon rounded-pill"
-              onClick={() => handleShowModal(row)}
+              onClick={() =>
+                navigate(`/studentmeetings?student_id=${row.student_id}`)
+              }
             >
               <i className="ti ti-message"></i>
             </Button>{" "}


### PR DESCRIPTION
## Summary
- open meeting modal when clicking note button
- navigate to student meetings from message button

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_684fddf24e78832c968d1324b0f4196c