### PR TITLE
Fix width of leftover filter columns

### DIFF
--- a/src/components/common/expences/main/component/organisms/SearchFilters.tsx
+++ b/src/components/common/expences/main/component/organisms/SearchFilters.tsx
@@ -88,7 +88,7 @@ const FilterGroup: React.FC<FilterGroupProps> = ({
         <Card>
             <div className="mb-1 bg-white rounded-3">
                 {groups.map((group, idx) => {
-                    const width = `${100 / group.length}%`;
+                    const width = `${100 / (filters.length <= 6 ? group.length : columnsPerRow)}%`;
                     return (
                         <Row key={`filter-row-${idx}`} className="mb-2">
                             {group.map((filter) => (


### PR DESCRIPTION
## Summary
- adjust SearchFilters column width so leftover filters do not stretch the row

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684ffd1703ec832c918e908952dcabcc