### PR TITLE
Add consolidated lesson fee management page

### DIFF
--- a/src/components/common/personel/personelDetail/lesson-oct-fee/index.tsx
+++ b/src/components/common/personel/personelDetail/lesson-oct-fee/index.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import TabsContainer from "../../guidance/components/organisms/TabsContainer";
+import PersonelTuitionFeeCrud from "../tabs/ders-ucreti/crud";
+import PersonelCouponCrud from "../tabs/kupon/crud";
+import PersonelCoachingCrud from "../tabs/kocluk/crud";
+import PersonelSpecialCrud from "../tabs/ozel-ders/crud";
+
+const LessonOctFeePage: React.FC = () => {
+  const [, setActiveIdx] = useState<number>(0);
+
+  const tabsConfig = [
+    {
+      label: "Ders Ücreti",
+      content: <PersonelTuitionFeeCrud />,
+      activeBgColor: "#5C67F7",
+      activeTextColor: "#FFFFFF",
+      passiveBgColor: "#E1E4FB",
+      passiveTextColor: "#5C67F7",
+    },
+    {
+      label: "Ders – Soru Çözüm Ücretleri",
+      content: <PersonelCouponCrud />,
+      activeBgColor: "#5C67F7",
+      activeTextColor: "#FFFFFF",
+      passiveBgColor: "#E1E4FB",
+      passiveTextColor: "#5C67F7",
+    },
+    {
+      label: "Koçluk Ücreti",
+      content: <PersonelCoachingCrud />,
+      activeBgColor: "#5C67F7",
+      activeTextColor: "#FFFFFF",
+      passiveBgColor: "#E1E4FB",
+      passiveTextColor: "#5C67F7",
+    },
+    {
+      label: "Özel Ders",
+      content: <PersonelSpecialCrud />,
+      activeBgColor: "#5C67F7",
+      activeTextColor: "#FFFFFF",
+      passiveBgColor: "#E1E4FB",
+      passiveTextColor: "#5C67F7",
+    },
+  ];
+
+  return (
+    <div>
+      <TabsContainer tabs={tabsConfig} onTabChange={(idx) => setActiveIdx(idx)} />
+    </div>
+  );
+};
+
+export default LessonOctFeePage;

--- a/src/components/sidebar/nav.tsx
+++ b/src/components/sidebar/nav.tsx
@@ -271,13 +271,8 @@ export const MENUITEMS: any = [
           children: [
             {
               title: "Ders & Ek Ücretler",
-              type: "sub",
-              children: [
-                { title: "Ders Ücreti", path: "/personelTuitionFeeCrud", type: "link" },
-                { title: "Ders – Soru Çözüm Ücretleri", path: "/personelCouponCrud", type: "link" },
-                { title: "Koçluk Ücreti", path: "/personelCoachingCrud", type: "link" },
-                { title: "Özel Ders", path: "/personelSpecialCrud", type: "link" },
-              ],
+              path: "/lessonOctFee",
+              type: "link",
             },
             {
               title: "Çalışma ve Hakediş",

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -316,6 +316,9 @@ const PersonelSpecialCrud = lazy(
 const PersonelCoachingCrud = lazy(
   () => import("../components/common/personel/personelDetail/tabs/kocluk/crud")
 );
+const LessonOctFeePage = lazy(
+  () => import("../components/common/personel/personelDetail/lesson-oct-fee")
+);
 const PersonelFinancialSummary = lazy(
   () => import("../components/common/personel/financialSummary")
 );
@@ -927,6 +930,11 @@ export const Routedata = [
     path: `${import.meta.env.BASE_URL}personelCoachingCrud/:id?`,
 
     element: <PersonelCoachingCrud />,
+  },
+  {
+    id: 10,
+    path: `${import.meta.env.BASE_URL}lessonOctFee`,
+    element: <LessonOctFeePage />,
   },
   {
     id: 22,


### PR DESCRIPTION
## Summary
- consolidate lesson fee forms under new page `lesson-oct-fee`
- update sidebar navigation to link to the new consolidated page
- register the page in routing

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68501931d1fc832c874e8ec51e01610e