### PR TITLE
Add LessonOctFee page to navigation and routes

### DIFF
--- a/src/components/sidebar/nav.tsx
+++ b/src/components/sidebar/nav.tsx
@@ -269,16 +269,7 @@ export const MENUITEMS: any = [
           title: "Personel Yönetimi",
           type: "sub",
           children: [
-            {
-              title: "Ders & Ek Ücretler",
-              type: "sub",
-              children: [
-                { title: "Ders Ücreti", path: "/personelTuitionFeeCrud", type: "link" },
-                { title: "Ders – Soru Çözüm Ücretleri", path: "/personelCouponCrud", type: "link" },
-                { title: "Koçluk Ücreti", path: "/personelCoachingCrud", type: "link" },
-                { title: "Özel Ders", path: "/personelSpecialCrud", type: "link" },
-              ],
-            },
+            { title: "Ders & Ek Ücretler", path: "/lesson-oct-fee", type: "link" },
             {
               title: "Çalışma ve Hakediş",
               type: "sub",

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -316,6 +316,9 @@ const PersonelSpecialCrud = lazy(
 const PersonelCoachingCrud = lazy(
   () => import("../components/common/personel/personelDetail/tabs/kocluk/crud")
 );
+const LessonOctFeeIndex = lazy(
+  () => import("../components/common/personel/personelDetail/lesson-oct-fee")
+);
 const PersonelFinancialSummary = lazy(
   () => import("../components/common/personel/financialSummary")
 );
@@ -915,6 +918,12 @@ export const Routedata = [
     id: 10,
     path: `${import.meta.env.BASE_URL}personelCouponCrud/:id?`,
     element: <PersonelCouponCrud />,
+  },
+
+  {
+    id: 10,
+    path: `${import.meta.env.BASE_URL}lesson-oct-fee/:id?`,
+    element: <LessonOctFeeIndex />,
   },
 
   {


### PR DESCRIPTION
## Summary
- link "Ders & Ek Ücretler" menu directly to lesson and extra fees index
- register LessonOctFeeIndex component in routing data

## Testing
- `npm run lint` *(fails: ESLint couldn't find config or plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68501d3433cc832c90a0ddb77d8da8f7