### PR TITLE
Add filter-enabled tuition fee table

### DIFF
--- a/src/components/common/personel/personelDetail/tabs/ders-ucreti/table.tsx
+++ b/src/components/common/personel/personelDetail/tabs/ders-ucreti/table.tsx
@@ -1,9 +1,16 @@
-import { useState, useEffect, useMemo } from "react"
+import { useState, useMemo } from "react"
 import { useNavigate } from "react-router-dom"
-import { Button } from "react-bootstrap"
-import ReusableTable, { ColumnDefinition } from "../../../../ReusableTable"
-import { useTuitionFeesShow } from "../../../../../hooks/employee/tuition_fees/useTuitionFeesShow"
+import { Button, Modal, Table } from "react-bootstrap"
+import ReusableTable, {
+  ColumnDefinition,
+  FilterDefinition,
+} from "../../../../ReusableTable"
+import FilterGroup from "../../../pollingManagement/class-course/component/organisms/SearchFilters"
+import { useTuitionFeesList } from "../../../../../hooks/employee/tuition_fees/useTuitionFeesList"
 import { useTuitionFeesDelete } from "../../../../../hooks/employee/tuition_fees/useTuitionFeesDelete"
+import { useLevelsTable } from "../../../../../hooks/levels/useList"
+import { useLessonList } from "../../../../../hooks/lessons/useList"
+import { usePersonnelTable } from "../../../../../hooks/employee/personel/useList"
 import { TuitionFees } from "../../../../../../types/employee/tuition_fees/list"
 
 interface TuitionFeesTabProps {
@@ -11,62 +18,70 @@ interface TuitionFeesTabProps {
   enabled: boolean
 }
 
-export default function TuitionFeesTab({
-  personelId,
-  enabled,
-}: TuitionFeesTabProps) {
+export default function TuitionFeesTab({ personelId, enabled }: TuitionFeesTabProps) {
   const navigate = useNavigate()
-  const [fees, setFees] = useState<TuitionFees[]>([])
 
-  const {
+  const [dateRange, setDateRange] = useState<{ startDate: string; endDate: string }>({
+    startDate: '',
+    endDate: '',
+  })
+  const [level, setLevel] = useState('')
+  const [teacher, setTeacher] = useState('')
+  const [lesson, setLesson] = useState('')
+  const [page, setPage] = useState(1)
+  const [paginate, setPaginate] = useState(10)
+  const [detailRow, setDetailRow] = useState<TuitionFees | null>(null)
 
-    getTuitionFees,
-    loading,
-    error,
-  } = useTuitionFeesShow()
+  const { fees = [], loading, error } = useTuitionFeesList({
+    enabled,
+    page,
+    per_page: paginate,
+    start_date: dateRange.startDate || undefined,
+    end_date: dateRange.endDate || undefined,
+    level_id: level || undefined,
+    lesson_id: lesson || undefined,
+    personel_id: teacher || personelId,
+  })
 
-  const { deleteExistingTuitionFees, error: deleteError } =
-    useTuitionFeesDelete()
+  const { deleteExistingTuitionFees, error: deleteError } = useTuitionFeesDelete()
 
-  // fetch on mount / enabled
-  useEffect(() => {
-    if (!enabled) return
-
-    ;(async () => {
-      const res = await getTuitionFees(personelId)
-      // the detail API returns { data: TuitionFees[] } or a single object?
-      // Here we assume getTuitionFees returns the raw array or single object:
-      const arr = Array.isArray(res) ? res : res ? [res] : []
-      setFees(arr)
-    })()
-  }, [enabled, personelId, getTuitionFees])
+  const { levelsData = [] } = useLevelsTable({ enabled: true })
+  const { lessonsData = [] } = useLessonList({ enabled: true })
+  const { personnelData: teachers = [] } = usePersonnelTable({ enabled: true })
 
   const columns: ColumnDefinition<TuitionFees>[] = useMemo(
     () => [
       {
-        key: "tarih",
-        label: "Tarih",
-        render: (row) => row.tarih || "-",
+        key: "teacher",
+        label: "Eğitmen Adı",
+        render: (row) =>
+          row.personel ? `${row.personel.ad} ${row.personel.soyad}` : "-",
+      },
+      {
+        key: "lesson_name",
+        label: "Ürün/Ders Adı",
+        render: (row) =>
+          (row as any).lesson_name || (row as any).lesson?.name || "-",
       },
       {
         key: "ders_sayisi",
-        label: "Ders Sayısı",
+        label: "Toplam Ders Saati",
         render: (row) => String(row.ders_sayisi ?? 0),
       },
       {
         key: "ders_ucreti",
-        label: "1 Ders Ücreti",
+        label: "Ders Ücreti (₺)",
         render: (row) =>
           row.ders_ucreti
-            ? `${Number(row.ders_ucreti).toLocaleString()} ₺`
-            : "0,00 ₺",
+            ? `${Number(row.ders_ucreti).toLocaleString()} ₺`
+            : "0,00 ₺",
       },
       {
         key: "toplam_ucret",
-        label: "Toplam Ücret",
+        label: "Ders Ücretleri Toplamı (₺)",
         render: (row) => {
           const tot = Number(row.ders_sayisi) * Number(row.ders_ucreti)
-          return `${tot.toLocaleString()} ₺`
+          return `${tot.toLocaleString()} ₺`
         },
       },
       {
@@ -77,17 +92,26 @@ export default function TuitionFeesTab({
             <Button
               size="sm"
               variant="primary"
+              onClick={() => setDetailRow(row)}
+              className="me-1"
+            >
+              Detay
+            </Button>
+            <Button
+              size="sm"
+              variant="info"
               onClick={() =>
                 navigate(`/personelTuitionFeeCrud/${row.id}`, {
                   state: {
                     personelId,
-                    selectedTuition: fees.find((t) => t.id === row.id),
+                    selectedTuition: row,
                   },
                 })
               }
+              className="me-1"
             >
               <i className="ti ti-pencil" />
-            </Button>{" "}
+            </Button>
             <Button
               size="sm"
               variant="danger"
@@ -99,42 +123,136 @@ export default function TuitionFeesTab({
         ),
       },
     ],
-    [navigate, personelId, fees]
+    [navigate, personelId]
   )
 
   function handleDelete(row: TuitionFees) {
     if (row.id) deleteExistingTuitionFees(row.id)
   }
 
-  return (
-    <div>
-      <div className="d-flex justify-content-between align-items-center mb-3">
-        <h6>Ders Ücreti</h6>
-        <Button
-          variant="success"
-          onClick={() =>
-            navigate("/personelTuitionFeeCrud", { state: { personelId } })
-          }
-        >
-          Ekle
-        </Button>
-      </div>
+  const totalFee = useMemo(
+    () =>
+      fees.reduce(
+        (sum, r) => sum + Number(r.ders_sayisi) * Number(r.ders_ucreti),
+        0
+      ),
+    [fees]
+  )
 
+  const footer = (
+    <div className="text-end fw-bold me-2">
+      Toplam: {totalFee.toLocaleString()} ₺
+    </div>
+  )
+
+  const filters: FilterDefinition[] = [
+    {
+      key: 'dateRange',
+      label: 'Tarih Aralığı',
+      type: 'doubledate',
+      value: dateRange,
+      onChange: (v) => setDateRange(v ?? { startDate: '', endDate: '' }),
+    },
+    {
+      key: 'level',
+      label: 'Sınıf Seviyesi',
+      type: 'select',
+      value: level,
+      onChange: setLevel,
+      options: levelsData.map((l: any) => ({ value: l.id, label: l.name })),
+    },
+    {
+      key: 'teacher',
+      label: 'Eğitmen Adı Soyadı',
+      type: 'select',
+      value: teacher,
+      onChange: setTeacher,
+      options: teachers.map((t: any) => ({
+        value: t.id,
+        label: `${t.ad} ${t.soyad}`,
+      })),
+    },
+    {
+      key: 'lesson',
+      label: 'Ürün/Ders Adı',
+      type: 'select',
+      value: lesson,
+      onChange: setLesson,
+      options: lessonsData.map((d: any) => ({ value: d.id, label: d.name })),
+    },
+  ]
+
+  return (
+    <>
+      <FilterGroup filters={filters} navigate={navigate} columnsPerRow={4} />
       <ReusableTable<TuitionFees>
+        tableMode="single"
+        onAdd={() =>
+          navigate("/personelTuitionFeeCrud", { state: { personelId } })
+        }
         columns={columns}
         data={fees}
         loading={loading}
         error={error || deleteError}
-        currentPage={1}
+        currentPage={page}
         totalPages={1}
         totalItems={fees.length}
-        onPageChange={() => {}}
-        pageSize={fees.length}
-        onPageSizeChange={() => {}}
+        onPageChange={(p) => setPage(p)}
+        pageSize={paginate}
+        onPageSizeChange={(s) => {
+          setPaginate(s)
+          setPage(1)
+        }}
         exportFileName="ders_ucreti"
         showExportButtons
         onDeleteRow={handleDelete}
+        customFooter={footer}
       />
-    </div>
+
+      {detailRow && (
+        <Modal
+          show={true}
+          onHide={() => setDetailRow(null)}
+          centered
+          size="lg"
+        >
+          <Modal.Header closeButton>
+            <Modal.Title>Detay</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <Table bordered size="sm" className="mb-0">
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Tarih</th>
+                  <th>Ders Saati</th>
+                  <th>Ders Ücreti (₺)</th>
+                  <th>Günlük Toplam (₺)</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>1</td>
+                  <td>{detailRow.tarih}</td>
+                  <td>{detailRow.ders_sayisi}</td>
+                  <td>
+                    {detailRow.ders_ucreti
+                      ? `${Number(detailRow.ders_ucreti).toLocaleString()} ₺`
+                      : '0,00 ₺'}
+                  </td>
+                  <td>
+                    {(
+                      Number(detailRow.ders_sayisi) *
+                      Number(detailRow.ders_ucreti)
+                    ).toLocaleString()}{' '}
+                    ₺
+                  </td>
+                </tr>
+              </tbody>
+            </Table>
+          </Modal.Body>
+        </Modal>
+      )}
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- enhance `Ders Ücreti` tab table with filter support
- use tuition fee list hook
- add detail modal and footer total computation

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68501f2ac8e8832cb5bbbcfc2d0261c2