### PR TITLE
Add Lesson Oct Fee index page

### DIFF
--- a/src/components/common/lesson-oct-fee/index.tsx
+++ b/src/components/common/lesson-oct-fee/index.tsx
@@ -1,0 +1,20 @@
+import TabsContainer from "../guidance/components/organisms/TabsContainer";
+import TuitionFeesTab from "../personel/personelDetail/tabs/ders-ucreti/table";
+import CouponTab from "../personel/personelDetail/tabs/kupon/table";
+import CoachingTab from "../personel/personelDetail/tabs/kocluk/table";
+import SpecialTab from "../personel/personelDetail/tabs/ozel-ders/table";
+
+export default function LessonOctFeeIndex() {
+  const tabsConfig = [
+    { label: "Ders Ücreti", content: <TuitionFeesTab /> },
+    { label: "Ders – Soru Çözüm Ücretleri", content: <CouponTab personelId={0} enabled={true} /> },
+    { label: "Koçluk Ücreti", content: <CoachingTab personelId={0} enabled={true} /> },
+    { label: "Özel Ders", content: <SpecialTab personelId={0} enabled={true} /> },
+  ];
+
+  return (
+    <div className="flex" style={{ padding: "23px 50px 0" }}>
+      <TabsContainer tabs={tabsConfig as any} />
+    </div>
+  );
+}

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -329,6 +329,9 @@ const BudgetEstimate = lazy(
 const FinancialSummary = lazy(
   () => import("../components/common/accounting/financialSummary")
 );
+const LessonOctFeeIndex = lazy(
+  () => import("../components/common/lesson-oct-fee")
+);
 
 const InvoiceTable = lazy(() => import("../components/common/invoice/table"));
 const Invoicedetail = lazy(() => import("../components/common/invoice/detail"));
@@ -940,6 +943,11 @@ export const Routedata = [
     id: 23,
     path: `${import.meta.env.BASE_URL}personel/cost-planning`,
     element: <PersonelCostPlanning />,
+  },
+  {
+    id: 68,
+    path: `${import.meta.env.BASE_URL}lesson-oct-fee`,
+    element: <LessonOctFeeIndex />,
   },
   {
     id: 24,


### PR DESCRIPTION
## Summary
- add LessonOctFeeIndex component combining multiple fee tables
- expose new Lesson Oct Fee route in routing data

## Testing
- `node -e "console.log('No tests specified')"`

------
https://chatgpt.com/codex/tasks/task_e_68504bc214f8832ca692ad8d334bd41d