### PR TITLE
Fix infinite fetch loop in tuition fees hook

### DIFF
--- a/src/components/hooks/employee/tuition_fees/useTuitionFeesList.tsx
+++ b/src/components/hooks/employee/tuition_fees/useTuitionFeesList.tsx
@@ -19,11 +19,13 @@ export function useTuitionFeesList(params: { enabled?: boolean; [key: string]: a
   useEffect(() => {
     if (!enabled) return;
 
-    dispatch(fetchTuitionFeesList({
-      ...otherParams,
-      filter,
-    }));
-  }, [enabled, filter, dispatch, otherParams]);
+    dispatch(
+      fetchTuitionFeesList({
+        ...otherParams,
+        filter,
+      })
+    );
+  }, [enabled, filter, dispatch, JSON.stringify(otherParams)]);
   const fees: TuitionFees[] = data || [];
   const loading = status === TuitionFeesListStatus.LOADING;
 


### PR DESCRIPTION
## Summary
- prevent endless dispatches in `useTuitionFeesList`

## Testing
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_685050b3c060832cb958108f273898d8