### PR TITLE
Add filters and detail modal for coaching table

### DIFF
--- a/src/components/common/personel/personelDetail/tabs/kocluk/table.tsx
+++ b/src/components/common/personel/personelDetail/tabs/kocluk/table.tsx
@@ -1,66 +1,184 @@
 
-import { useEffect, useState, useMemo } from "react"
+import { useMemo, useState } from "react"
 import { useNavigate } from "react-router-dom"
-import { Button } from "react-bootstrap"
-import ReusableTable, { ColumnDefinition } from "../../../../ReusableTable"
-import { useCoachingShow } from "../../../../../hooks/employee/coaching/useShow"
+import { Button, Modal } from "react-bootstrap"
+import ReusableTable, {
+  ColumnDefinition,
+  FilterDefinition,
+} from "../../../../ReusableTable"
+import { useCoachingList } from "../../../../../hooks/employee/coaching/useList"
 import { useCoachingDelete } from "../../../../../hooks/employee/coaching/useDelete"
+import { useLevelsTable } from "../../../../../hooks/levels/useList"
+import { useAttendanceTeachersTable } from "../../../../../hooks/attendanceTeacher/useList"
+import darkcontrol from "../../../../../../utils/darkmodecontroller"
 import { Coaching } from "../../../../../../types/employee/coaching/list"
 
-interface CoachingTabProps {
-  personelId: number
-  enabled: boolean
-}
-
-export default function CoachingTab({ personelId, enabled }: CoachingTabProps) {
+export default function CoachingTab() {
   const navigate = useNavigate()
-  const [data, setData] = useState<Coaching[]>([])
 
-  const {
-    coaching: _singleCoaching,
-    getCoaching,
-    error: detailError,
-  } = useCoachingShow()
+  const [dateRange, setDateRange] = useState({ startDate: "", endDate: "" })
+  const [level, setLevel] = useState("")
+  const [teacher, setTeacher] = useState("")
+
+  const [enabled, setEnabled] = useState({ levels: false, teachers: false })
+
+  const { levelsData } = useLevelsTable({ enabled: enabled.levels })
+  const { attendanceTeachersData: teachersData } = useAttendanceTeachersTable({
+    enabled: enabled.teachers,
+  })
+
+  const listParams = useMemo(
+    () => ({
+      enabled: true,
+      start_date: dateRange.startDate || undefined,
+      end_date: dateRange.endDate || undefined,
+      level_id: level || undefined,
+      teacher_id: teacher || undefined,
+    }),
+    [dateRange, level, teacher]
+  )
+
+  const { coachings, loading, error } = useCoachingList(listParams)
   const { deleteExistingCoaching, error: deleteError } = useCoachingDelete()
 
-  // when enabled, fetch this person's coachings
-  useEffect(() => {
-    if (!enabled) return
-      ; (async () => {
-        const res = await getCoaching(personelId)
-        // show endpoint returns array under `.data` or as array directly
-        const arr = Array.isArray(res) ? res : res ? [res] : []
-        setData(arr)
-      })()
-  }, [enabled, personelId, getCoaching])
+  interface SummaryRow {
+    teacherName: string
+    coachings: Coaching[]
+    totalSession: number
+    totalStudent: number
+    totalFee: number
+  }
 
-  const columns: ColumnDefinition<Coaching>[] = useMemo(
+  const rows: SummaryRow[] = useMemo(() => {
+    const map = new Map<string, SummaryRow>()
+    ;(coachings ?? []).forEach(c => {
+      const key = c.ad_soyad || "-"
+      if (!map.has(key)) {
+        map.set(key, {
+          teacherName: key,
+          coachings: [],
+          totalSession: 0,
+          totalStudent: 0,
+          totalFee: 0,
+        })
+      }
+      const item = map.get(key)!
+      item.coachings.push(c)
+      item.totalSession += 1
+      item.totalStudent += Number(c.ogrenci_sayisi ?? 0)
+      item.totalFee += Number(c.toplam_ucret ?? 0)
+    })
+    return Array.from(map.values())
+  }, [coachings])
+
+  const [detailRow, setDetailRow] = useState<SummaryRow | null>(null)
+
+  const columns: ColumnDefinition<SummaryRow>[] = useMemo(
+    () => [
+      { key: "teacherName", label: "Eğitmen Adı", render: r => r.teacherName },
+      {
+        key: "totalSession",
+        label: "Toplam Seans Sayısı",
+        render: r => r.totalSession.toString(),
+      },
+      {
+        key: "totalStudent",
+        label: "Toplam Öğrenci Sayısı",
+        render: r => r.totalStudent.toString(),
+      },
+      {
+        key: "totalFee",
+        label: "Toplam Koçluk Ücreti (₺)",
+        render: r => `${r.totalFee.toLocaleString()} ₺`,
+      },
+      {
+        key: "actions",
+        label: "İşlemler",
+        render: r => (
+          <Button
+            variant="primary-light"
+            size="sm"
+            className="btn-icon rounded-pill"
+            onClick={() => setDetailRow(r)}
+          >
+            <i className="ti ti-eye" />
+          </Button>
+        ),
+      },
+    ],
+    []
+  )
+
+  const filters: FilterDefinition[] = useMemo(
     () => [
       {
-        key: "tarih",
-        label: "Tarih",
-        render: row => row.tarih || "-",
+        key: "date_range",
+        label: "Tarih Aralığı",
+        type: "doubledate",
+        value: dateRange,
+        onChange: v => setDateRange(v ?? { startDate: "", endDate: "" }),
+      },
+      {
+        key: "level",
+        label: "Sınıf Seviyesi",
+        type: "select",
+        value: level,
+        onClick: () => setEnabled(e => ({ ...e, levels: true })),
+        onChange: setLevel,
+        options: (levelsData ?? []).map((l: any) => ({
+          value: String(l.id),
+          label: l.name,
+        })),
+      },
+      {
+        key: "teacher",
+        label: "Eğitmen Adı Soyadı",
+        type: "select",
+        value: teacher,
+        onClick: () => setEnabled(e => ({ ...e, teachers: true })),
+        onChange: setTeacher,
+        options: (teachersData ?? []).map((t: any) => ({
+          value: String(t.teacher_id),
+          label: t.teacher?.name_surname ?? "-",
+        })),
+      },
+    ],
+    [dateRange, level, teacher, levelsData, teachersData]
+  )
+
+  const totalAmount = rows.reduce((acc, r) => acc + r.totalFee, 0)
+  const textColor = darkcontrol.dataThemeMode === "dark" ? "#fff" : "#000"
+  const footer = (
+    <div className="d-flex justify-content-end fw-bold me-3" style={{ color: textColor }}>
+      Toplam: {totalAmount.toLocaleString()} ₺
+    </div>
+  )
+
+  function handleDeleteRow(row: Coaching) {
+    if (!row.id) return
+    deleteExistingCoaching(row.id)
+  }
+
+  const detailColumns: ColumnDefinition<Coaching>[] = useMemo(
+    () => [
+      { key: "tarih", label: "Tarih", render: r => r.tarih || "-" },
+      {
+        key: "ogrenci_adi",
+        label: "Öğrenci Adı Soyadı",
+        render: r => (r as any).ogrenci_adi || "-",
+      },
+      {
+        key: "time",
+        label: "Başlangıç- Bitiş",
+        render: r => `${(r as any).baslangic_saati || ""} - ${(r as any).bitis_saati || ""}`,
       },
       {
         key: "kisi_basi_ucreti",
-        label: "Kişi Başı",
-        render: row =>
-          row.kisi_basi_ucreti
-            ? `${Number(row.kisi_basi_ucreti).toLocaleString()} ₺`
-            : "0,00 ₺",
-      },
-      {
-        key: "ogrenci_sayisi",
-        label: "Öğrenci Sayısı",
-        render: row => row.ogrenci_sayisi?.toString() ?? "0",
-      },
-      {
-        key: "toplam_ucret",
-        label: "Toplam",
-        render: (row: { toplam_ucret: any }) =>
-          row.toplam_ucret
-            ? `${Number(row.toplam_ucret).toLocaleString()} ₺`
-            : "0,00 ₺",
+        label: "Seans Ücreti (₺)",
+        render: r =>
+          r.kisi_basi_ucreti
+            ? `${Number(r.kisi_basi_ucreti).toLocaleString()} ₺`
+            : "0,00 ₺",
       },
       {
         key: "actions",
@@ -72,10 +190,7 @@ export default function CoachingTab({ personelId, enabled }: CoachingTabProps) {
               variant="primary"
               onClick={() =>
                 navigate(`/personelCoachingCrud/${row.id}`, {
-                  state: {
-                    personelId,
-                    selectedCoaching: data.find(c => c.id === row.id),
-                  },
+                  state: { personelId: row.personel_id, selectedCoaching: row },
                 })
               }
             >
@@ -92,41 +207,58 @@ export default function CoachingTab({ personelId, enabled }: CoachingTabProps) {
         ),
       },
     ],
-    [navigate, personelId, data]
+    [navigate]
   )
 
-  function handleDelete(row: Coaching) {
-    if (row.id) deleteExistingCoaching(row.id)
-  }
+  const detailFooter = (
+    <div className="d-flex justify-content-end fw-bold me-3" style={{ color: textColor }}>
+      Toplam: {detailRow?.coachings.reduce((acc, r) => acc + Number(r.kisi_basi_ucreti ?? 0), 0).toLocaleString()} ₺
+    </div>
+  )
 
   return (
-    <div>
-      <div className="d-flex justify-content-between align-items-center mb-3">
-        <h6>Koçluk</h6>
-        <Button
-          variant="success"
-          onClick={() =>
-            navigate("/personelCoachingCrud", { state: { personelId } })
-          }
-        >
-          Ekle
-        </Button>
-      </div>
-
-      <ReusableTable<Coaching>
+    <>
+      <ReusableTable<SummaryRow>
+        tableMode="single"
+        filters={filters}
         columns={columns}
-        data={data}
-        error={detailError || deleteError}
-        currentPage={1}
-        totalPages={1}
-        totalItems={data.length}
-        pageSize={data.length}
-        onPageChange={() => { }}
-        onPageSizeChange={() => { }}
-        exportFileName="kocluk"
+        data={rows}
+        loading={loading}
+        error={error || deleteError}
         showExportButtons
-        onDeleteRow={handleDelete}
+        exportFileName="kocluk"
+        customFooter={footer}
       />
-    </div>
+
+      {detailRow && (
+        <Modal show={true} onHide={() => setDetailRow(null)} centered size="lg">
+          <Modal.Header closeButton>
+            <Modal.Title>Detay</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <div className="d-flex justify-content-end mb-2">
+              <Button
+                variant="success"
+                onClick={() =>
+                  navigate("/personelCoachingCrud", {
+                    state: { personelId: detailRow.coachings[0]?.personel_id },
+                  })
+                }
+              >
+                Ekle
+              </Button>
+            </div>
+            <ReusableTable<Coaching>
+              columns={detailColumns}
+              data={detailRow.coachings}
+              error={error || deleteError}
+              showExportButtons={false}
+              onDeleteRow={handleDeleteRow}
+              customFooter={detailFooter}
+            />
+          </Modal.Body>
+        </Modal>
+      )}
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- implement filterable coaching table
- allow filtering by date range, level, and teacher
- show aggregated results per teacher
- add detail modal with CRUD options for individual coaching sessions

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68506a7486f8832c914d0a35c8ae606a