### PR TITLE
Improve service and discount management modals

### DIFF
--- a/src/components/common/ReusableModalForm.tsx
+++ b/src/components/common/ReusableModalForm.tsx
@@ -180,6 +180,8 @@ interface ReusableModalFormProps<T extends FormikValues> {
   children?: React.ReactNode;
   activeStep?: number;
   handleStepAttempt?: (targetIndex: number) => void;
+  /** Modal boyutu (lg varsayılan) */
+  modalSize?: "sm" | "lg" | "xl";
 }
 
 /** Elemanları satır bazında gruplamak için helper */
@@ -213,6 +215,7 @@ export default function ReusableModalForm<T extends FormikValues>({
   activeStep = 0,
   buttonText,
   handleStepAttempt,
+  modalSize = "lg",
 }: ReusableModalFormProps<T>) {
   const navigate = useNavigate();
 
@@ -235,7 +238,7 @@ export default function ReusableModalForm<T extends FormikValues>({
 
   if (show) {
     return (
-      <Modal show={true} onHide={handleClose} centered size="lg">
+      <Modal show={true} onHide={handleClose} centered size={modalSize}>
         {/** OPSİYONEL STEPPER */}
         {showStepper && steps.length > 0 && (
           <div className="p-3">

--- a/src/components/common/student/service_management/discount/crud.tsx
+++ b/src/components/common/student/service_management/discount/crud.tsx
@@ -46,12 +46,14 @@ const DiscountModal: React.FC<DiscountModalProps> = ({
         name: "name",
         label: "Ad",
         type: "text",
+        placeholder: "İndirim adı...",
         required: true,
       },
       {
         name: "amount",
         label: "Ücret",
         type: "currency",
+        placeholder: "Ücret...",
         required: true,
       },
       {
@@ -159,7 +161,7 @@ const DiscountModal: React.FC<DiscountModalProps> = ({
       fields={getFields()}
       initialValues={initialValues}
       onSubmit={handleSubmit}
-      confirmButtonLabel={mode === "add" ? "Ekle" : "Güncelle"}
+      confirmButtonLabel={mode === "add" ? "Kaydet" : "Güncelle"}
       cancelButtonLabel="Vazgeç"
       isLoading={loading}
       error={error || null}

--- a/src/components/common/student/service_management/discount/table.tsx
+++ b/src/components/common/student/service_management/discount/table.tsx
@@ -5,6 +5,7 @@ import ReusableTable, {
   useDebounce,
 } from "../../../ReusableTable";
 import { useDiscountsTable } from "../../../../hooks/discounts/useList";
+import { useDiscountDelete } from "../../../../hooks/discounts/useDelete";
 import { DiscountData } from "../../../../../types/discounts/list";
 import { formatCurrency } from "../../../../../utils/formatters";
 import { useLocation, useNavigate } from "react-router-dom";
@@ -28,6 +29,7 @@ export default function DiscountTable({ serviceId }: DiscountTableProps) {
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
   const [enabled, setEnabled] = useState(false);
+  const { deleteExistingDiscount } = useDiscountDelete();
   const { state } = useLocation() as {
     state?: { service_id?: number; enabled?: boolean };
   };
@@ -159,7 +161,7 @@ export default function DiscountTable({ serviceId }: DiscountTableProps) {
       {
         key: "actions",
         label: "İşlemler",
-        render: (row) => (
+        render: (row, openDeleteModal) => (
           <div className="d-flex gap-2">
             <button
               className="btn btn-icon btn-sm btn-info-light rounded-pill"
@@ -169,7 +171,10 @@ export default function DiscountTable({ serviceId }: DiscountTableProps) {
             >
               <i className="ti ti-pencil"></i>
             </button>
-            <button className="btn btn-icon btn-sm btn-danger-light rounded-pill">
+            <button
+              className="btn btn-icon btn-sm btn-danger-light rounded-pill"
+              onClick={() => openDeleteModal && openDeleteModal(row)}
+            >
               <i className="ti ti-trash"></i>
             </button>
           </div>
@@ -199,6 +204,10 @@ export default function DiscountTable({ serviceId }: DiscountTableProps) {
             state: { service_id: currentServiceId, enabled: enabled },
           });
         }}
+        onDeleteRow={(row) => deleteExistingDiscount(row.id)}
+        deleteMessage={(row) => `${row.name} adlı indirimi silmek istediğinize emin misiniz?`}
+        deleteCancelButtonLabel="Vazgeç"
+        deleteConfirmButtonLabel="Sil"
       />
     </div>
   );

--- a/src/components/common/student/service_management/index.tsx
+++ b/src/components/common/student/service_management/index.tsx
@@ -6,6 +6,7 @@ import DiscountTable from "./discount/table"; // 2. adımda oluşturduğumuz dis
 
 export default function CombinedPage() {
   const [selectedServiceId, setSelectedServiceId] = useState<number>();
+  const [selectedServiceName, setSelectedServiceName] = useState<string>("");
   const [enabled, setEnabled] = useState(false);
 
   return (
@@ -17,6 +18,7 @@ export default function CombinedPage() {
             <ServiceTable
               onSelectService={(service) => {
                 setSelectedServiceId(service.id);
+                setSelectedServiceName(service.name);
                 setEnabled(true);
               }}
             />
@@ -25,7 +27,10 @@ export default function CombinedPage() {
 
         <Col md={6}>
           <Card>
-            <h5>Hizmetine Bağlı İndirimler</h5>
+            <h5>
+              Hizmetine Bağlı İndirimler
+              {selectedServiceName && ` - ${selectedServiceName}`}
+            </h5>
             <DiscountTable serviceId={selectedServiceId} enabled={enabled} />
           </Card>
         </Col>

--- a/src/components/common/student/service_management/service/service_management/crud.tsx
+++ b/src/components/common/student/service_management/service/service_management/crud.tsx
@@ -40,6 +40,7 @@ const ServiceTypeModal: React.FC<ServiceTypeModalProps> = ({
         name: "name",
         label: "Hizmet Adı",
         type: "text",
+        placeholder: "Hizmet adı...",
         required: true,
       },
     ];
@@ -120,12 +121,13 @@ const ServiceTypeModal: React.FC<ServiceTypeModalProps> = ({
         fields={getFields()}
         initialValues={initialValues}
         onSubmit={handleSubmit}
-        confirmButtonLabel={mode === "add" ? "Ekle" : "Güncelle"}
+        confirmButtonLabel={mode === "add" ? "Kaydet" : "Güncelle"}
         cancelButtonLabel="Vazgeç"
         isLoading={loading}
         error={error || null}
         autoGoBackOnModalClose={true}
         onClose={onClose}
+        modalSize="md"
       />
     </>
   );

--- a/src/components/common/student/service_management/service/service_management/table.tsx
+++ b/src/components/common/student/service_management/service/service_management/table.tsx
@@ -65,6 +65,7 @@ export default function ServiceTypeTable() {
       loading={loading}
       error={error}
       showModal={true}
+      modalTitle="Hizmet Türleri"
       tableMode="single"
       totalPages={totalPages}
       totalItems={totalItems}

--- a/src/components/common/student/service_management/service/table.tsx
+++ b/src/components/common/student/service_management/service/table.tsx
@@ -508,6 +508,9 @@ export default function ServiceManagementListPage({
         onDeleteRow={(row) => {
           deleteServicetype(row.id);
         }}
+        deleteMessage={(row) => `${row.name} adlı hizmeti silmek istediğinize emin misiniz?`}
+        deleteCancelButtonLabel="Vazgeç"
+        deleteConfirmButtonLabel="Sil"
         onPageSizeChange={(newPageSize) => {
           setPageSize(newPageSize);
           updatePageSize(newPageSize);


### PR DESCRIPTION
## Summary
- allow resizing of `ReusableModalForm` via new `modalSize` prop
- tweak service type modal placeholders and save button text
- show service type table in a modal with title
- localise delete messages for service & discount tables
- improve discount CRUD form placeholders & labels
- display selected service name next to discount table header

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_685113d89adc832c8248f3b2e89c9fef