### PR TITLE
Fix rendering of children in ReusableModalForm

### DIFF
--- a/src/components/common/ReusableModalForm.tsx
+++ b/src/components/common/ReusableModalForm.tsx
@@ -309,6 +309,7 @@ export default function ReusableModalForm<T extends FormikValues>({
                       })}
                     </Row>
                   ))}
+                  {children}
                 </Modal.Body>
                 {!hideButtons && (
                   <Modal.Footer>
@@ -404,20 +405,21 @@ export default function ReusableModalForm<T extends FormikValues>({
 
                 {error && <div className="alert alert-danger">{error}</div>}
 
-                {fieldChunks.map((row, idx) => (
-                  <Row key={idx}>
-                    {row.map((fieldDef) => {
-                      const span = fieldDef.col ?? (mode === "single" ? 12 : 6);
-                      return (
-                        <Col md={span} key={fieldDef.name}>
-                          {renderField(fieldDef, formik, navigate)}
-                        </Col>
-                      );
-                    })}
-                  </Row>
-                ))}
+                  {fieldChunks.map((row, idx) => (
+                    <Row key={idx}>
+                      {row.map((fieldDef) => {
+                        const span = fieldDef.col ?? (mode === "single" ? 12 : 6);
+                        return (
+                          <Col md={span} key={fieldDef.name}>
+                            {renderField(fieldDef, formik, navigate)}
+                          </Col>
+                        );
+                      })}
+                    </Row>
+                  ))}
+                  {children}
 
-                {!hideButtons && (
+                  {!hideButtons && (
                   <div className="mt-3 d-flex justify-content-end">
                     <Button
                       variant="outline-secondary"


### PR DESCRIPTION
## Summary
- ensure children passed to `ReusableModalForm` render inside the modal and fallback layout

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: missing dependencies/types)*

------
https://chatgpt.com/codex/tasks/task_e_6851334b4ff8832cba0304ef10fcbb7e