### PR TITLE
Separate service search bar

### DIFF
--- a/src/components/common/student/service_management/service/table.tsx
+++ b/src/components/common/student/service_management/service/table.tsx
@@ -18,7 +18,7 @@ import {
   formatDateForApi,
 } from "../../../../../utils/formatters";
 import { deleteServicetype } from "../../../../../slices/serviceTypes/delete/thunk";
-import { Button } from "react-bootstrap";
+import { Button, Form } from "react-bootstrap";
 import sec_buton from "../../../../../assets/images/media/sec-buton.svg";
 import sec_hover from "../../../../../assets/images/media/sec-buton-hover.svg";
 
@@ -135,6 +135,20 @@ export default function ServiceManagementListPage({
     if (key === "end_installment_date") setEndInstallmentDate(value);
   };
 
+  const handleNameInputChange = (val: string) => {
+    handleFilterChange("name", val);
+    if (val) {
+      const matchedService = servicesData?.find(
+        (item: any) => item.name.toLowerCase() === val.toLowerCase()
+      );
+      if (matchedService && matchedService.name) {
+        setName(matchedService.name);
+      }
+    } else {
+      setName("");
+    }
+  };
+
   useEffect(() => {
     if (debouncedName) {
       // name güncellemesi
@@ -214,29 +228,6 @@ export default function ServiceManagementListPage({
 
   const filters = useMemo(() => {
     const basicFilters = [
-      {
-        key: "name",
-        label: "Hizmet Adı",
-        value: inputName,
-        placeholder: "Hizmet adı...",
-        type: "text" as const,
-        onChange: (val: any) => {
-
-          setInputName(val);
-          if (val) {
-            const matchedService = servicesData?.find(
-              (item: any) => item.name.toLowerCase() === val.toLowerCase()
-            );
-            if (matchedService) {
-              if (matchedService.name) {
-                setName(matchedService.name);
-              }
-            }
-          } else {
-            setName("");
-          }
-        },
-      },
       {
         key: "branch",
         label: "Şube",
@@ -376,7 +367,7 @@ export default function ServiceManagementListPage({
     ];
 
     return basicFilters;
-  }, [name, branch, serviceTypesFilterData, branchData]);
+  }, [branch, serviceTypesFilterData, branchData]);
 
   const questionParams = useMemo(
     () => ({
@@ -487,6 +478,15 @@ export default function ServiceManagementListPage({
   );
   return (
     <>
+      <Form.Group className="mb-3">
+        <Form.Label>Hizmet Adı</Form.Label>
+        <Form.Control
+          type="text"
+          placeholder="Hizmet adı..."
+          value={inputName}
+          onChange={(e) => handleNameInputChange(e.target.value)}
+        />
+      </Form.Group>
       <ReusableTable<IService>
         columns={columns}
         data={servicesData}


### PR DESCRIPTION
## Summary
- display service name search input above filter row
- remove service name from filter config to avoid duplicate layout

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6851449e4ca4832c8af02c904827f346