### PR TITLE
Update attendance buttons with icons

### DIFF
--- a/src/components/common/pollingManagement/teachers/pages/lesson/table.tsx
+++ b/src/components/common/pollingManagement/teachers/pages/lesson/table.tsx
@@ -11,6 +11,7 @@ import { useLessonList } from '../../../../../hooks/lessons/useList';
 import { useLevelsTable } from '../../../../../hooks/levels/useList';
 import { useClassroomList } from '../../../../../hooks/classrooms/useList';
 import { useAttendanceStudentsTable } from '../../../../../hooks/attendanceStudent/useList';
+import classFullIcon from '../../../../../../assets/images/media/list-button.svg';
 
 
 interface Row {
@@ -286,7 +287,11 @@ export default function LessonPollingTable() {
                     onClick={handleSetAllCame}
                     disabled={rows.every(r => !isEditable(r) || r.status === 0)}
                 >
-                    Sınıf Tam
+                    <img
+                        src={classFullIcon}
+                        alt="Sınıf Tam"
+                        style={{ width: 28, height: 28 }}
+                    />
                 </button>
             </div>
 

--- a/src/components/common/pollingManagement/teachers/pages/teachers/table.tsx
+++ b/src/components/common/pollingManagement/teachers/pages/teachers/table.tsx
@@ -10,6 +10,7 @@ import { useLessonList } from '../../../../../hooks/lessons/useList';
 import { useLevelsTable } from '../../../../../hooks/levels/useList';
 import { useClassroomList } from '../../../../../hooks/classrooms/useList';
 import { useAttendanceStudentsTable } from '../../../../../hooks/attendanceStudent/useList';
+import classFullIcon from '../../../../../../assets/images/media/list-button.svg';
 
 
 interface Row {
@@ -288,7 +289,11 @@ export default function LessonPollingTable() {
                     onClick={setAllCame}
                     disabled={rows.every(r => !isEditable(r) || r.status === 0)}
                 >
-                    Sınıf Tam
+                    <img
+                        src={classFullIcon}
+                        alt="Sınıf Tam"
+                        style={{ width: 28, height: 28 }}
+                    />
                 </button>
             </div>
 

--- a/src/components/common/pollingManagement/teachers/pages/teachersPolling/table.tsx
+++ b/src/components/common/pollingManagement/teachers/pages/teachersPolling/table.tsx
@@ -10,6 +10,7 @@ import { useLessonList } from '../../../../../hooks/lessons/useList';
 import { useLevelsTable } from '../../../../../hooks/levels/useList';
 import { useClassroomList } from '../../../../../hooks/classrooms/useList';
 import { useAttendanceStudentsTable } from '../../../../../hooks/attendanceStudent/useList';
+import classFullIcon from '../../../../../../assets/images/media/list-button.svg';
 
 
 interface Row {
@@ -298,7 +299,11 @@ export default function LessonPollingTable() {
                     onClick={setAllCame}
                     disabled={rows.every(r => !isEditable(r) || r.status === 0)}
                 >
-                    Sınıf Tam
+                    <img
+                        src={classFullIcon}
+                        alt="Sınıf Tam"
+                        style={{ width: 28, height: 28 }}
+                    />
                 </button>
             </div>
 


### PR DESCRIPTION
## Summary
- replace "Sınıf Tam" buttons with an icon in teacher polling pages

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: missing modules / TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68541b6209d0832caa8e2e1b2e981431