### PR TITLE
Fix Sınıf Tam button icon path

### DIFF
--- a/src/components/common/pollingManagement/teachers/pages/lesson/table.tsx
+++ b/src/components/common/pollingManagement/teachers/pages/lesson/table.tsx
@@ -11,7 +11,7 @@ import { useLessonList } from '../../../../../hooks/lessons/useList';
 import { useLevelsTable } from '../../../../../hooks/levels/useList';
 import { useClassroomList } from '../../../../../hooks/classrooms/useList';
 import { useAttendanceStudentsTable } from '../../../../../hooks/attendanceStudent/useList';
-import sınıftam from "../../../../../../assets/images/media/sınıftam.svg";
+import sınıfTam from "../../../../../../assets/images/media/sınıf-tam.svg";
 
 
 interface Row {
@@ -288,7 +288,7 @@ export default function LessonPollingTable() {
                     disabled={rows.every(r => !isEditable(r) || r.status === 0)}
                 >
                     <img
-                        src={sınıftam}
+                        src={sınıfTam}
                         alt="Sınıf Tam"
                         style={{ width: 28, height: 28 }}
                     />

--- a/src/components/common/pollingManagement/teachers/pages/teachers/table.tsx
+++ b/src/components/common/pollingManagement/teachers/pages/teachers/table.tsx
@@ -10,7 +10,7 @@ import { useLessonList } from '../../../../../hooks/lessons/useList';
 import { useLevelsTable } from '../../../../../hooks/levels/useList';
 import { useClassroomList } from '../../../../../hooks/classrooms/useList';
 import { useAttendanceStudentsTable } from '../../../../../hooks/attendanceStudent/useList';
-import sınıftam from "../../../../../../assets/images/media/sınıftam.svg";
+import sınıfTam from "../../../../../../assets/images/media/sınıf-tam.svg";
 
 
 interface Row {
@@ -290,7 +290,7 @@ export default function LessonPollingTable() {
                     disabled={rows.every(r => !isEditable(r) || r.status === 0)}
                 >
                     <img
-                        src={sınıftam}
+                        src={sınıfTam}
                         alt="Sınıf Tam"
                         style={{ width: 28, height: 28 }}
                     />

--- a/src/components/common/pollingManagement/teachers/pages/teachersPolling/table.tsx
+++ b/src/components/common/pollingManagement/teachers/pages/teachersPolling/table.tsx
@@ -10,7 +10,7 @@ import { useLessonList } from '../../../../../hooks/lessons/useList';
 import { useLevelsTable } from '../../../../../hooks/levels/useList';
 import { useClassroomList } from '../../../../../hooks/classrooms/useList';
 import { useAttendanceStudentsTable } from '../../../../../hooks/attendanceStudent/useList';
-import sınıftam from "../../../../../../assets/images/media/sınıftam.svg";
+import sınıfTam from "../../../../../../assets/images/media/sınıf-tam.svg";
 
 
 interface Row {
@@ -300,7 +300,7 @@ export default function LessonPollingTable() {
                     disabled={rows.every(r => !isEditable(r) || r.status === 0)}
                 >
                     <img
-                        src={sınıftam}
+                        src={sınıfTam}
                         alt="Sınıf Tam"
                         style={{ width: 28, height: 28 }}
                     />


### PR DESCRIPTION
## Summary
- fix the import path for **Sınıf Tam** icon in lesson, teachers and teachersPolling tables

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_685421a3e9f0832c8d7dc47fecebe287