### PR TITLE
Fix Sınıf Tam button icon path

### DIFF
--- a/src/components/common/pollingManagement/teachers/pages/lesson/table.tsx
+++ b/src/components/common/pollingManagement/teachers/pages/lesson/table.tsx
@@ -11,7 +11,9 @@ import { useLessonList } from '../../../../../hooks/lessons/useList';
 import { useLevelsTable } from '../../../../../hooks/levels/useList';
 import { useClassroomList } from '../../../../../hooks/classrooms/useList';
 import { useAttendanceStudentsTable } from '../../../../../hooks/attendanceStudent/useList';
-import sınıftam from "../../../../../../assets/images/media/sınıftam.svg";
+import sınıfTam from "../../../../../../assets/images/media/sınıf-tam.svg";
+import sınıfTamHover from "../../../../../../assets/images/media/sınıf-tam-hover.svg";
+import { Button } from 'react-bootstrap';
 
 
 interface Row {
@@ -278,21 +280,25 @@ export default function LessonPollingTable() {
 
             <div style={{ display: 'flex', alignItems: 'center', marginBottom: 10 }}>
                 {/* <span style={{ fontWeight: 600, fontSize: 18 }}>Ders Yoklama</span> */}
-                <button
-                    style={{
-                        marginLeft: 'auto', background: '#52c41a', color: '#fff',
-                        border: 'none', borderRadius: 6, padding: '6px 16px',
-                        cursor: 'pointer', fontWeight: 500,
-                    }}
+                <Button
+                    style={{ marginLeft: 'auto', padding: 0 }}
+                    variant=""
                     onClick={handleSetAllCame}
                     disabled={rows.every(r => !isEditable(r) || r.status === 0)}
                 >
                     <img
-                        src={sınıftam}
+                        src={sınıfTam}
                         alt="Sınıf Tam"
-                        style={{ width: 28, height: 28 }}
+                        width={24}
+                        height={24}
+                        onMouseEnter={(e) => {
+                            (e.currentTarget as HTMLImageElement).src = sınıfTamHover;
+                        }}
+                        onMouseLeave={(e) => {
+                            (e.currentTarget as HTMLImageElement).src = sınıfTam;
+                        }}
                     />
-                </button>
+                </Button>
             </div>
 
             <ReusableTable<Row>

--- a/src/components/common/pollingManagement/teachers/pages/teachers/table.tsx
+++ b/src/components/common/pollingManagement/teachers/pages/teachers/table.tsx
@@ -10,7 +10,9 @@ import { useLessonList } from '../../../../../hooks/lessons/useList';
 import { useLevelsTable } from '../../../../../hooks/levels/useList';
 import { useClassroomList } from '../../../../../hooks/classrooms/useList';
 import { useAttendanceStudentsTable } from '../../../../../hooks/attendanceStudent/useList';
-import sınıftam from "../../../../../../assets/images/media/sınıftam.svg";
+import sınıfTam from "../../../../../../assets/images/media/sınıf-tam.svg";
+import sınıfTamHover from "../../../../../../assets/images/media/sınıf-tam-hover.svg";
+import { Button } from 'react-bootstrap';
 
 
 interface Row {
@@ -280,21 +282,25 @@ export default function LessonPollingTable() {
 
             <div style={{ display: 'flex', alignItems: 'center', marginBottom: 10 }}>
                 {/* <span style={{ fontWeight: 600, fontSize: 18 }}>Öğretmen Yoklama</span> */}
-                <button
-                    style={{
-                        marginLeft: 'auto', background: '#52c41a', color: '#fff',
-                        border: 'none', borderRadius: 6, padding: '6px 16px',
-                        cursor: 'pointer', fontWeight: 500,
-                    }}
+                <Button
+                    style={{ marginLeft: 'auto', padding: 0 }}
+                    variant=""
                     onClick={setAllCame}
                     disabled={rows.every(r => !isEditable(r) || r.status === 0)}
                 >
                     <img
-                        src={sınıftam}
+                        src={sınıfTam}
                         alt="Sınıf Tam"
-                        style={{ width: 28, height: 28 }}
+                        width={24}
+                        height={24}
+                        onMouseEnter={(e) => {
+                            (e.currentTarget as HTMLImageElement).src = sınıfTamHover;
+                        }}
+                        onMouseLeave={(e) => {
+                            (e.currentTarget as HTMLImageElement).src = sınıfTam;
+                        }}
                     />
-                </button>
+                </Button>
             </div>
 
             <ReusableTable<Row>

--- a/src/components/common/pollingManagement/teachers/pages/teachersPolling/table.tsx
+++ b/src/components/common/pollingManagement/teachers/pages/teachersPolling/table.tsx
@@ -10,7 +10,9 @@ import { useLessonList } from '../../../../../hooks/lessons/useList';
 import { useLevelsTable } from '../../../../../hooks/levels/useList';
 import { useClassroomList } from '../../../../../hooks/classrooms/useList';
 import { useAttendanceStudentsTable } from '../../../../../hooks/attendanceStudent/useList';
-import sınıftam from "../../../../../../assets/images/media/sınıftam.svg";
+import sınıfTam from "../../../../../../assets/images/media/sınıf-tam.svg";
+import sınıfTamHover from "../../../../../../assets/images/media/sınıf-tam-hover.svg";
+import { Button } from 'react-bootstrap';
 
 
 interface Row {
@@ -290,21 +292,25 @@ export default function LessonPollingTable() {
 
             <div style={{ display: 'flex', alignItems: 'center', marginBottom: 10 }}>
                 {/* <span style={{ fontWeight: 600, fontSize: 18 }}>Ders Yoklama</span> */}
-                <button
-                    style={{
-                        marginLeft: 'auto', background: '#52c41a', color: '#fff',
-                        border: 'none', borderRadius: 6, padding: '6px 16px',
-                        cursor: 'pointer', fontWeight: 500,
-                    }}
+                <Button
+                    style={{ marginLeft: 'auto', padding: 0 }}
+                    variant=""
                     onClick={setAllCame}
                     disabled={rows.every(r => !isEditable(r) || r.status === 0)}
                 >
                     <img
-                        src={sınıftam}
+                        src={sınıfTam}
                         alt="Sınıf Tam"
-                        style={{ width: 28, height: 28 }}
+                        width={24}
+                        height={24}
+                        onMouseEnter={(e) => {
+                            (e.currentTarget as HTMLImageElement).src = sınıfTamHover;
+                        }}
+                        onMouseLeave={(e) => {
+                            (e.currentTarget as HTMLImageElement).src = sınıfTam;
+                        }}
                     />
-                </button>
+                </Button>
             </div>
 
             <ReusableTable<Row>


### PR DESCRIPTION
## Summary
- fix the import path for **Sınıf Tam** icon in lesson, teachers and teachersPolling tables
- restyle Sınıf Tam buttons so the icon appears round without a colored background
- match the style and size with the **Ödeme Al** button, including hover state

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_685421a3e9f0832c8d7dc47fecebe287