### PR TITLE
Fix full class button across pages

### DIFF
--- a/src/components/common/pollingManagement/teachers/pages/lesson/table.tsx
+++ b/src/components/common/pollingManagement/teachers/pages/lesson/table.tsx
@@ -279,14 +279,16 @@ export default function LessonPollingTable() {
 
             <div style={{ display: 'flex', alignItems: 'center', marginBottom: 10 }}>
                 {/* <span style={{ fontWeight: 600, fontSize: 18 }}>Ders Yoklama</span> */}
-                <Button variant="">
+                <Button
+                    variant=""
+                    onClick={handleSetAllCame}
+                >
                     <img
                         src={sınıfTam}
                         alt="Sınıf Tam"
                         style={{ width: 24, height: 24 }}
                         onMouseEnter={e => { (e.currentTarget as HTMLImageElement).src = sınıfTamHover; }}
                         onMouseLeave={e => { (e.currentTarget as HTMLImageElement).src = sınıfTam; }}
-                        onClick={handleSetAllCame}
                     />
                 </Button>
 

--- a/src/components/common/pollingManagement/teachers/pages/teachers/table.tsx
+++ b/src/components/common/pollingManagement/teachers/pages/teachers/table.tsx
@@ -266,8 +266,8 @@ export default function LessonPollingTable() {
     ]);
 
 
-    function handleSetAllCame(event: MouseEvent<HTMLImageElement>): void {
-        throw new Error('Function not implemented.');
+    function handleSetAllCame(_event: MouseEvent<HTMLImageElement>): void {
+        setAllCame();
     }
 
     return (
@@ -285,14 +285,16 @@ export default function LessonPollingTable() {
 
             <div style={{ display: 'flex', alignItems: 'center', marginBottom: 10 }}>
                 {/* <span style={{ fontWeight: 600, fontSize: 18 }}>Öğretmen Yoklama</span> */}
-                <Button variant="">
+                <Button
+                    variant=""
+                    onClick={handleSetAllCame}
+                >
                     <img
                         src={sınıfTam}
                         alt="Sınıf Tam"
                         style={{ width: 24, height: 24 }}
                         onMouseEnter={e => { (e.currentTarget as HTMLImageElement).src = sınıfTamHover; }}
                         onMouseLeave={e => { (e.currentTarget as HTMLImageElement).src = sınıfTam; }}
-                        onClick={handleSetAllCame}
                     />
                 </Button>
 

--- a/src/components/common/pollingManagement/teachers/pages/teachersPolling/table.tsx
+++ b/src/components/common/pollingManagement/teachers/pages/teachersPolling/table.tsx
@@ -277,8 +277,8 @@ export default function LessonPollingTable() {
         lessonsData, levelsData, classroomData, studentsData,
     ]);
 
-    function handleSetAllCame(event: MouseEvent<HTMLButtonElement>): void {
-        throw new Error('Function not implemented.');
+    function handleSetAllCame(_event: MouseEvent<HTMLButtonElement>): void {
+        setAllCame();
     }
 
     /* —— Render —— */


### PR DESCRIPTION
## Summary
- ensure the **Sınıf Tam** button triggers attendance update on click on all pages
- make the button container clickable in lesson and teachers pages

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: couldn't find eslint.config)*

------
https://chatgpt.com/codex/tasks/task_e_6854ff77acdc832ca3a53dcfccd49ce0