### PR TITLE
Add bulletins redux module

### DIFF
--- a/src/components/hooks/bulletin/useAdd.tsx
+++ b/src/components/hooks/bulletin/useAdd.tsx
@@ -1,0 +1,24 @@
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { AppDispatch } from '../../../store';
+import { RootState } from '../../../store/rootReducer';
+import { addBulletin } from '../../../slices/bulletins/add/thunk';
+import { BulletinsAddPayload } from '../../../types/bulletins/add';
+
+export function useBulletinAdd() {
+  const dispatch = useDispatch<AppDispatch>();
+  const { data, status, error } = useSelector((state: RootState) => state.bulletinAdd);
+
+  const addNewBulletin = useCallback(
+    async (payload: BulletinsAddPayload) => {
+      const resultAction = await dispatch(addBulletin(payload));
+      if (addBulletin.fulfilled.match(resultAction)) {
+        return resultAction.payload;
+      }
+      return null;
+    },
+    [dispatch]
+  );
+
+  return { addedBulletin: data, status, error, addNewBulletin };
+}

--- a/src/components/hooks/bulletin/useDelete.tsx
+++ b/src/components/hooks/bulletin/useDelete.tsx
@@ -1,0 +1,23 @@
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { AppDispatch } from '../../../store';
+import { RootState } from '../../../store/rootReducer';
+import { deleteBulletin } from '../../../slices/bulletins/delete/thunk';
+
+export function useBulletinDelete() {
+  const dispatch = useDispatch<AppDispatch>();
+  const { data, status, error } = useSelector((state: RootState) => state.bulletinDelete);
+
+  const deleteExistingBulletin = useCallback(
+    async (bulletinId: number) => {
+      const resultAction = await dispatch(deleteBulletin(bulletinId));
+      if (deleteBulletin.fulfilled.match(resultAction)) {
+        return resultAction.payload;
+      }
+      return null;
+    },
+    [dispatch]
+  );
+
+  return { deletedBulletin: data, status, error, deleteExistingBulletin };
+}

--- a/src/components/hooks/bulletin/useDetail.tsx
+++ b/src/components/hooks/bulletin/useDetail.tsx
@@ -1,0 +1,24 @@
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { AppDispatch } from '../../../store';
+import { RootState } from '../../../store/rootReducer';
+import { fetchBulletin } from '../../../slices/bulletins/detail/thunk';
+
+export function useBulletinShow() {
+  const dispatch = useDispatch<AppDispatch>();
+  const { data, status, error } = useSelector((state: RootState) => state.bulletinShow);
+
+  const getBulletin = useCallback(
+    async (bulletinId: number) => {
+      const resultAction = await dispatch(fetchBulletin(bulletinId));
+      if (fetchBulletin.fulfilled.match(resultAction)) {
+        return resultAction.payload;
+      }
+      return null;
+    },
+    [dispatch]
+  );
+
+  return { bulletin: data, status, error, getBulletin };
+}
+export default useBulletinShow;

--- a/src/components/hooks/bulletin/useList.tsx
+++ b/src/components/hooks/bulletin/useList.tsx
@@ -1,0 +1,54 @@
+import { useState, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '../../../store/rootReducer';
+import { AppDispatch } from '../../../store';
+import { fetchBulletins } from '../../../slices/bulletins/list/thunk';
+import { data, meta, BulletinListArg } from '../../../types/bulletins/list';
+import { BulletinsListStatus } from '../../../enums/bulletins/list';
+
+export function useBulletinsTable(params: BulletinListArg) {
+  const dispatch = useDispatch<AppDispatch>();
+  const [page, setPage] = useState<number>(params.page || 1);
+  const [pageSize, setPageSize] = useState<number>(params.pageSize || 10);
+  const [filter, setFilter] = useState<any>(null);
+
+  const { data, meta, status, error } = useSelector(
+    (state: RootState) => state.bulletinList
+  );
+
+  useEffect(() => {
+    const { enabled = true, ...restParams } = params;
+    if (!enabled) return;
+
+    const query: BulletinListArg = {
+      enabled,
+      ...restParams,
+      filter,
+      page,
+      pageSize,
+      per_page: pageSize,
+    };
+
+    dispatch(fetchBulletins(query));
+  }, [dispatch, filter, page, pageSize, params]);
+
+  const loading = status === BulletinsListStatus.LOADING;
+  const bulletinsData: data[] = data || [];
+  const paginationMeta: meta | null = meta;
+  const totalPages = paginationMeta ? paginationMeta.last_page : 1;
+  const totalItems = paginationMeta ? paginationMeta.total : 0;
+
+  return {
+    bulletinsData,
+    loading,
+    error,
+    page,
+    setPage,
+    pageSize,
+    setPageSize,
+    filter,
+    setFilter,
+    totalPages,
+    totalItems,
+  };
+}

--- a/src/components/hooks/bulletin/useUpdate.tsx
+++ b/src/components/hooks/bulletin/useUpdate.tsx
@@ -1,0 +1,24 @@
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { AppDispatch } from '../../../store';
+import { RootState } from '../../../store/rootReducer';
+import { updateBulletin } from '../../../slices/bulletins/update/thunk';
+import { BulletinsUpdatePayload } from '../../../types/bulletins/update';
+
+export function useBulletinUpdate() {
+  const dispatch = useDispatch<AppDispatch>();
+  const { data, status, error } = useSelector((state: RootState) => state.bulletinUpdate);
+
+  const updateExistingBulletin = useCallback(
+    async (payload: BulletinsUpdatePayload) => {
+      const resultAction = await dispatch(updateBulletin(payload));
+      if (updateBulletin.fulfilled.match(resultAction)) {
+        return resultAction.payload;
+      }
+      return null;
+    },
+    [dispatch]
+  );
+
+  return { updatedBulletin: data, status, error, updateExistingBulletin };
+}

--- a/src/enums/bulletins/list.tsx
+++ b/src/enums/bulletins/list.tsx
@@ -1,0 +1,7 @@
+export enum BulletinsListStatus {
+  IDLE = 'IDLE',
+  LOADING = 'LOADING',
+  SUCCEEDED = 'SUCCEEDED',
+  FAILED = 'FAILED',
+}
+export default BulletinsListStatus;

--- a/src/helpers/url_helper.ts
+++ b/src/helpers/url_helper.ts
@@ -26,6 +26,7 @@ export const DEBTS = '/debts';
 export const DISCOUNT_STUDENT = '/enrollment-report';
 export const TRANSFERS = '/transfers';
 export const ESTIMATED_BUDGETS = '/estimated-budgets';
+export const BULLETINS = '/bulletins';
 
 export const DAILY_SUMMARY = '/accounting/daily-summary';
 export const FINANCIAL_SUMMARY = '/accounting/financial-summary';

--- a/src/slices/bulletins/add/reducer.tsx
+++ b/src/slices/bulletins/add/reducer.tsx
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { addBulletin } from './thunk';
+import { BulletinsAddState } from '../../../types/bulletins/add';
+import { BulletinsListStatus } from '../../../enums/bulletins/list';
+
+const initialState: BulletinsAddState = {
+  data: null,
+  status: BulletinsListStatus.IDLE,
+  error: null,
+};
+
+const bulletinAddSlice = createSlice({
+  name: 'bulletinAdd',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(addBulletin.pending, (state) => {
+        state.status = BulletinsListStatus.LOADING;
+        state.error = null;
+      })
+      .addCase(addBulletin.fulfilled, (state, action: PayloadAction<any>) => {
+        state.status = BulletinsListStatus.SUCCEEDED;
+        state.data = action.payload;
+      })
+      .addCase(addBulletin.rejected, (state, action: PayloadAction<any>) => {
+        state.status = BulletinsListStatus.FAILED;
+        state.error = action.payload;
+      });
+  },
+});
+
+export default bulletinAddSlice.reducer;

--- a/src/slices/bulletins/add/thunk.tsx
+++ b/src/slices/bulletins/add/thunk.tsx
@@ -1,0 +1,17 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import axiosInstance from '../../../services/axiosClient';
+import { BULLETINS } from '../../../helpers/url_helper';
+import { BulletinsAddPayload } from '../../../types/bulletins/add';
+import { data } from '../../../types/bulletins/list';
+
+export const addBulletin = createAsyncThunk<data, BulletinsAddPayload>(
+  'bulletins/addBulletin',
+  async (payload, { rejectWithValue }) => {
+    try {
+      const resp = await axiosInstance.post(BULLETINS, payload);
+      return resp.data.data as data;
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || 'Add bulletin failed');
+    }
+  }
+);

--- a/src/slices/bulletins/delete/reducer.tsx
+++ b/src/slices/bulletins/delete/reducer.tsx
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { deleteBulletin } from './thunk';
+import { BulletinsDeleteState } from '../../../types/bulletins/delete';
+import { BulletinsListStatus } from '../../../enums/bulletins/list';
+
+const initialState: BulletinsDeleteState = {
+  data: null,
+  status: BulletinsListStatus.IDLE,
+  error: null,
+};
+
+const bulletinsDeleteSlice = createSlice({
+  name: 'bulletinsDelete',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(deleteBulletin.pending, (state) => {
+        state.status = BulletinsListStatus.LOADING;
+        state.error = null;
+      })
+      .addCase(deleteBulletin.fulfilled, (state, action: PayloadAction<any>) => {
+        state.status = BulletinsListStatus.SUCCEEDED;
+        state.data = action.payload;
+      })
+      .addCase(deleteBulletin.rejected, (state, action: PayloadAction<any>) => {
+        state.status = BulletinsListStatus.FAILED;
+        state.error = action.payload;
+      });
+  },
+});
+
+export default bulletinsDeleteSlice.reducer;

--- a/src/slices/bulletins/delete/thunk.tsx
+++ b/src/slices/bulletins/delete/thunk.tsx
@@ -1,0 +1,16 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import axiosInstance from '../../../services/axiosClient';
+import { BULLETINS } from '../../../helpers/url_helper';
+import { BulletinsDeleteState } from '../../../types/bulletins/delete';
+
+export const deleteBulletin = createAsyncThunk<BulletinsDeleteState, number>(
+  'bulletins/deleteBulletin',
+  async (bulletinId, { rejectWithValue }) => {
+    try {
+      const resp = await axiosInstance.delete(`${BULLETINS}/${bulletinId}`);
+      return resp.data as BulletinsDeleteState;
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || 'Delete bulletin failed');
+    }
+  }
+);

--- a/src/slices/bulletins/detail/reducer.tsx
+++ b/src/slices/bulletins/detail/reducer.tsx
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { fetchBulletin } from './thunk';
+import { BulletinShowState } from '../../../types/bulletins/detail';
+import { BulletinsListStatus } from '../../../enums/bulletins/list';
+
+const initialState: BulletinShowState = {
+  data: null,
+  status: BulletinsListStatus.IDLE,
+  error: null,
+};
+
+const bulletinShowSlice = createSlice({
+  name: 'bulletinShow',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchBulletin.pending, (state) => {
+        state.status = BulletinsListStatus.LOADING;
+        state.error = null;
+      })
+      .addCase(fetchBulletin.fulfilled, (state, action: PayloadAction<any>) => {
+        state.status = BulletinsListStatus.SUCCEEDED;
+        state.data = action.payload;
+      })
+      .addCase(fetchBulletin.rejected, (state, action: PayloadAction<any>) => {
+        state.status = BulletinsListStatus.FAILED;
+        state.error = action.payload;
+      });
+  },
+});
+
+export default bulletinShowSlice.reducer;

--- a/src/slices/bulletins/detail/thunk.tsx
+++ b/src/slices/bulletins/detail/thunk.tsx
@@ -1,0 +1,16 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import axiosInstance from '../../../services/axiosClient';
+import { BULLETINS } from '../../../helpers/url_helper';
+import { BulletinShowState } from '../../../types/bulletins/detail';
+
+export const fetchBulletin = createAsyncThunk<BulletinShowState, number>(
+  'bulletins/fetchBulletin',
+  async (bulletinId, { rejectWithValue }) => {
+    try {
+      const resp = await axiosInstance.get(`${BULLETINS}/${bulletinId}`);
+      return resp.data.data as BulletinShowState;
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || 'Fetch bulletin failed');
+    }
+  }
+);

--- a/src/slices/bulletins/list/reducer.tsx
+++ b/src/slices/bulletins/list/reducer.tsx
@@ -1,0 +1,45 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { fetchBulletins } from './thunk';
+import { ListBulletinResponse } from '../../../types/bulletins/list';
+import { BulletinsListStatus } from '../../../enums/bulletins/list';
+
+export interface BulletinsListState {
+  data: ListBulletinResponse['data'] | null;
+  links: ListBulletinResponse['links'] | null;
+  meta: ListBulletinResponse['meta'] | null;
+  status: BulletinsListStatus;
+  error: string | null;
+}
+
+const initialState: BulletinsListState = {
+  data: null,
+  links: null,
+  meta: null,
+  status: BulletinsListStatus.IDLE,
+  error: null,
+};
+
+const bulletinsListSlice = createSlice({
+  name: 'bulletins/list',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchBulletins.pending, (state) => {
+        state.status = BulletinsListStatus.LOADING;
+        state.error = null;
+      })
+      .addCase(fetchBulletins.fulfilled, (state, action: PayloadAction<ListBulletinResponse>) => {
+        state.status = BulletinsListStatus.SUCCEEDED;
+        state.data = action.payload.data;
+        state.links = action.payload.links;
+        state.meta = action.payload.meta;
+      })
+      .addCase(fetchBulletins.rejected, (state, action: PayloadAction<any>) => {
+        state.status = BulletinsListStatus.FAILED;
+        state.error = action.payload || 'Fetch bulletins failed';
+      });
+  },
+});
+
+export default bulletinsListSlice.reducer;

--- a/src/slices/bulletins/list/thunk.tsx
+++ b/src/slices/bulletins/list/thunk.tsx
@@ -1,0 +1,23 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import axiosInstance from '../../../services/axiosClient';
+import { BULLETINS } from '../../../helpers/url_helper';
+import { ListBulletinResponse, BulletinListArg } from '../../../types/bulletins/list';
+
+export const fetchBulletins = createAsyncThunk<ListBulletinResponse, BulletinListArg>(
+  'bulletins/fetchBulletins',
+  async (queryParams, { rejectWithValue }) => {
+    try {
+      const query = new URLSearchParams();
+      Object.entries(queryParams).forEach(([key, value]) => {
+        if (value !== undefined && value !== null) {
+          query.append(key, String(value));
+        }
+      });
+      const queryString = query.toString();
+      const resp = await axiosInstance.get(`${BULLETINS}?${queryString}`);
+      return resp.data as ListBulletinResponse;
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || 'Fetch bulletins failed');
+    }
+  }
+);

--- a/src/slices/bulletins/update/reducer.tsx
+++ b/src/slices/bulletins/update/reducer.tsx
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { updateBulletin } from './thunk';
+import { BulletinsUpdateState } from '../../../types/bulletins/update';
+import { BulletinsListStatus } from '../../../enums/bulletins/list';
+
+const initialState: BulletinsUpdateState = {
+  data: null,
+  status: BulletinsListStatus.IDLE,
+  error: null,
+};
+
+const bulletinsUpdateSlice = createSlice({
+  name: 'bulletinsUpdate',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(updateBulletin.pending, (state) => {
+        state.status = BulletinsListStatus.LOADING;
+        state.error = null;
+      })
+      .addCase(updateBulletin.fulfilled, (state, action: PayloadAction<any>) => {
+        state.status = BulletinsListStatus.SUCCEEDED;
+        state.data = action.payload;
+      })
+      .addCase(updateBulletin.rejected, (state, action: PayloadAction<any>) => {
+        state.status = BulletinsListStatus.FAILED;
+        state.error = action.payload;
+      });
+  },
+});
+
+export default bulletinsUpdateSlice.reducer;

--- a/src/slices/bulletins/update/thunk.tsx
+++ b/src/slices/bulletins/update/thunk.tsx
@@ -1,0 +1,17 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import axiosInstance from '../../../services/axiosClient';
+import { BULLETINS } from '../../../helpers/url_helper';
+import { BulletinsUpdatePayload } from '../../../types/bulletins/update';
+import { data } from '../../../types/bulletins/list';
+
+export const updateBulletin = createAsyncThunk<data, BulletinsUpdatePayload>(
+  'bulletins/updateBulletin',
+  async ({ bulletinId, payload }, { rejectWithValue }) => {
+    try {
+      const resp = await axiosInstance.put(`${BULLETINS}/${bulletinId}`, payload);
+      return resp.data.data as data;
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || 'Update bulletin failed');
+    }
+  }
+);

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -54,6 +54,11 @@ import supplierDeleteReducer from '../slices/suppliers/supplier/delete/reducer';
 import supplierListReducer from '../slices/suppliers/supplier/list/reducer';
 import supplierShowReducer from '../slices/suppliers/supplier/show/reducer';
 import overduePaymentsSlice from '../slices/overduePayments/list/reducer'; // Assuming you have a courseListSlice for listing courses
+import bulletinListSlice from '../slices/bulletins/list/reducer';
+import bulletinShowSlice from '../slices/bulletins/detail/reducer';
+import bulletinAddSlice from '../slices/bulletins/add/reducer';
+import bulletinUpdateSlice from '../slices/bulletins/update/reducer';
+import bulletinDeleteSlice from '../slices/bulletins/delete/reducer';
 // Transfers
 import transferListSlice from '../slices/transfers/list/reducer'; // Assuming you have a courseListSlice for listing courses
 import transferAddSlice from '../slices/transfers/add/reducer'; // Assuming you have a courseListSlice for adding courses
@@ -632,6 +637,11 @@ const combinedReducer = combineReducers({
   debtList: DebtListSlice,
   discountStudentList: discountStudentListSlice,
   overduePayments: overduePaymentsSlice,
+  bulletinList: bulletinListSlice,
+  bulletinShow: bulletinShowSlice,
+  bulletinAdd: bulletinAddSlice,
+  bulletinUpdate: bulletinUpdateSlice,
+  bulletinDelete: bulletinDeleteSlice,
   // Transfers
   transferList: transferListSlice,
   transferAdd: transferAddSlice,

--- a/src/types/bulletins/add.tsx
+++ b/src/types/bulletins/add.tsx
@@ -1,0 +1,20 @@
+import { data } from './list';
+import { BulletinsListStatus } from '../../enums/bulletins/list';
+
+export interface BulletinsAddPayload {
+  id?: number;
+  title: string;
+  content: string;
+  category_id: number;
+  start_date: string;
+  end_date: string;
+  created_by: number;
+  status: number;
+  group_id: number;
+}
+
+export interface BulletinsAddState {
+  data: data | null;
+  status: BulletinsListStatus;
+  error: string | null;
+}

--- a/src/types/bulletins/delete.tsx
+++ b/src/types/bulletins/delete.tsx
@@ -1,0 +1,12 @@
+import { data } from './list';
+import { BulletinsListStatus } from '../../enums/bulletins/list';
+
+export interface BulletinsDeletePayload {
+  id?: number;
+}
+
+export interface BulletinsDeleteState {
+  data: data | null;
+  status: BulletinsListStatus;
+  error: string | null;
+}

--- a/src/types/bulletins/detail.tsx
+++ b/src/types/bulletins/detail.tsx
@@ -1,0 +1,8 @@
+import { data } from './list';
+import { BulletinsListStatus } from '../../enums/bulletins/list';
+
+export interface BulletinShowState {
+  data: data | null;
+  status: BulletinsListStatus;
+  error: string | null;
+}

--- a/src/types/bulletins/list.tsx
+++ b/src/types/bulletins/list.tsx
@@ -1,0 +1,46 @@
+export interface data {
+  id: number;
+  title: string;
+  content: string;
+  category_id: number;
+  start_date: string;
+  end_date: string;
+  created_by: number;
+  createdby: any | null;
+  status: number;
+  group_id: number;
+  group: any | null;
+}
+
+export interface meta {
+  current_page: number;
+  from: number;
+  last_page: number;
+  links: [
+    {
+      url: string | null;
+      label: string;
+      active: boolean;
+    }
+  ];
+  path: string;
+  per_page: number;
+  to: number;
+  total: number;
+}
+
+export interface ListBulletinResponse {
+  data: data[];
+  links: {
+    first: string;
+    last: string;
+    prev: string | null;
+    next: string | null;
+  };
+  meta: meta;
+}
+
+export interface BulletinListArg {
+  enabled?: boolean;
+  [key: string]: any;
+}

--- a/src/types/bulletins/update.tsx
+++ b/src/types/bulletins/update.tsx
@@ -1,0 +1,22 @@
+import { data } from './list';
+import { BulletinsListStatus } from '../../enums/bulletins/list';
+
+export interface BulletinsUpdatePayload {
+  bulletinId: number;
+  payload: {
+    title: string;
+    content: string;
+    category_id: number;
+    start_date: string;
+    end_date: string;
+    created_by: number;
+    status: number;
+    group_id: number;
+  };
+}
+
+export interface BulletinsUpdateState {
+  data: data | null;
+  status: BulletinsListStatus;
+  error: string | null;
+}


### PR DESCRIPTION
## Summary
- create bulletins enums and types
- implement bulletins list/detail/add/update/delete slices and thunks
- add hooks for bulletins
- register bulletins reducers in rootReducer
- add BULLETINS constant

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_68550ba78b28832cb429d65ccec5b531