### PR TITLE
Add cash box info to daily financial summary

### DIFF
--- a/src/components/common/daily/dailyTransactionsFinancialSummary/index.tsx
+++ b/src/components/common/daily/dailyTransactionsFinancialSummary/index.tsx
@@ -58,6 +58,8 @@ const DailyTransactionsFinancialSummary: React.FC = () => {
     (summary?.liabilities.personnel_payables ?? 0) +
     (summary?.liabilities.supplier_debts ?? 0);
 
+  const cashBoxInfo = Math.abs(liquidTotal - liabilitiesTotal);
+
   const liquidRows: RowData[] = useMemo(() => {
     if (!summary) return [];
     const arr: RowData[] = [
@@ -179,6 +181,14 @@ const DailyTransactionsFinancialSummary: React.FC = () => {
           </Card>
         </Col>
       </Row>
+
+      <Card className="mt-4 glass-card">
+        <Card.Body>
+          <div className="d-flex justify-content-end fw-bold me-3" style={{ color: textColor }}>
+            Kasa Bilgisi: {formatCurrency(cashBoxInfo)}
+          </div>
+        </Card.Body>
+      </Card>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- calculate cash box info in daily summary
- show cash box info card after liquid assets/liabilities tables

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68550f1847d4832caa63e4c619403feb