### PR TITLE
Add conversations redux module

### DIFF
--- a/src/components/hooks/conversations/useAdd.tsx
+++ b/src/components/hooks/conversations/useAdd.tsx
@@ -1,0 +1,25 @@
+// file: src/components/hooks/conversations/useAdd.tsx
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { addConversation } from '../../../slices/conversations/add/thunk'
+import { ConversationsAddPayload } from '../../../types/conversations/add'
+
+export function useConversationAdd() {
+    const dispatch = useDispatch<AppDispatch>()
+    const { data, status, error } = useSelector((state: RootState) => state.conversationAdd)
+
+    const addNewConversation = useCallback(
+        async (payload: ConversationsAddPayload) => {
+            const resultAction = await dispatch(addConversation(payload))
+            if (addConversation.fulfilled.match(resultAction)) {
+                return resultAction.payload
+            }
+            return null
+        },
+        [dispatch]
+    )
+
+    return { addedConversation: data, status, error, addNewConversation }
+}

--- a/src/components/hooks/conversations/useDelete.tsx
+++ b/src/components/hooks/conversations/useDelete.tsx
@@ -1,0 +1,24 @@
+// file: src/components/hooks/conversations/useDelete.tsx
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { deleteConversation } from '../../../slices/conversations/delete/thunk'
+
+export function useConversationDelete() {
+    const dispatch = useDispatch<AppDispatch>()
+    const { data, status, error } = useSelector((state: RootState) => state.conversationDelete)
+
+    const deleteExistingConversation = useCallback(
+        async (conversationId: number) => {
+            const resultAction = await dispatch(deleteConversation(conversationId))
+            if (deleteConversation.fulfilled.match(resultAction)) {
+                return resultAction.payload
+            }
+            return null
+        },
+        [dispatch]
+    )
+
+    return { deletedConversation: data, status, error, deleteExistingConversation }
+}

--- a/src/components/hooks/conversations/useDetail.tsx
+++ b/src/components/hooks/conversations/useDetail.tsx
@@ -1,0 +1,24 @@
+// file: src/components/hooks/conversations/useDetail.tsx
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { fetchConversation } from '../../../slices/conversations/detail/thunk'
+
+export function useConversationDetail() {
+    const dispatch = useDispatch<AppDispatch>()
+    const { data, status, error } = useSelector((state: RootState) => state.conversationShow)
+
+    const getConversation = useCallback(
+        async (conversationId: number) => {
+            const resultAction = await dispatch(fetchConversation(conversationId))
+            if (fetchConversation.fulfilled.match(resultAction)) {
+                return resultAction.payload
+            }
+            return null
+        },
+        [dispatch]
+    )
+
+    return { conversation: data, status, error, getConversation }
+}

--- a/src/components/hooks/conversations/useList.tsx
+++ b/src/components/hooks/conversations/useList.tsx
@@ -1,0 +1,61 @@
+// file: src/components/hooks/conversations/useList.tsx
+import { useState, useEffect, useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { RootState } from '../../../store/rootReducer'
+import { AppDispatch } from '../../../store'
+import { fetchConversations } from '../../../slices/conversations/list/thunk'
+import { ConversationData, ListConversationArg, ListMeta } from '../../../types/conversations/list'
+import { ConversationListStatus } from '../../../enums/conversations/list'
+
+export function useConversationsList(params: ListConversationArg) {
+    const dispatch = useDispatch<AppDispatch>()
+
+    const [page, setPage] = useState<number>(params.page || 1)
+    const [pageSize, setPageSize] = useState<number>(params.pageSize || 10)
+    const [filter, setFilter] = useState<any>(null)
+
+    const { data, meta, status, error } = useSelector(
+        (state: RootState) => state.conversationList
+    )
+
+    const buildQuery = () => {
+        const { enabled, ...restParams } = params
+        return {
+            ...restParams,
+            filter,
+            page,
+            pageSize,
+            per_page: pageSize,
+        } as ListConversationArg
+    }
+
+    useEffect(() => {
+        if (params?.enabled === false) return;
+        dispatch(fetchConversations(buildQuery()))
+    }, [dispatch, filter, page, pageSize, params])
+
+    const refetch = useCallback(() => {
+        dispatch(fetchConversations(buildQuery()))
+    }, [dispatch, filter, page, pageSize, params])
+
+    const loading = status === ConversationListStatus.LOADING
+    const conversationsData: ConversationData[] = data || []
+    const paginationMeta: ListMeta | null = meta
+    const totalPages = paginationMeta ? paginationMeta.last_page : 1
+    const totalItems = paginationMeta ? paginationMeta.total : 0
+
+    return {
+        conversationsData,
+        loading,
+        error,
+        page,
+        setPage,
+        pageSize,
+        setPageSize,
+        filter,
+        setFilter,
+        totalPages,
+        totalItems,
+        refetch,
+    }
+}

--- a/src/components/hooks/conversations/useUpdate.tsx
+++ b/src/components/hooks/conversations/useUpdate.tsx
@@ -1,0 +1,25 @@
+// file: src/components/hooks/conversations/useUpdate.tsx
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { updateConversation } from '../../../slices/conversations/update/thunk'
+import { ConversationsUpdatePayload } from '../../../types/conversations/update'
+
+export function useConversationUpdate() {
+    const dispatch = useDispatch<AppDispatch>()
+    const { data, status, error } = useSelector((state: RootState) => state.conversationUpdate)
+
+    const updateExistingConversation = useCallback(
+        async (payload: ConversationsUpdatePayload) => {
+            const resultAction = await dispatch(updateConversation(payload))
+            if (updateConversation.fulfilled.match(resultAction)) {
+                return resultAction.payload
+            }
+            return null
+        },
+        [dispatch]
+    )
+
+    return { updatedConversation: data, status, error, updateExistingConversation }
+}

--- a/src/enums/conversations/list.tsx
+++ b/src/enums/conversations/list.tsx
@@ -1,0 +1,8 @@
+// file: src/enums/conversations/list.tsx
+export enum ConversationListStatus {
+    IDLE = 'IDLE',
+    LOADING = 'LOADING',
+    SUCCEEDED = 'SUCCEEDED',
+    FAILED = 'FAILED',
+}
+export default ConversationListStatus

--- a/src/slices/conversations/add/reducer.tsx
+++ b/src/slices/conversations/add/reducer.tsx
@@ -1,0 +1,35 @@
+// file: src/slices/conversations/add/reducer.tsx
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { addConversation } from './thunk'
+import { ConversationsAddState } from '../../../types/conversations/add'
+import { ConversationListStatus } from '../../../enums/conversations/list'
+import { ConversationData } from '../../../types/conversations/list'
+
+const initialState: ConversationsAddState = {
+    data: null,
+    status: ConversationListStatus.IDLE,
+    error: null,
+}
+
+const conversationsAddSlice = createSlice({
+    name: 'conversationsAdd',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(addConversation.pending, (state) => {
+                state.status = ConversationListStatus.LOADING
+                state.error = null
+            })
+            .addCase(addConversation.fulfilled, (state, action: PayloadAction<ConversationData>) => {
+                state.status = ConversationListStatus.SUCCEEDED
+                state.data = action.payload
+            })
+            .addCase(addConversation.rejected, (state, action: PayloadAction<any>) => {
+                state.status = ConversationListStatus.FAILED
+                state.error = action.payload
+            })
+    },
+})
+
+export default conversationsAddSlice.reducer

--- a/src/slices/conversations/add/thunk.tsx
+++ b/src/slices/conversations/add/thunk.tsx
@@ -1,0 +1,18 @@
+// file: src/slices/conversations/add/thunk.tsx
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { CONVERSATIONS } from '../../../helpers/url_helper'
+import { ConversationsAddPayload } from '../../../types/conversations/add'
+import { ConversationData } from '../../../types/conversations/list'
+
+export const addConversation = createAsyncThunk<ConversationData, ConversationsAddPayload>(
+    'conversations/addConversation',
+    async (payload, { rejectWithValue }) => {
+        try {
+            const resp = await axiosInstance.post(CONVERSATIONS, payload)
+            return resp.data.data as ConversationData
+        } catch (err: any) {
+            return rejectWithValue(err.response?.data?.message || 'Add conversation failed')
+        }
+    }
+)

--- a/src/slices/conversations/delete/reducer.tsx
+++ b/src/slices/conversations/delete/reducer.tsx
@@ -1,0 +1,34 @@
+// file: src/slices/conversations/delete/reducer.tsx
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { deleteConversation } from './thunk'
+import { ConversationsDeleteState } from '../../../types/conversations/delete'
+import { ConversationListStatus } from '../../../enums/conversations/list'
+
+const initialState: ConversationsDeleteState = {
+    data: null,
+    status: ConversationListStatus.IDLE,
+    error: null,
+}
+
+const conversationsDeleteSlice = createSlice({
+    name: 'conversationsDelete',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(deleteConversation.pending, (state) => {
+                state.status = ConversationListStatus.LOADING
+                state.error = null
+            })
+            .addCase(deleteConversation.fulfilled, (state, action: PayloadAction<any>) => {
+                state.status = ConversationListStatus.SUCCEEDED
+                state.data = action.payload
+            })
+            .addCase(deleteConversation.rejected, (state, action: PayloadAction<any>) => {
+                state.status = ConversationListStatus.FAILED
+                state.error = action.payload
+            })
+    },
+})
+
+export default conversationsDeleteSlice.reducer

--- a/src/slices/conversations/delete/thunk.tsx
+++ b/src/slices/conversations/delete/thunk.tsx
@@ -1,0 +1,17 @@
+// file: src/slices/conversations/delete/thunk.tsx
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { CONVERSATIONS } from '../../../helpers/url_helper'
+import { ConversationsDeleteState } from '../../../types/conversations/delete'
+
+export const deleteConversation = createAsyncThunk<ConversationsDeleteState, number>(
+    'conversations/deleteConversation',
+    async (conversationId, { rejectWithValue }) => {
+        try {
+            const resp = await axiosInstance.delete(`${CONVERSATIONS}/${conversationId}`)
+            return resp.data as ConversationsDeleteState
+        } catch (err: any) {
+            return rejectWithValue(err.response?.data?.message || 'Delete conversation failed')
+        }
+    }
+)

--- a/src/slices/conversations/detail/reducer.tsx
+++ b/src/slices/conversations/detail/reducer.tsx
@@ -1,0 +1,35 @@
+// file: src/slices/conversations/detail/reducer.tsx
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { fetchConversation } from './thunk'
+import { ConversationsDetailState } from '../../../types/conversations/detail'
+import { ConversationListStatus } from '../../../enums/conversations/list'
+import { ConversationData } from '../../../types/conversations/list'
+
+const initialState: ConversationsDetailState = {
+    data: null,
+    status: ConversationListStatus.IDLE,
+    error: null,
+}
+
+const conversationsDetailSlice = createSlice({
+    name: 'conversationsDetail',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(fetchConversation.pending, (state) => {
+                state.status = ConversationListStatus.LOADING
+                state.error = null
+            })
+            .addCase(fetchConversation.fulfilled, (state, action: PayloadAction<ConversationData>) => {
+                state.status = ConversationListStatus.SUCCEEDED
+                state.data = action.payload
+            })
+            .addCase(fetchConversation.rejected, (state, action: PayloadAction<any>) => {
+                state.status = ConversationListStatus.FAILED
+                state.error = action.payload
+            })
+    },
+})
+
+export default conversationsDetailSlice.reducer

--- a/src/slices/conversations/detail/thunk.tsx
+++ b/src/slices/conversations/detail/thunk.tsx
@@ -1,0 +1,17 @@
+// file: src/slices/conversations/detail/thunk.tsx
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { CONVERSATIONS } from '../../../helpers/url_helper'
+import { ConversationData } from '../../../types/conversations/list'
+
+export const fetchConversation = createAsyncThunk<ConversationData, number>(
+    'conversations/fetchConversation',
+    async (conversationId, { rejectWithValue }) => {
+        try {
+            const resp = await axiosInstance.get(`${CONVERSATIONS}/${conversationId}`)
+            return resp.data.data as ConversationData
+        } catch (err: any) {
+            return rejectWithValue(err.response?.data?.message || 'Fetch conversation failed')
+        }
+    }
+)

--- a/src/slices/conversations/list/reducer.tsx
+++ b/src/slices/conversations/list/reducer.tsx
@@ -1,0 +1,45 @@
+// file: src/slices/conversations/list/reducer.tsx
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { fetchConversations } from './thunk'
+import { ListConversationsResponse } from '../../../types/conversations/list'
+import { ConversationListStatus } from '../../../enums/conversations/list'
+
+export interface ConversationsListState {
+    data: ListConversationsResponse['data'] | null
+    links: ListConversationsResponse['links'] | null
+    meta: ListConversationsResponse['meta'] | null
+    status: ConversationListStatus
+    error: string | null
+}
+
+const initialState: ConversationsListState = {
+    data: null,
+    links: null,
+    meta: null,
+    status: ConversationListStatus.IDLE,
+    error: null,
+}
+
+const conversationsListSlice = createSlice({
+    name: 'conversations/list',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder.addCase(fetchConversations.pending, (state) => {
+            state.status = ConversationListStatus.LOADING
+            state.error = null
+        })
+        builder.addCase(fetchConversations.fulfilled, (state, action: PayloadAction<ListConversationsResponse>) => {
+            state.status = ConversationListStatus.SUCCEEDED
+            state.data = action.payload.data
+            state.links = action.payload.links
+            state.meta = action.payload.meta
+        })
+        builder.addCase(fetchConversations.rejected, (state, action: PayloadAction<any>) => {
+            state.status = ConversationListStatus.FAILED
+            state.error = action.payload || 'Fetch conversations failed'
+        })
+    },
+})
+
+export default conversationsListSlice.reducer

--- a/src/slices/conversations/list/thunk.tsx
+++ b/src/slices/conversations/list/thunk.tsx
@@ -1,0 +1,24 @@
+// file: src/slices/conversations/list/thunk.tsx
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { CONVERSATIONS } from '../../../helpers/url_helper'
+import { ListConversationsResponse, ListConversationArg } from '../../../types/conversations/list'
+
+export const fetchConversations = createAsyncThunk<ListConversationsResponse, ListConversationArg>(
+    'conversations/fetchConversations',
+    async (queryParams, { rejectWithValue }) => {
+        try {
+            const query = new URLSearchParams()
+            Object.entries(queryParams).forEach(([key, value]) => {
+                if (value !== undefined && value !== null && key !== 'enabled') {
+                    query.append(key, String(value))
+                }
+            })
+            const url = `${CONVERSATIONS}?${query.toString()}`
+            const resp = await axiosInstance.get(url)
+            return resp.data as ListConversationsResponse
+        } catch (err: any) {
+            return rejectWithValue(err.response?.data?.message || 'Fetch conversations failed')
+        }
+    }
+)

--- a/src/slices/conversations/update/reducer.tsx
+++ b/src/slices/conversations/update/reducer.tsx
@@ -1,0 +1,35 @@
+// file: src/slices/conversations/update/reducer.tsx
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { updateConversation } from './thunk'
+import { ConversationsUpdateState } from '../../../types/conversations/update'
+import { ConversationListStatus } from '../../../enums/conversations/list'
+import { ConversationData } from '../../../types/conversations/list'
+
+const initialState: ConversationsUpdateState = {
+    data: null,
+    status: ConversationListStatus.IDLE,
+    error: null,
+}
+
+const conversationsUpdateSlice = createSlice({
+    name: 'conversationsUpdate',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(updateConversation.pending, (state) => {
+                state.status = ConversationListStatus.LOADING
+                state.error = null
+            })
+            .addCase(updateConversation.fulfilled, (state, action: PayloadAction<ConversationData>) => {
+                state.status = ConversationListStatus.SUCCEEDED
+                state.data = action.payload
+            })
+            .addCase(updateConversation.rejected, (state, action: PayloadAction<any>) => {
+                state.status = ConversationListStatus.FAILED
+                state.error = action.payload
+            })
+    },
+})
+
+export default conversationsUpdateSlice.reducer

--- a/src/slices/conversations/update/thunk.tsx
+++ b/src/slices/conversations/update/thunk.tsx
@@ -1,0 +1,18 @@
+// file: src/slices/conversations/update/thunk.tsx
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { CONVERSATIONS } from '../../../helpers/url_helper'
+import { ConversationsUpdatePayload } from '../../../types/conversations/update'
+import { ConversationData } from '../../../types/conversations/list'
+
+export const updateConversation = createAsyncThunk<ConversationData, ConversationsUpdatePayload>(
+    'conversations/updateConversation',
+    async ({ conversationId, payload }, { rejectWithValue }) => {
+        try {
+            const resp = await axiosInstance.put(`${CONVERSATIONS}/${conversationId}`, payload)
+            return resp.data.data as ConversationData
+        } catch (err: any) {
+            return rejectWithValue(err.response?.data?.message || 'Update conversation failed')
+        }
+    }
+)

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -509,6 +509,11 @@ import assignmentsDeleteSlice from '../slices/assignments/delete/reducer';
 import assignmentsListSlice from '../slices/assignments/list/reducer';
 import assignmentsUpdateSlice from '../slices/assignments/update/reducer';
 import assignmentsDetailSlice from '../slices/assignments/detail/reducer';
+import conversationsListReducer from '../slices/conversations/list/reducer';
+import conversationsShowReducer from '../slices/conversations/detail/reducer';
+import conversationsAddReducer from '../slices/conversations/add/reducer';
+import conversationsUpdateReducer from '../slices/conversations/update/reducer';
+import conversationsDeleteReducer from '../slices/conversations/delete/reducer';
 
 //sourceTypes
 import sourceTypesAddSlice from '../slices/sourceTypes/add/reducer';
@@ -1094,6 +1099,11 @@ const combinedReducer = combineReducers({
   assignmentsList: assignmentsListSlice,
   assignmentsUpdate: assignmentsUpdateSlice,
   assignmentsDetail: assignmentsDetailSlice,
+  conversationList: conversationsListReducer,
+  conversationShow: conversationsShowReducer,
+  conversationAdd: conversationsAddReducer,
+  conversationUpdate: conversationsUpdateReducer,
+  conversationDelete: conversationsDeleteReducer,
 
   //sourcetypes
   sourceTypesAdd: sourceTypesAddSlice,

--- a/src/types/conversations/add.tsx
+++ b/src/types/conversations/add.tsx
@@ -1,0 +1,17 @@
+// file: src/types/conversations/add.tsx
+import { ConversationData } from './list'
+import { ConversationListStatus } from '../../enums/conversations/list'
+
+export interface ConversationsAddPayload {
+    id?: number
+    name: string
+    type_id: string
+    user_one_id: number
+    user_two_id: number
+}
+
+export interface ConversationsAddState {
+    data: ConversationData | null
+    status: ConversationListStatus
+    error: string | null
+}

--- a/src/types/conversations/delete.tsx
+++ b/src/types/conversations/delete.tsx
@@ -1,0 +1,13 @@
+// file: src/types/conversations/delete.tsx
+import { ConversationData } from './list'
+import { ConversationListStatus } from '../../enums/conversations/list'
+
+export interface ConversationsDeletePayload {
+    id?: number
+}
+
+export interface ConversationsDeleteState {
+    data: ConversationData | null
+    status: ConversationListStatus
+    error: string | null
+}

--- a/src/types/conversations/detail.tsx
+++ b/src/types/conversations/detail.tsx
@@ -1,0 +1,9 @@
+// file: src/types/conversations/detail.tsx
+import { ConversationData } from './list'
+import { ConversationListStatus } from '../../enums/conversations/list'
+
+export interface ConversationsDetailState {
+    data: ConversationData | null
+    status: ConversationListStatus
+    error: string | null
+}

--- a/src/types/conversations/list.tsx
+++ b/src/types/conversations/list.tsx
@@ -1,0 +1,68 @@
+// file: src/types/conversations/list.tsx
+export interface ConversationUser {
+    id: number
+    first_name: string
+    last_name: string
+    email: string
+    username: string | null
+    status: number
+    confirmation_code: string
+    confirmed: number
+    is_term_accept: number
+    profile_img: string | null
+    cover: string | null
+    bio: string | null
+    country_id: number | null
+    city_id: number | null
+    timezone_id: number | null
+    lang_id: number | null
+    created_by: number
+    updated_by: number | null
+    created_at: string
+    updated_at: string
+    deleted_at: string | null
+    platform_id: number
+}
+
+export interface ConversationData {
+    id: number
+    name: string
+    type_id: string
+    user_one_id: number
+    user_one: ConversationUser
+    user_two_id: number
+    user_two: ConversationUser
+}
+
+export interface ListLinks {
+    first: string
+    last: string
+    prev: string | null
+    next: string | null
+}
+
+export interface ListMeta {
+    current_page: number
+    from: number
+    last_page: number
+    links: {
+        url: string | null
+        label: string
+        active: boolean
+    }[]
+    path: string
+    per_page: number
+    to: number
+    total: number
+}
+
+export interface ListConversationsResponse {
+    data: ConversationData[]
+    links: ListLinks
+    meta: ListMeta
+}
+
+export interface ListConversationArg {
+    enabled?: boolean
+    [key: string]: any
+}

--- a/src/types/conversations/update.tsx
+++ b/src/types/conversations/update.tsx
@@ -1,0 +1,19 @@
+// file: src/types/conversations/update.tsx
+import { ConversationData } from './list'
+import { ConversationListStatus } from '../../enums/conversations/list'
+
+export interface ConversationsUpdatePayload {
+    conversationId: number
+    payload: {
+        name?: string | null
+        type_id?: string | null
+        user_one_id?: number | null
+        user_two_id?: number | null
+    }
+}
+
+export interface ConversationsUpdateState {
+    data: ConversationData | null
+    status: ConversationListStatus
+    error: string | null
+}


### PR DESCRIPTION
## Summary
- add conversation enums
- define conversation types
- create conversation async thunks and reducers
- add hooks for conversation CRUD operations
- wire conversation slices into rootReducer

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68551082bb24832cbb5d3f25c424cb3c