### PR TITLE
Add messages module redux toolkit

### DIFF
--- a/src/components/hooks/messages/useAdd.tsx
+++ b/src/components/hooks/messages/useAdd.tsx
@@ -1,0 +1,25 @@
+// file: src/components/hooks/messages/useAdd.tsx
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { addMessage } from '../../../slices/messages/add/thunk'
+import { MessagesAddPayload } from '../../../types/messages/add'
+
+export function useMessageAdd() {
+    const dispatch = useDispatch<AppDispatch>()
+    const { data, status, error } = useSelector((state: RootState) => state.messageAdd)
+
+    const addNewMessage = useCallback(
+        async (payload: MessagesAddPayload) => {
+            const resultAction = await dispatch(addMessage(payload))
+            if (addMessage.fulfilled.match(resultAction)) {
+                return resultAction.payload
+            }
+            return null
+        },
+        [dispatch]
+    )
+
+    return { addedMessage: data, status, error, addNewMessage }
+}

--- a/src/components/hooks/messages/useDelete.tsx
+++ b/src/components/hooks/messages/useDelete.tsx
@@ -1,0 +1,24 @@
+// file: src/components/hooks/messages/useDelete.tsx
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { deleteMessage } from '../../../slices/messages/delete/thunk'
+
+export function useMessageDelete() {
+    const dispatch = useDispatch<AppDispatch>()
+    const { data, status, error } = useSelector((state: RootState) => state.messageDelete)
+
+    const deleteExistingMessage = useCallback(
+        async (messageId: number) => {
+            const resultAction = await dispatch(deleteMessage(messageId))
+            if (deleteMessage.fulfilled.match(resultAction)) {
+                return resultAction.payload
+            }
+            return null
+        },
+        [dispatch]
+    )
+
+    return { deletedMessage: data, status, error, deleteExistingMessage }
+}

--- a/src/components/hooks/messages/useDetail.tsx
+++ b/src/components/hooks/messages/useDetail.tsx
@@ -1,0 +1,24 @@
+// file: src/components/hooks/messages/useDetail.tsx
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { fetchMessage } from '../../../slices/messages/detail/thunk'
+
+export function useMessageDetail() {
+    const dispatch = useDispatch<AppDispatch>()
+    const { data, status, error } = useSelector((state: RootState) => state.messageShow)
+
+    const getMessage = useCallback(
+        async (messageId: number) => {
+            const resultAction = await dispatch(fetchMessage(messageId))
+            if (fetchMessage.fulfilled.match(resultAction)) {
+                return resultAction.payload
+            }
+            return null
+        },
+        [dispatch]
+    )
+
+    return { message: data, status, error, getMessage }
+}

--- a/src/components/hooks/messages/useList.tsx
+++ b/src/components/hooks/messages/useList.tsx
@@ -1,0 +1,61 @@
+// file: src/components/hooks/messages/useList.tsx
+import { useState, useEffect, useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { RootState } from '../../../store/rootReducer'
+import { AppDispatch } from '../../../store'
+import { fetchMessages } from '../../../slices/messages/list/thunk'
+import { MessageData, ListMessageArg, ListMeta } from '../../../types/messages/list'
+import { MessageListStatus } from '../../../enums/messages/list'
+
+export function useMessagesList(params: ListMessageArg) {
+    if (params?.enabled === false) return
+    const dispatch = useDispatch<AppDispatch>()
+
+    const [page, setPage] = useState<number>(params.page || 1)
+    const [pageSize, setPageSize] = useState<number>(params.pageSize || 10)
+    const [filter, setFilter] = useState<any>(null)
+
+    const { data, meta, status, error } = useSelector(
+        (state: RootState) => state.messageList
+    )
+
+    const buildQuery = () => {
+        const { enabled, ...restParams } = params
+        return {
+            ...restParams,
+            filter,
+            page,
+            pageSize,
+            per_page: pageSize,
+        } as ListMessageArg
+    }
+
+    useEffect(() => {
+        dispatch(fetchMessages(buildQuery()))
+    }, [dispatch, filter, page, pageSize, params])
+
+    const refetch = useCallback(() => {
+        dispatch(fetchMessages(buildQuery()))
+    }, [dispatch, filter, page, pageSize, params])
+
+    const loading = status === MessageListStatus.LOADING
+    const messagesData: MessageData[] = data || []
+    const paginationMeta: ListMeta | null = meta
+    const totalPages = paginationMeta ? paginationMeta.last_page : 1
+    const totalItems = paginationMeta ? paginationMeta.total : 0
+
+    return {
+        messagesData,
+        loading,
+        error,
+        page,
+        setPage,
+        pageSize,
+        setPageSize,
+        filter,
+        setFilter,
+        totalPages,
+        totalItems,
+        refetch,
+    }
+}

--- a/src/components/hooks/messages/useUpdate.tsx
+++ b/src/components/hooks/messages/useUpdate.tsx
@@ -1,0 +1,25 @@
+// file: src/components/hooks/messages/useUpdate.tsx
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { updateMessage } from '../../../slices/messages/update/thunk'
+import { MessagesUpdatePayload } from '../../../types/messages/update'
+
+export function useMessageUpdate() {
+    const dispatch = useDispatch<AppDispatch>()
+    const { data, status, error } = useSelector((state: RootState) => state.messageUpdate)
+
+    const updateExistingMessage = useCallback(
+        async (payload: MessagesUpdatePayload) => {
+            const resultAction = await dispatch(updateMessage(payload))
+            if (updateMessage.fulfilled.match(resultAction)) {
+                return resultAction.payload
+            }
+            return null
+        },
+        [dispatch]
+    )
+
+    return { updatedMessage: data, status, error, updateExistingMessage }
+}

--- a/src/enums/messages/list.tsx
+++ b/src/enums/messages/list.tsx
@@ -1,0 +1,8 @@
+// file: src/enums/messages/list.tsx
+export enum MessageListStatus {
+    IDLE = 'IDLE',
+    LOADING = 'LOADING',
+    SUCCEEDED = 'SUCCEEDED',
+    FAILED = 'FAILED',
+}
+export default MessageListStatus

--- a/src/helpers/url_helper.ts
+++ b/src/helpers/url_helper.ts
@@ -166,4 +166,6 @@ export const STUDENTGROUPS = "/studentgroups";
 export const BULLETINS = '/bulletins';
 export const CONVERSATIONS = '/conversations';
 
+export const MESSAGES = '/messages';
+
 

--- a/src/slices/messages/add/reducer.tsx
+++ b/src/slices/messages/add/reducer.tsx
@@ -1,0 +1,35 @@
+// file: src/slices/messages/add/reducer.tsx
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { addMessage } from './thunk'
+import { MessagesAddState } from '../../../types/messages/add'
+import { MessageListStatus } from '../../../enums/messages/list'
+import { MessageData } from '../../../types/messages/list'
+
+const initialState: MessagesAddState = {
+    data: null,
+    status: MessageListStatus.IDLE,
+    error: null,
+}
+
+const messagesAddSlice = createSlice({
+    name: 'messagesAdd',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(addMessage.pending, (state) => {
+                state.status = MessageListStatus.LOADING
+                state.error = null
+            })
+            .addCase(addMessage.fulfilled, (state, action: PayloadAction<MessageData>) => {
+                state.status = MessageListStatus.SUCCEEDED
+                state.data = action.payload
+            })
+            .addCase(addMessage.rejected, (state, action: PayloadAction<any>) => {
+                state.status = MessageListStatus.FAILED
+                state.error = action.payload
+            })
+    },
+})
+
+export default messagesAddSlice.reducer

--- a/src/slices/messages/add/thunk.tsx
+++ b/src/slices/messages/add/thunk.tsx
@@ -1,0 +1,18 @@
+// file: src/slices/messages/add/thunk.tsx
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { MESSAGES } from '../../../helpers/url_helper'
+import { MessagesAddPayload } from '../../../types/messages/add'
+import { MessageData } from '../../../types/messages/list'
+
+export const addMessage = createAsyncThunk<MessageData, MessagesAddPayload>(
+    'messages/addMessage',
+    async (payload, { rejectWithValue }) => {
+        try {
+            const resp = await axiosInstance.post(MESSAGES, payload)
+            return resp.data.data as MessageData
+        } catch (err: any) {
+            return rejectWithValue(err.response?.data?.message || 'Add message failed')
+        }
+    }
+)

--- a/src/slices/messages/delete/reducer.tsx
+++ b/src/slices/messages/delete/reducer.tsx
@@ -1,0 +1,34 @@
+// file: src/slices/messages/delete/reducer.tsx
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { deleteMessage } from './thunk'
+import { MessagesDeleteState } from '../../../types/messages/delete'
+import { MessageListStatus } from '../../../enums/messages/list'
+
+const initialState: MessagesDeleteState = {
+    data: null,
+    status: MessageListStatus.IDLE,
+    error: null,
+}
+
+const messagesDeleteSlice = createSlice({
+    name: 'messagesDelete',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(deleteMessage.pending, (state) => {
+                state.status = MessageListStatus.LOADING
+                state.error = null
+            })
+            .addCase(deleteMessage.fulfilled, (state, action: PayloadAction<any>) => {
+                state.status = MessageListStatus.SUCCEEDED
+                state.data = action.payload
+            })
+            .addCase(deleteMessage.rejected, (state, action: PayloadAction<any>) => {
+                state.status = MessageListStatus.FAILED
+                state.error = action.payload
+            })
+    },
+})
+
+export default messagesDeleteSlice.reducer

--- a/src/slices/messages/delete/thunk.tsx
+++ b/src/slices/messages/delete/thunk.tsx
@@ -1,0 +1,17 @@
+// file: src/slices/messages/delete/thunk.tsx
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { MESSAGES } from '../../../helpers/url_helper'
+import { MessagesDeleteState } from '../../../types/messages/delete'
+
+export const deleteMessage = createAsyncThunk<MessagesDeleteState, number>(
+    'messages/deleteMessage',
+    async (messageId, { rejectWithValue }) => {
+        try {
+            const resp = await axiosInstance.delete(`${MESSAGES}/${messageId}`)
+            return resp.data as MessagesDeleteState
+        } catch (err: any) {
+            return rejectWithValue(err.response?.data?.message || 'Delete message failed')
+        }
+    }
+)

--- a/src/slices/messages/detail/reducer.tsx
+++ b/src/slices/messages/detail/reducer.tsx
@@ -1,0 +1,35 @@
+// file: src/slices/messages/detail/reducer.tsx
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { fetchMessage } from './thunk'
+import { MessagesDetailState } from '../../../types/messages/detail'
+import { MessageListStatus } from '../../../enums/messages/list'
+import { MessageData } from '../../../types/messages/list'
+
+const initialState: MessagesDetailState = {
+    data: null,
+    status: MessageListStatus.IDLE,
+    error: null,
+}
+
+const messagesDetailSlice = createSlice({
+    name: 'messagesDetail',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(fetchMessage.pending, (state) => {
+                state.status = MessageListStatus.LOADING
+                state.error = null
+            })
+            .addCase(fetchMessage.fulfilled, (state, action: PayloadAction<MessageData>) => {
+                state.status = MessageListStatus.SUCCEEDED
+                state.data = action.payload
+            })
+            .addCase(fetchMessage.rejected, (state, action: PayloadAction<any>) => {
+                state.status = MessageListStatus.FAILED
+                state.error = action.payload
+            })
+    },
+})
+
+export default messagesDetailSlice.reducer

--- a/src/slices/messages/detail/thunk.tsx
+++ b/src/slices/messages/detail/thunk.tsx
@@ -1,0 +1,17 @@
+// file: src/slices/messages/detail/thunk.tsx
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { MESSAGES } from '../../../helpers/url_helper'
+import { MessageData } from '../../../types/messages/list'
+
+export const fetchMessage = createAsyncThunk<MessageData, number>(
+    'messages/fetchMessage',
+    async (messageId, { rejectWithValue }) => {
+        try {
+            const resp = await axiosInstance.get(`${MESSAGES}/${messageId}`)
+            return resp.data.data as MessageData
+        } catch (err: any) {
+            return rejectWithValue(err.response?.data?.message || 'Fetch message failed')
+        }
+    }
+)

--- a/src/slices/messages/list/reducer.tsx
+++ b/src/slices/messages/list/reducer.tsx
@@ -1,0 +1,45 @@
+// file: src/slices/messages/list/reducer.tsx
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { fetchMessages } from './thunk'
+import { ListMessagesResponse } from '../../../types/messages/list'
+import { MessageListStatus } from '../../../enums/messages/list'
+
+export interface MessagesListState {
+    data: ListMessagesResponse['data'] | null
+    links: ListMessagesResponse['links'] | null
+    meta: ListMessagesResponse['meta'] | null
+    status: MessageListStatus
+    error: string | null
+}
+
+const initialState: MessagesListState = {
+    data: null,
+    links: null,
+    meta: null,
+    status: MessageListStatus.IDLE,
+    error: null,
+}
+
+const messagesListSlice = createSlice({
+    name: 'messages/list',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder.addCase(fetchMessages.pending, (state) => {
+            state.status = MessageListStatus.LOADING
+            state.error = null
+        })
+        builder.addCase(fetchMessages.fulfilled, (state, action: PayloadAction<ListMessagesResponse>) => {
+            state.status = MessageListStatus.SUCCEEDED
+            state.data = action.payload.data
+            state.links = action.payload.links
+            state.meta = action.payload.meta
+        })
+        builder.addCase(fetchMessages.rejected, (state, action: PayloadAction<any>) => {
+            state.status = MessageListStatus.FAILED
+            state.error = action.payload || 'Fetch messages failed'
+        })
+    },
+})
+
+export default messagesListSlice.reducer

--- a/src/slices/messages/list/thunk.tsx
+++ b/src/slices/messages/list/thunk.tsx
@@ -1,0 +1,24 @@
+// file: src/slices/messages/list/thunk.tsx
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { MESSAGES } from '../../../helpers/url_helper'
+import { ListMessagesResponse, ListMessageArg } from '../../../types/messages/list'
+
+export const fetchMessages = createAsyncThunk<ListMessagesResponse, ListMessageArg>(
+    'messages/fetchMessages',
+    async (queryParams, { rejectWithValue }) => {
+        try {
+            const query = new URLSearchParams()
+            Object.entries(queryParams).forEach(([key, value]) => {
+                if (value !== undefined && value !== null && key !== 'enabled') {
+                    query.append(key, String(value))
+                }
+            })
+            const url = `${MESSAGES}?${query.toString()}`
+            const resp = await axiosInstance.get(url)
+            return resp.data as ListMessagesResponse
+        } catch (err: any) {
+            return rejectWithValue(err.response?.data?.message || 'Fetch messages failed')
+        }
+    }
+)

--- a/src/slices/messages/update/reducer.tsx
+++ b/src/slices/messages/update/reducer.tsx
@@ -1,0 +1,35 @@
+// file: src/slices/messages/update/reducer.tsx
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { updateMessage } from './thunk'
+import { MessagesUpdateState } from '../../../types/messages/update'
+import { MessageListStatus } from '../../../enums/messages/list'
+import { MessageData } from '../../../types/messages/list'
+
+const initialState: MessagesUpdateState = {
+    data: null,
+    status: MessageListStatus.IDLE,
+    error: null,
+}
+
+const messagesUpdateSlice = createSlice({
+    name: 'messagesUpdate',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(updateMessage.pending, (state) => {
+                state.status = MessageListStatus.LOADING
+                state.error = null
+            })
+            .addCase(updateMessage.fulfilled, (state, action: PayloadAction<MessageData>) => {
+                state.status = MessageListStatus.SUCCEEDED
+                state.data = action.payload
+            })
+            .addCase(updateMessage.rejected, (state, action: PayloadAction<any>) => {
+                state.status = MessageListStatus.FAILED
+                state.error = action.payload
+            })
+    },
+})
+
+export default messagesUpdateSlice.reducer

--- a/src/slices/messages/update/thunk.tsx
+++ b/src/slices/messages/update/thunk.tsx
@@ -1,0 +1,18 @@
+// file: src/slices/messages/update/thunk.tsx
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { MESSAGES } from '../../../helpers/url_helper'
+import { MessagesUpdatePayload } from '../../../types/messages/update'
+import { MessageData } from '../../../types/messages/list'
+
+export const updateMessage = createAsyncThunk<MessageData, MessagesUpdatePayload>(
+    'messages/updateMessage',
+    async ({ messageId, payload }, { rejectWithValue }) => {
+        try {
+            const resp = await axiosInstance.put(`${MESSAGES}/${messageId}`, payload)
+            return resp.data.data as MessageData
+        } catch (err: any) {
+            return rejectWithValue(err.response?.data?.message || 'Update message failed')
+        }
+    }
+)

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -514,6 +514,11 @@ import conversationsShowReducer from '../slices/conversations/detail/reducer';
 import conversationsAddReducer from '../slices/conversations/add/reducer';
 import conversationsUpdateReducer from '../slices/conversations/update/reducer';
 import conversationsDeleteReducer from '../slices/conversations/delete/reducer';
+import messagesListReducer from '../slices/messages/list/reducer';
+import messagesShowReducer from '../slices/messages/detail/reducer';
+import messagesAddReducer from '../slices/messages/add/reducer';
+import messagesUpdateReducer from '../slices/messages/update/reducer';
+import messagesDeleteReducer from '../slices/messages/delete/reducer';
 
 //sourceTypes
 import sourceTypesAddSlice from '../slices/sourceTypes/add/reducer';
@@ -1104,6 +1109,11 @@ const combinedReducer = combineReducers({
   conversationAdd: conversationsAddReducer,
   conversationUpdate: conversationsUpdateReducer,
   conversationDelete: conversationsDeleteReducer,
+  messageList: messagesListReducer,
+  messageShow: messagesShowReducer,
+  messageAdd: messagesAddReducer,
+  messageUpdate: messagesUpdateReducer,
+  messageDelete: messagesDeleteReducer,
 
   //sourcetypes
   sourceTypesAdd: sourceTypesAddSlice,

--- a/src/types/messages/add.tsx
+++ b/src/types/messages/add.tsx
@@ -1,0 +1,18 @@
+// file: src/types/messages/add.tsx
+import { MessageData } from './list'
+import MessageListStatus from '../../enums/messages/list'
+
+export interface MessagesAddPayload {
+    id?: number
+    conversation_id: number
+    sender_id: number
+    body: string
+    read_at?: string | null
+    status?: number
+}
+
+export interface MessagesAddState {
+    data: MessageData | null
+    status: MessageListStatus
+    error: string | null
+}

--- a/src/types/messages/delete.tsx
+++ b/src/types/messages/delete.tsx
@@ -1,0 +1,13 @@
+// file: src/types/messages/delete.tsx
+import { MessageData } from './list'
+import MessageListStatus from '../../enums/messages/list'
+
+export interface MessagesDeletePayload {
+    id?: number
+}
+
+export interface MessagesDeleteState {
+    data: MessageData | null
+    status: MessageListStatus
+    error: string | null
+}

--- a/src/types/messages/detail.tsx
+++ b/src/types/messages/detail.tsx
@@ -1,0 +1,9 @@
+// file: src/types/messages/detail.tsx
+import { MessageData } from './list'
+import MessageListStatus from '../../enums/messages/list'
+
+export interface MessagesDetailState {
+    data: MessageData | null
+    status: MessageListStatus
+    error: string | null
+}

--- a/src/types/messages/list.tsx
+++ b/src/types/messages/list.tsx
@@ -1,0 +1,76 @@
+// file: src/types/messages/list.tsx
+export interface MessageConversation {
+    id: number
+    name: string
+    type_id: number
+    user_one_id: number
+    user_two_id: number
+    created_at: string | null
+    updated_at: string | null
+    platform_id: number
+}
+
+export interface MessageSender {
+    id: number
+    first_name: string
+    last_name: string
+    email: string
+    username: string | null
+    status: number
+    confirmation_code: string
+    confirmed: number
+    is_term_accept: number
+    profile_img: string | null
+    cover: string | null
+    bio: string | null
+    country_id: number | null
+    city_id: number | null
+    timezone_id: number | null
+    lang_id: number | null
+    created_by: number
+    updated_by: number | null
+    created_at: string
+    updated_at: string
+    deleted_at: string | null
+    platform_id: number
+}
+
+export interface MessageData {
+    id: number
+    conversation_id: number
+    conversation: MessageConversation
+    sender_id: number
+    sender: MessageSender
+    body: string
+    read_at: string | null
+    status: number
+}
+
+export interface ListLinks {
+    first: string
+    last: string
+    prev: string | null
+    next: string | null
+}
+
+export interface ListMeta {
+    current_page: number
+    from: number
+    last_page: number
+    links: { url: string | null; label: string; active: boolean }[]
+    path: string
+    per_page: number
+    to: number
+    total: number
+}
+
+export interface ListMessagesResponse {
+    data: MessageData[]
+    links: ListLinks
+    meta: ListMeta
+}
+
+export interface ListMessageArg {
+    enabled?: boolean
+    [key: string]: any
+}

--- a/src/types/messages/update.tsx
+++ b/src/types/messages/update.tsx
@@ -1,0 +1,20 @@
+// file: src/types/messages/update.tsx
+import { MessageData } from './list'
+import MessageListStatus from '../../enums/messages/list'
+
+export interface MessagesUpdatePayload {
+    messageId: number
+    payload: {
+        conversation_id?: number | null
+        sender_id?: number | null
+        body?: string | null
+        read_at?: string | null
+        status?: number | null
+    }
+}
+
+export interface MessagesUpdateState {
+    data: MessageData | null
+    status: MessageListStatus
+    error: string | null
+}


### PR DESCRIPTION
## Summary
- add `MESSAGES` endpoint helper
- create message enums, types, slices, thunks and hooks
- combine new reducers in rootReducer

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6855174a0004832c8e898a078433eec2