### PR TITLE
Add toast notifications for class full

### DIFF
--- a/src/components/common/pollingManagement/teachers/pages/lesson/table.tsx
+++ b/src/components/common/pollingManagement/teachers/pages/lesson/table.tsx
@@ -14,6 +14,7 @@ import { useAttendanceStudentsTable } from '../../../../../hooks/attendanceStude
 import sınıfTam from "../../../../../../assets/images/media/sınıf-tam.svg";
 import sınıfTamHover from "../../../../../../assets/images/media/sınıf-tam-hover.svg";
 import { Button } from 'react-bootstrap';
+import { toast } from 'react-toastify';
 
 interface Row {
     id: number;
@@ -152,11 +153,15 @@ export default function LessonPollingTable() {
 
     const handleSetAllCame = async () => {
         const updatable = rows.filter(r => isEditable(r) && r.status !== 0);
-        if (!updatable.length) return;
+        if (!updatable.length) {
+            toast.info('Sınıf zaten tam.');
+            return;
+        }
         setRows(r => r.map(row =>
             isEditable(row) ? { ...row, status: 0, clicked: true } : row,
         ));
         await updateAllAttendanceStatus(updatable.map(r => r.id), 0);
+        toast.success('Sınıf tam olarak işaretlendi.');
     };
 
 

--- a/src/components/common/pollingManagement/teachers/pages/teachers/table.tsx
+++ b/src/components/common/pollingManagement/teachers/pages/teachers/table.tsx
@@ -13,6 +13,7 @@ import { useAttendanceStudentsTable } from '../../../../../hooks/attendanceStude
 import sınıfTam from "../../../../../../assets/images/media/sınıf-tam.svg";
 import sınıfTamHover from "../../../../../../assets/images/media/sınıf-tam-hover.svg";
 import { Button } from 'react-bootstrap';
+import { toast } from 'react-toastify';
 
 interface Row {
     id: number;
@@ -147,11 +148,15 @@ export default function LessonPollingTable() {
 
     const setAllCame = async () => {
         const updatable = rows.filter(r => isEditable(r) && r.status !== 0);
-        if (!updatable.length) return;
+        if (!updatable.length) {
+            toast.info('Sınıf zaten tam.');
+            return;
+        }
         setRows(r => r.map(row =>
             isEditable(row) ? { ...row, status: 0, clicked: true } : row,
         ));
         await updateAllAttendanceStatus(updatable.map(r => r.id), 0);
+        toast.success('Sınıf tam olarak işaretlendi.');
     };
 
 

--- a/src/components/common/pollingManagement/teachers/pages/teachersPolling/table.tsx
+++ b/src/components/common/pollingManagement/teachers/pages/teachersPolling/table.tsx
@@ -13,6 +13,7 @@ import { useAttendanceStudentsTable } from '../../../../../hooks/attendanceStude
 import sınıfTam from "../../../../../../assets/images/media/sınıf-tam.svg";
 import sınıfTamHover from "../../../../../../assets/images/media/sınıf-tam-hover.svg";
 import { Button } from 'react-bootstrap';
+import { toast } from 'react-toastify';
 
 
 interface Row {
@@ -157,11 +158,15 @@ export default function LessonPollingTable() {
 
     const setAllCame = async () => {
         const updatable = rows.filter(r => isEditable(r) && r.status !== 0);
-        if (!updatable.length) return;
+        if (!updatable.length) {
+            toast.info('Sınıf zaten tam.');
+            return;
+        }
         setRows(r => r.map(row =>
             isEditable(row) ? { ...row, status: 0, clicked: true } : row,
         ));
         await updateAllAttendanceStatus(updatable.map(r => r.id), 0);
+        toast.success('Sınıf tam olarak işaretlendi.');
     };
 
 


### PR DESCRIPTION
## Summary
- notify users when attempting to mark all students as present
- show success message when class is set to full
- show info message when class is already full

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_685518d9de20832c93d790173bf9b685