### PR TITLE
Add conversationusers Redux module

### DIFF
--- a/src/components/hooks/conversationusers/useAdd.tsx
+++ b/src/components/hooks/conversationusers/useAdd.tsx
@@ -1,0 +1,25 @@
+// file: src/components/hooks/conversationusers/useAdd.tsx
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { addConversationUser } from '../../../slices/conversationusers/add/thunk'
+import { ConversationUsersAddPayload } from '../../../types/conversationusers/add'
+
+export function useConversationUserAdd() {
+    const dispatch = useDispatch<AppDispatch>()
+    const { data, status, error } = useSelector((state: RootState) => state.conversationUserAdd)
+
+    const addNewConversationUser = useCallback(
+        async (payload: ConversationUsersAddPayload) => {
+            const resultAction = await dispatch(addConversationUser(payload))
+            if (addConversationUser.fulfilled.match(resultAction)) {
+                return resultAction.payload
+            }
+            return null
+        },
+        [dispatch]
+    )
+
+    return { addedConversationUser: data, status, error, addNewConversationUser }
+}

--- a/src/components/hooks/conversationusers/useDelete.tsx
+++ b/src/components/hooks/conversationusers/useDelete.tsx
@@ -1,0 +1,24 @@
+// file: src/components/hooks/conversationusers/useDelete.tsx
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { deleteConversationUser } from '../../../slices/conversationusers/delete/thunk'
+
+export function useConversationUserDelete() {
+    const dispatch = useDispatch<AppDispatch>()
+    const { data, status, error } = useSelector((state: RootState) => state.conversationUserDelete)
+
+    const deleteExistingConversationUser = useCallback(
+        async (conversationUserId: number) => {
+            const resultAction = await dispatch(deleteConversationUser(conversationUserId))
+            if (deleteConversationUser.fulfilled.match(resultAction)) {
+                return resultAction.payload
+            }
+            return null
+        },
+        [dispatch]
+    )
+
+    return { deletedConversationUser: data, status, error, deleteExistingConversationUser }
+}

--- a/src/components/hooks/conversationusers/useDetail.tsx
+++ b/src/components/hooks/conversationusers/useDetail.tsx
@@ -1,0 +1,24 @@
+// file: src/components/hooks/conversationusers/useDetail.tsx
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { fetchConversationUser } from '../../../slices/conversationusers/detail/thunk'
+
+export function useConversationUserDetail() {
+    const dispatch = useDispatch<AppDispatch>()
+    const { data, status, error } = useSelector((state: RootState) => state.conversationUserShow)
+
+    const getConversationUser = useCallback(
+        async (conversationUserId: number) => {
+            const resultAction = await dispatch(fetchConversationUser(conversationUserId))
+            if (fetchConversationUser.fulfilled.match(resultAction)) {
+                return resultAction.payload
+            }
+            return null
+        },
+        [dispatch]
+    )
+
+    return { conversationUser: data, status, error, getConversationUser }
+}

--- a/src/components/hooks/conversationusers/useList.tsx
+++ b/src/components/hooks/conversationusers/useList.tsx
@@ -1,0 +1,61 @@
+// file: src/components/hooks/conversationusers/useList.tsx
+import { useState, useEffect, useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { RootState } from '../../../store/rootReducer'
+import { AppDispatch } from '../../../store'
+import { fetchConversationUsers } from '../../../slices/conversationusers/list/thunk'
+import { ConversationUsersData, ListConversationUserArg, ListMeta } from '../../../types/conversationusers/list'
+import { ConversationUserListStatus } from '../../../enums/conversationusers/list'
+
+export function useConversationUsersList(params: ListConversationUserArg) {
+    if (params?.enabled === false) return
+    const dispatch = useDispatch<AppDispatch>()
+
+    const [page, setPage] = useState<number>(params.page || 1)
+    const [pageSize, setPageSize] = useState<number>(params.pageSize || 10)
+    const [filter, setFilter] = useState<any>(null)
+
+    const { data, meta, status, error } = useSelector(
+        (state: RootState) => state.conversationUserList
+    )
+
+    const buildQuery = () => {
+        const { enabled, ...restParams } = params
+        return {
+            ...restParams,
+            filter,
+            page,
+            pageSize,
+            per_page: pageSize,
+        } as ListConversationUserArg
+    }
+
+    useEffect(() => {
+        dispatch(fetchConversationUsers(buildQuery()))
+    }, [dispatch, filter, page, pageSize, params])
+
+    const refetch = useCallback(() => {
+        dispatch(fetchConversationUsers(buildQuery()))
+    }, [dispatch, filter, page, pageSize, params])
+
+    const loading = status === ConversationUserListStatus.LOADING
+    const conversationUsersData: ConversationUsersData[] = data || []
+    const paginationMeta: ListMeta | null = meta
+    const totalPages = paginationMeta ? paginationMeta.last_page : 1
+    const totalItems = paginationMeta ? paginationMeta.total : 0
+
+    return {
+        conversationUsersData,
+        loading,
+        error,
+        page,
+        setPage,
+        pageSize,
+        setPageSize,
+        filter,
+        setFilter,
+        totalPages,
+        totalItems,
+        refetch,
+    }
+}

--- a/src/components/hooks/conversationusers/useUpdate.tsx
+++ b/src/components/hooks/conversationusers/useUpdate.tsx
@@ -1,0 +1,25 @@
+// file: src/components/hooks/conversationusers/useUpdate.tsx
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { updateConversationUser } from '../../../slices/conversationusers/update/thunk'
+import { ConversationUsersUpdatePayload } from '../../../types/conversationusers/update'
+
+export function useConversationUserUpdate() {
+    const dispatch = useDispatch<AppDispatch>()
+    const { data, status, error } = useSelector((state: RootState) => state.conversationUserUpdate)
+
+    const updateExistingConversationUser = useCallback(
+        async (payload: ConversationUsersUpdatePayload) => {
+            const resultAction = await dispatch(updateConversationUser(payload))
+            if (updateConversationUser.fulfilled.match(resultAction)) {
+                return resultAction.payload
+            }
+            return null
+        },
+        [dispatch]
+    )
+
+    return { updatedConversationUser: data, status, error, updateExistingConversationUser }
+}

--- a/src/enums/conversationusers/list.tsx
+++ b/src/enums/conversationusers/list.tsx
@@ -1,0 +1,8 @@
+// file: src/enums/conversationusers/list.tsx
+export enum ConversationUserListStatus {
+    IDLE = 'IDLE',
+    LOADING = 'LOADING',
+    SUCCEEDED = 'SUCCEEDED',
+    FAILED = 'FAILED',
+}
+export default ConversationUserListStatus

--- a/src/helpers/url_helper.ts
+++ b/src/helpers/url_helper.ts
@@ -167,5 +167,6 @@ export const BULLETINS = '/bulletins';
 export const CONVERSATIONS = '/conversations';
 
 export const MESSAGES = '/messages';
+export const CONVERSATIONUSERS = '/conversationusers';
 
 

--- a/src/slices/conversationusers/add/reducer.tsx
+++ b/src/slices/conversationusers/add/reducer.tsx
@@ -1,0 +1,35 @@
+// file: src/slices/conversationusers/add/reducer.tsx
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { addConversationUser } from './thunk'
+import { ConversationUsersAddState } from '../../../types/conversationusers/add'
+import { ConversationUserListStatus } from '../../../enums/conversationusers/list'
+import { ConversationUsersData } from '../../../types/conversationusers/list'
+
+const initialState: ConversationUsersAddState = {
+    data: null,
+    status: ConversationUserListStatus.IDLE,
+    error: null,
+}
+
+const conversationUsersAddSlice = createSlice({
+    name: 'conversationUsersAdd',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(addConversationUser.pending, (state) => {
+                state.status = ConversationUserListStatus.LOADING
+                state.error = null
+            })
+            .addCase(addConversationUser.fulfilled, (state, action: PayloadAction<ConversationUsersData>) => {
+                state.status = ConversationUserListStatus.SUCCEEDED
+                state.data = action.payload
+            })
+            .addCase(addConversationUser.rejected, (state, action: PayloadAction<any>) => {
+                state.status = ConversationUserListStatus.FAILED
+                state.error = action.payload
+            })
+    },
+})
+
+export default conversationUsersAddSlice.reducer

--- a/src/slices/conversationusers/add/thunk.tsx
+++ b/src/slices/conversationusers/add/thunk.tsx
@@ -1,0 +1,18 @@
+// file: src/slices/conversationusers/add/thunk.tsx
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { CONVERSATIONUSERS } from '../../../helpers/url_helper'
+import { ConversationUsersAddPayload } from '../../../types/conversationusers/add'
+import { ConversationUsersData } from '../../../types/conversationusers/list'
+
+export const addConversationUser = createAsyncThunk<ConversationUsersData, ConversationUsersAddPayload>(
+    'conversationusers/addConversationUser',
+    async (payload, { rejectWithValue }) => {
+        try {
+            const resp = await axiosInstance.post(CONVERSATIONUSERS, payload)
+            return resp.data.data as ConversationUsersData
+        } catch (err: any) {
+            return rejectWithValue(err.response?.data?.message || 'Add conversation user failed')
+        }
+    }
+)

--- a/src/slices/conversationusers/delete/reducer.tsx
+++ b/src/slices/conversationusers/delete/reducer.tsx
@@ -1,0 +1,34 @@
+// file: src/slices/conversationusers/delete/reducer.tsx
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { deleteConversationUser } from './thunk'
+import { ConversationUsersDeleteState } from '../../../types/conversationusers/delete'
+import { ConversationUserListStatus } from '../../../enums/conversationusers/list'
+
+const initialState: ConversationUsersDeleteState = {
+    data: null,
+    status: ConversationUserListStatus.IDLE,
+    error: null,
+}
+
+const conversationUsersDeleteSlice = createSlice({
+    name: 'conversationUsersDelete',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(deleteConversationUser.pending, (state) => {
+                state.status = ConversationUserListStatus.LOADING
+                state.error = null
+            })
+            .addCase(deleteConversationUser.fulfilled, (state, action: PayloadAction<any>) => {
+                state.status = ConversationUserListStatus.SUCCEEDED
+                state.data = action.payload
+            })
+            .addCase(deleteConversationUser.rejected, (state, action: PayloadAction<any>) => {
+                state.status = ConversationUserListStatus.FAILED
+                state.error = action.payload
+            })
+    },
+})
+
+export default conversationUsersDeleteSlice.reducer

--- a/src/slices/conversationusers/delete/thunk.tsx
+++ b/src/slices/conversationusers/delete/thunk.tsx
@@ -1,0 +1,17 @@
+// file: src/slices/conversationusers/delete/thunk.tsx
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { CONVERSATIONUSERS } from '../../../helpers/url_helper'
+import { ConversationUsersDeleteState } from '../../../types/conversationusers/delete'
+
+export const deleteConversationUser = createAsyncThunk<ConversationUsersDeleteState, number>(
+    'conversationusers/deleteConversationUser',
+    async (conversationUserId, { rejectWithValue }) => {
+        try {
+            const resp = await axiosInstance.delete(`${CONVERSATIONUSERS}/${conversationUserId}`)
+            return resp.data as ConversationUsersDeleteState
+        } catch (err: any) {
+            return rejectWithValue(err.response?.data?.message || 'Delete conversation user failed')
+        }
+    }
+)

--- a/src/slices/conversationusers/detail/reducer.tsx
+++ b/src/slices/conversationusers/detail/reducer.tsx
@@ -1,0 +1,35 @@
+// file: src/slices/conversationusers/detail/reducer.tsx
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { fetchConversationUser } from './thunk'
+import { ConversationUsersDetailState } from '../../../types/conversationusers/detail'
+import { ConversationUserListStatus } from '../../../enums/conversationusers/list'
+import { ConversationUsersData } from '../../../types/conversationusers/list'
+
+const initialState: ConversationUsersDetailState = {
+    data: null,
+    status: ConversationUserListStatus.IDLE,
+    error: null,
+}
+
+const conversationUsersDetailSlice = createSlice({
+    name: 'conversationUsersDetail',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(fetchConversationUser.pending, (state) => {
+                state.status = ConversationUserListStatus.LOADING
+                state.error = null
+            })
+            .addCase(fetchConversationUser.fulfilled, (state, action: PayloadAction<ConversationUsersData>) => {
+                state.status = ConversationUserListStatus.SUCCEEDED
+                state.data = action.payload
+            })
+            .addCase(fetchConversationUser.rejected, (state, action: PayloadAction<any>) => {
+                state.status = ConversationUserListStatus.FAILED
+                state.error = action.payload
+            })
+    },
+})
+
+export default conversationUsersDetailSlice.reducer

--- a/src/slices/conversationusers/detail/thunk.tsx
+++ b/src/slices/conversationusers/detail/thunk.tsx
@@ -1,0 +1,17 @@
+// file: src/slices/conversationusers/detail/thunk.tsx
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { CONVERSATIONUSERS } from '../../../helpers/url_helper'
+import { ConversationUsersData } from '../../../types/conversationusers/list'
+
+export const fetchConversationUser = createAsyncThunk<ConversationUsersData, number>(
+    'conversationusers/fetchConversationUser',
+    async (conversationUserId, { rejectWithValue }) => {
+        try {
+            const resp = await axiosInstance.get(`${CONVERSATIONUSERS}/${conversationUserId}`)
+            return resp.data.data as ConversationUsersData
+        } catch (err: any) {
+            return rejectWithValue(err.response?.data?.message || 'Fetch conversation user failed')
+        }
+    }
+)

--- a/src/slices/conversationusers/list/reducer.tsx
+++ b/src/slices/conversationusers/list/reducer.tsx
@@ -1,0 +1,45 @@
+// file: src/slices/conversationusers/list/reducer.tsx
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { fetchConversationUsers } from './thunk'
+import { ListConversationUsersResponse } from '../../../types/conversationusers/list'
+import { ConversationUserListStatus } from '../../../enums/conversationusers/list'
+
+export interface ConversationUsersListState {
+    data: ListConversationUsersResponse['data'] | null
+    links: ListConversationUsersResponse['links'] | null
+    meta: ListConversationUsersResponse['meta'] | null
+    status: ConversationUserListStatus
+    error: string | null
+}
+
+const initialState: ConversationUsersListState = {
+    data: null,
+    links: null,
+    meta: null,
+    status: ConversationUserListStatus.IDLE,
+    error: null,
+}
+
+const conversationUsersListSlice = createSlice({
+    name: 'conversationusers/list',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder.addCase(fetchConversationUsers.pending, (state) => {
+            state.status = ConversationUserListStatus.LOADING
+            state.error = null
+        })
+        builder.addCase(fetchConversationUsers.fulfilled, (state, action: PayloadAction<ListConversationUsersResponse>) => {
+            state.status = ConversationUserListStatus.SUCCEEDED
+            state.data = action.payload.data
+            state.links = action.payload.links
+            state.meta = action.payload.meta
+        })
+        builder.addCase(fetchConversationUsers.rejected, (state, action: PayloadAction<any>) => {
+            state.status = ConversationUserListStatus.FAILED
+            state.error = action.payload || 'Fetch conversation users failed'
+        })
+    },
+})
+
+export default conversationUsersListSlice.reducer

--- a/src/slices/conversationusers/list/thunk.tsx
+++ b/src/slices/conversationusers/list/thunk.tsx
@@ -1,0 +1,24 @@
+// file: src/slices/conversationusers/list/thunk.tsx
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { CONVERSATIONUSERS } from '../../../helpers/url_helper'
+import { ListConversationUsersResponse, ListConversationUserArg } from '../../../types/conversationusers/list'
+
+export const fetchConversationUsers = createAsyncThunk<ListConversationUsersResponse, ListConversationUserArg>(
+    'conversationusers/fetchConversationUsers',
+    async (queryParams, { rejectWithValue }) => {
+        try {
+            const query = new URLSearchParams()
+            Object.entries(queryParams).forEach(([key, value]) => {
+                if (value !== undefined && value !== null && key !== 'enabled') {
+                    query.append(key, String(value))
+                }
+            })
+            const url = `${CONVERSATIONUSERS}?${query.toString()}`
+            const resp = await axiosInstance.get(url)
+            return resp.data as ListConversationUsersResponse
+        } catch (err: any) {
+            return rejectWithValue(err.response?.data?.message || 'Fetch conversation users failed')
+        }
+    }
+)

--- a/src/slices/conversationusers/update/reducer.tsx
+++ b/src/slices/conversationusers/update/reducer.tsx
@@ -1,0 +1,35 @@
+// file: src/slices/conversationusers/update/reducer.tsx
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { updateConversationUser } from './thunk'
+import { ConversationUsersUpdateState } from '../../../types/conversationusers/update'
+import { ConversationUserListStatus } from '../../../enums/conversationusers/list'
+import { ConversationUsersData } from '../../../types/conversationusers/list'
+
+const initialState: ConversationUsersUpdateState = {
+    data: null,
+    status: ConversationUserListStatus.IDLE,
+    error: null,
+}
+
+const conversationUsersUpdateSlice = createSlice({
+    name: 'conversationUsersUpdate',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(updateConversationUser.pending, (state) => {
+                state.status = ConversationUserListStatus.LOADING
+                state.error = null
+            })
+            .addCase(updateConversationUser.fulfilled, (state, action: PayloadAction<ConversationUsersData>) => {
+                state.status = ConversationUserListStatus.SUCCEEDED
+                state.data = action.payload
+            })
+            .addCase(updateConversationUser.rejected, (state, action: PayloadAction<any>) => {
+                state.status = ConversationUserListStatus.FAILED
+                state.error = action.payload
+            })
+    },
+})
+
+export default conversationUsersUpdateSlice.reducer

--- a/src/slices/conversationusers/update/thunk.tsx
+++ b/src/slices/conversationusers/update/thunk.tsx
@@ -1,0 +1,18 @@
+// file: src/slices/conversationusers/update/thunk.tsx
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { CONVERSATIONUSERS } from '../../../helpers/url_helper'
+import { ConversationUsersUpdatePayload } from '../../../types/conversationusers/update'
+import { ConversationUsersData } from '../../../types/conversationusers/list'
+
+export const updateConversationUser = createAsyncThunk<ConversationUsersData, ConversationUsersUpdatePayload>(
+    'conversationusers/updateConversationUser',
+    async ({ conversationUserId, payload }, { rejectWithValue }) => {
+        try {
+            const resp = await axiosInstance.put(`${CONVERSATIONUSERS}/${conversationUserId}`, payload)
+            return resp.data.data as ConversationUsersData
+        } catch (err: any) {
+            return rejectWithValue(err.response?.data?.message || 'Update conversation user failed')
+        }
+    }
+)

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -519,6 +519,11 @@ import messagesShowReducer from '../slices/messages/detail/reducer';
 import messagesAddReducer from '../slices/messages/add/reducer';
 import messagesUpdateReducer from '../slices/messages/update/reducer';
 import messagesDeleteReducer from '../slices/messages/delete/reducer';
+import conversationUsersListReducer from '../slices/conversationusers/list/reducer';
+import conversationUsersShowReducer from '../slices/conversationusers/detail/reducer';
+import conversationUsersAddReducer from '../slices/conversationusers/add/reducer';
+import conversationUsersUpdateReducer from '../slices/conversationusers/update/reducer';
+import conversationUsersDeleteReducer from '../slices/conversationusers/delete/reducer';
 
 //sourceTypes
 import sourceTypesAddSlice from '../slices/sourceTypes/add/reducer';
@@ -1109,6 +1114,11 @@ const combinedReducer = combineReducers({
   conversationAdd: conversationsAddReducer,
   conversationUpdate: conversationsUpdateReducer,
   conversationDelete: conversationsDeleteReducer,
+  conversationUserList: conversationUsersListReducer,
+  conversationUserShow: conversationUsersShowReducer,
+  conversationUserAdd: conversationUsersAddReducer,
+  conversationUserUpdate: conversationUsersUpdateReducer,
+  conversationUserDelete: conversationUsersDeleteReducer,
   messageList: messagesListReducer,
   messageShow: messagesShowReducer,
   messageAdd: messagesAddReducer,

--- a/src/types/conversationusers/add.tsx
+++ b/src/types/conversationusers/add.tsx
@@ -1,0 +1,15 @@
+// file: src/types/conversationusers/add.tsx
+import { ConversationUsersData } from './list'
+import { ConversationUserListStatus } from '../../enums/conversationusers/list'
+
+export interface ConversationUsersAddPayload {
+    id?: number
+    conversation_id: number
+    user_id: number
+}
+
+export interface ConversationUsersAddState {
+    data: ConversationUsersData | null
+    status: ConversationUserListStatus
+    error: string | null
+}

--- a/src/types/conversationusers/delete.tsx
+++ b/src/types/conversationusers/delete.tsx
@@ -1,0 +1,13 @@
+// file: src/types/conversationusers/delete.tsx
+import { ConversationUsersData } from './list'
+import { ConversationUserListStatus } from '../../enums/conversationusers/list'
+
+export interface ConversationUsersDeletePayload {
+    id?: number
+}
+
+export interface ConversationUsersDeleteState {
+    data: ConversationUsersData | null
+    status: ConversationUserListStatus
+    error: string | null
+}

--- a/src/types/conversationusers/detail.tsx
+++ b/src/types/conversationusers/detail.tsx
@@ -1,0 +1,9 @@
+// file: src/types/conversationusers/detail.tsx
+import { ConversationUsersData } from './list'
+import { ConversationUserListStatus } from '../../enums/conversationusers/list'
+
+export interface ConversationUsersDetailState {
+    data: ConversationUsersData | null
+    status: ConversationUserListStatus
+    error: string | null
+}

--- a/src/types/conversationusers/list.tsx
+++ b/src/types/conversationusers/list.tsx
@@ -1,0 +1,73 @@
+// file: src/types/conversationusers/list.tsx
+export interface ConversationUsersConversation {
+    id: number
+    name: string
+    type_id: number
+    user_one_id: number
+    user_two_id: number
+    created_at: string | null
+    updated_at: string | null
+    platform_id: number
+}
+
+export interface ConversationUsersUser {
+    id: number
+    first_name: string
+    last_name: string
+    email: string
+    username: string | null
+    status: number
+    confirmation_code: string
+    confirmed: number
+    is_term_accept: number
+    profile_img: string | null
+    cover: string | null
+    bio: string | null
+    country_id: number | null
+    city_id: number | null
+    timezone_id: number | null
+    lang_id: number | null
+    created_by: number
+    updated_by: number | null
+    created_at: string
+    updated_at: string
+    deleted_at: string | null
+    platform_id: number
+}
+
+export interface ConversationUsersData {
+    id: number
+    conversation_id: number
+    conversation: ConversationUsersConversation
+    user_id: number
+    user: ConversationUsersUser
+}
+
+export interface ListLinks {
+    first: string
+    last: string
+    prev: string | null
+    next: string | null
+}
+
+export interface ListMeta {
+    current_page: number
+    from: number
+    last_page: number
+    links: { url: string | null; label: string; active: boolean }[]
+    path: string
+    per_page: number
+    to: number
+    total: number
+}
+
+export interface ListConversationUsersResponse {
+    data: ConversationUsersData[]
+    links: ListLinks
+    meta: ListMeta
+}
+
+export interface ListConversationUserArg {
+    enabled?: boolean
+    [key: string]: any
+}

--- a/src/types/conversationusers/update.tsx
+++ b/src/types/conversationusers/update.tsx
@@ -1,0 +1,17 @@
+// file: src/types/conversationusers/update.tsx
+import { ConversationUsersData } from './list'
+import { ConversationUserListStatus } from '../../enums/conversationusers/list'
+
+export interface ConversationUsersUpdatePayload {
+    conversationUserId: number
+    payload: {
+        conversation_id?: number | null
+        user_id?: number | null
+    }
+}
+
+export interface ConversationUsersUpdateState {
+    data: ConversationUsersData | null
+    status: ConversationUserListStatus
+    error: string | null
+}


### PR DESCRIPTION
## Summary
- implement conversationusers state management with CRUD thunks and reducers
- provide React hooks for conversationusers operations
- define conversationusers data types and enums
- update API url helpers with CONVERSATIONUSERS
- register reducers in rootReducer

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: missing type declarations and modules)*

------
https://chatgpt.com/codex/tasks/task_e_685519cd3d44832cb788bb7e35e94ecc