### PR TITLE
Add notificationusers module

### DIFF
--- a/src/components/hooks/notificationusers/useAdd.tsx
+++ b/src/components/hooks/notificationusers/useAdd.tsx
@@ -1,0 +1,25 @@
+// file: src/components/hooks/notificationusers/useAdd.tsx
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { addNotificationUser } from '../../../slices/notificationusers/add/thunk'
+import { NotificationUsersAddPayload } from '../../../types/notificationusers/add'
+
+export function useNotificationUserAdd() {
+    const dispatch = useDispatch<AppDispatch>()
+    const { data, status, error } = useSelector((state: RootState) => state.notificationUserAdd)
+
+    const addNewNotificationUser = useCallback(
+        async (payload: NotificationUsersAddPayload) => {
+            const resultAction = await dispatch(addNotificationUser(payload))
+            if (addNotificationUser.fulfilled.match(resultAction)) {
+                return resultAction.payload
+            }
+            return null
+        },
+        [dispatch]
+    )
+
+    return { addedNotificationUser: data, status, error, addNewNotificationUser }
+}

--- a/src/components/hooks/notificationusers/useDelete.tsx
+++ b/src/components/hooks/notificationusers/useDelete.tsx
@@ -1,0 +1,24 @@
+// file: src/components/hooks/notificationusers/useDelete.tsx
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { deleteNotificationUser } from '../../../slices/notificationusers/delete/thunk'
+
+export function useNotificationUserDelete() {
+    const dispatch = useDispatch<AppDispatch>()
+    const { data, status, error } = useSelector((state: RootState) => state.notificationUserDelete)
+
+    const deleteExistingNotificationUser = useCallback(
+        async (notificationUserId: number) => {
+            const resultAction = await dispatch(deleteNotificationUser(notificationUserId))
+            if (deleteNotificationUser.fulfilled.match(resultAction)) {
+                return resultAction.payload
+            }
+            return null
+        },
+        [dispatch]
+    )
+
+    return { deletedNotificationUser: data, status, error, deleteExistingNotificationUser }
+}

--- a/src/components/hooks/notificationusers/useDetail.tsx
+++ b/src/components/hooks/notificationusers/useDetail.tsx
@@ -1,0 +1,24 @@
+// file: src/components/hooks/notificationusers/useDetail.tsx
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { fetchNotificationUser } from '../../../slices/notificationusers/detail/thunk'
+
+export function useNotificationUserDetail() {
+    const dispatch = useDispatch<AppDispatch>()
+    const { data, status, error } = useSelector((state: RootState) => state.notificationUserShow)
+
+    const getNotificationUser = useCallback(
+        async (notificationUserId: number) => {
+            const resultAction = await dispatch(fetchNotificationUser(notificationUserId))
+            if (fetchNotificationUser.fulfilled.match(resultAction)) {
+                return resultAction.payload
+            }
+            return null
+        },
+        [dispatch]
+    )
+
+    return { notificationUser: data, status, error, getNotificationUser }
+}

--- a/src/components/hooks/notificationusers/useList.tsx
+++ b/src/components/hooks/notificationusers/useList.tsx
@@ -1,0 +1,61 @@
+// file: src/components/hooks/notificationusers/useList.tsx
+import { useState, useEffect, useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { RootState } from '../../../store/rootReducer'
+import { AppDispatch } from '../../../store'
+import { fetchNotificationUsers } from '../../../slices/notificationusers/list/thunk'
+import { NotificationUsersData, ListNotificationUserArg, ListMeta } from '../../../types/notificationusers/list'
+import { NotificationUserListStatus } from '../../../enums/notificationusers/list'
+
+export function useNotificationUsersList(params: ListNotificationUserArg) {
+    if (params?.enabled === false) return
+    const dispatch = useDispatch<AppDispatch>()
+
+    const [page, setPage] = useState<number>(params.page || 1)
+    const [pageSize, setPageSize] = useState<number>(params.pageSize || 10)
+    const [filter, setFilter] = useState<any>(null)
+
+    const { data, meta, status, error } = useSelector(
+        (state: RootState) => state.notificationUserList
+    )
+
+    const buildQuery = () => {
+        const { enabled, ...restParams } = params
+        return {
+            ...restParams,
+            filter,
+            page,
+            pageSize,
+            per_page: pageSize,
+        } as ListNotificationUserArg
+    }
+
+    useEffect(() => {
+        dispatch(fetchNotificationUsers(buildQuery()))
+    }, [dispatch, filter, page, pageSize, params])
+
+    const refetch = useCallback(() => {
+        dispatch(fetchNotificationUsers(buildQuery()))
+    }, [dispatch, filter, page, pageSize, params])
+
+    const loading = status === NotificationUserListStatus.LOADING
+    const notificationUsersData: NotificationUsersData[] = data || []
+    const paginationMeta: ListMeta | null = meta
+    const totalPages = paginationMeta ? paginationMeta.last_page : 1
+    const totalItems = paginationMeta ? paginationMeta.total : 0
+
+    return {
+        notificationUsersData,
+        loading,
+        error,
+        page,
+        setPage,
+        pageSize,
+        setPageSize,
+        filter,
+        setFilter,
+        totalPages,
+        totalItems,
+        refetch,
+    }
+}

--- a/src/components/hooks/notificationusers/useUpdate.tsx
+++ b/src/components/hooks/notificationusers/useUpdate.tsx
@@ -1,0 +1,25 @@
+// file: src/components/hooks/notificationusers/useUpdate.tsx
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { updateNotificationUser } from '../../../slices/notificationusers/update/thunk'
+import { NotificationUsersUpdatePayload } from '../../../types/notificationusers/update'
+
+export function useNotificationUserUpdate() {
+    const dispatch = useDispatch<AppDispatch>()
+    const { data, status, error } = useSelector((state: RootState) => state.notificationUserUpdate)
+
+    const updateExistingNotificationUser = useCallback(
+        async (payload: NotificationUsersUpdatePayload) => {
+            const resultAction = await dispatch(updateNotificationUser(payload))
+            if (updateNotificationUser.fulfilled.match(resultAction)) {
+                return resultAction.payload
+            }
+            return null
+        },
+        [dispatch]
+    )
+
+    return { updatedNotificationUser: data, status, error, updateExistingNotificationUser }
+}

--- a/src/enums/notificationusers/list.tsx
+++ b/src/enums/notificationusers/list.tsx
@@ -1,0 +1,8 @@
+// file: src/enums/notificationusers/list.tsx
+export enum NotificationUserListStatus {
+    IDLE = 'IDLE',
+    LOADING = 'LOADING',
+    SUCCEEDED = 'SUCCEEDED',
+    FAILED = 'FAILED',
+}
+export default NotificationUserListStatus

--- a/src/slices/notificationusers/add/reducer.tsx
+++ b/src/slices/notificationusers/add/reducer.tsx
@@ -1,0 +1,35 @@
+// file: src/slices/notificationusers/add/reducer.tsx
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { addNotificationUser } from './thunk'
+import { NotificationUsersAddState } from '../../../types/notificationusers/add'
+import { NotificationUserListStatus } from '../../../enums/notificationusers/list'
+import { NotificationUsersData } from '../../../types/notificationusers/list'
+
+const initialState: NotificationUsersAddState = {
+    data: null,
+    status: NotificationUserListStatus.IDLE,
+    error: null,
+}
+
+const notificationUsersAddSlice = createSlice({
+    name: 'notificationUsersAdd',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(addNotificationUser.pending, (state) => {
+                state.status = NotificationUserListStatus.LOADING
+                state.error = null
+            })
+            .addCase(addNotificationUser.fulfilled, (state, action: PayloadAction<NotificationUsersData>) => {
+                state.status = NotificationUserListStatus.SUCCEEDED
+                state.data = action.payload
+            })
+            .addCase(addNotificationUser.rejected, (state, action: PayloadAction<any>) => {
+                state.status = NotificationUserListStatus.FAILED
+                state.error = action.payload
+            })
+    },
+})
+
+export default notificationUsersAddSlice.reducer

--- a/src/slices/notificationusers/add/thunk.tsx
+++ b/src/slices/notificationusers/add/thunk.tsx
@@ -1,0 +1,18 @@
+// file: src/slices/notificationusers/add/thunk.tsx
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { NOTIFICATIONUSERS } from '../../../helpers/url_helper'
+import { NotificationUsersAddPayload } from '../../../types/notificationusers/add'
+import { NotificationUsersData } from '../../../types/notificationusers/list'
+
+export const addNotificationUser = createAsyncThunk<NotificationUsersData, NotificationUsersAddPayload>(
+    'notificationusers/addNotificationUser',
+    async (payload, { rejectWithValue }) => {
+        try {
+            const resp = await axiosInstance.post(NOTIFICATIONUSERS, payload)
+            return resp.data.data as NotificationUsersData
+        } catch (err: any) {
+            return rejectWithValue(err.response?.data?.message || 'Add notification user failed')
+        }
+    }
+)

--- a/src/slices/notificationusers/delete/reducer.tsx
+++ b/src/slices/notificationusers/delete/reducer.tsx
@@ -1,0 +1,34 @@
+// file: src/slices/notificationusers/delete/reducer.tsx
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { deleteNotificationUser } from './thunk'
+import { NotificationUsersDeleteState } from '../../../types/notificationusers/delete'
+import { NotificationUserListStatus } from '../../../enums/notificationusers/list'
+
+const initialState: NotificationUsersDeleteState = {
+    data: null,
+    status: NotificationUserListStatus.IDLE,
+    error: null,
+}
+
+const notificationUsersDeleteSlice = createSlice({
+    name: 'notificationUsersDelete',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(deleteNotificationUser.pending, (state) => {
+                state.status = NotificationUserListStatus.LOADING
+                state.error = null
+            })
+            .addCase(deleteNotificationUser.fulfilled, (state, action: PayloadAction<any>) => {
+                state.status = NotificationUserListStatus.SUCCEEDED
+                state.data = action.payload
+            })
+            .addCase(deleteNotificationUser.rejected, (state, action: PayloadAction<any>) => {
+                state.status = NotificationUserListStatus.FAILED
+                state.error = action.payload
+            })
+    },
+})
+
+export default notificationUsersDeleteSlice.reducer

--- a/src/slices/notificationusers/delete/thunk.tsx
+++ b/src/slices/notificationusers/delete/thunk.tsx
@@ -1,0 +1,17 @@
+// file: src/slices/notificationusers/delete/thunk.tsx
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { NOTIFICATIONUSERS } from '../../../helpers/url_helper'
+import { NotificationUsersDeleteState } from '../../../types/notificationusers/delete'
+
+export const deleteNotificationUser = createAsyncThunk<NotificationUsersDeleteState, number>(
+    'notificationusers/deleteNotificationUser',
+    async (notificationUserId, { rejectWithValue }) => {
+        try {
+            const resp = await axiosInstance.delete(`${NOTIFICATIONUSERS}/${notificationUserId}`)
+            return resp.data as NotificationUsersDeleteState
+        } catch (err: any) {
+            return rejectWithValue(err.response?.data?.message || 'Delete notification user failed')
+        }
+    }
+)

--- a/src/slices/notificationusers/detail/reducer.tsx
+++ b/src/slices/notificationusers/detail/reducer.tsx
@@ -1,0 +1,35 @@
+// file: src/slices/notificationusers/detail/reducer.tsx
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { fetchNotificationUser } from './thunk'
+import { NotificationUsersDetailState } from '../../../types/notificationusers/detail'
+import { NotificationUserListStatus } from '../../../enums/notificationusers/list'
+import { NotificationUsersData } from '../../../types/notificationusers/list'
+
+const initialState: NotificationUsersDetailState = {
+    data: null,
+    status: NotificationUserListStatus.IDLE,
+    error: null,
+}
+
+const notificationUsersDetailSlice = createSlice({
+    name: 'notificationUsersDetail',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(fetchNotificationUser.pending, (state) => {
+                state.status = NotificationUserListStatus.LOADING
+                state.error = null
+            })
+            .addCase(fetchNotificationUser.fulfilled, (state, action: PayloadAction<NotificationUsersData>) => {
+                state.status = NotificationUserListStatus.SUCCEEDED
+                state.data = action.payload
+            })
+            .addCase(fetchNotificationUser.rejected, (state, action: PayloadAction<any>) => {
+                state.status = NotificationUserListStatus.FAILED
+                state.error = action.payload
+            })
+    },
+})
+
+export default notificationUsersDetailSlice.reducer

--- a/src/slices/notificationusers/detail/thunk.tsx
+++ b/src/slices/notificationusers/detail/thunk.tsx
@@ -1,0 +1,17 @@
+// file: src/slices/notificationusers/detail/thunk.tsx
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { NOTIFICATIONUSERS } from '../../../helpers/url_helper'
+import { NotificationUsersData } from '../../../types/notificationusers/list'
+
+export const fetchNotificationUser = createAsyncThunk<NotificationUsersData, number>(
+    'notificationusers/fetchNotificationUser',
+    async (notificationUserId, { rejectWithValue }) => {
+        try {
+            const resp = await axiosInstance.get(`${NOTIFICATIONUSERS}/${notificationUserId}`)
+            return resp.data.data as NotificationUsersData
+        } catch (err: any) {
+            return rejectWithValue(err.response?.data?.message || 'Fetch notification user failed')
+        }
+    }
+)

--- a/src/slices/notificationusers/list/reducer.tsx
+++ b/src/slices/notificationusers/list/reducer.tsx
@@ -1,0 +1,45 @@
+// file: src/slices/notificationusers/list/reducer.tsx
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { fetchNotificationUsers } from './thunk'
+import { ListNotificationUsersResponse } from '../../../types/notificationusers/list'
+import { NotificationUserListStatus } from '../../../enums/notificationusers/list'
+
+export interface NotificationUsersListState {
+    data: ListNotificationUsersResponse['data'] | null
+    links: ListNotificationUsersResponse['links'] | null
+    meta: ListNotificationUsersResponse['meta'] | null
+    status: NotificationUserListStatus
+    error: string | null
+}
+
+const initialState: NotificationUsersListState = {
+    data: null,
+    links: null,
+    meta: null,
+    status: NotificationUserListStatus.IDLE,
+    error: null,
+}
+
+const notificationUsersListSlice = createSlice({
+    name: 'notificationusers/list',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder.addCase(fetchNotificationUsers.pending, (state) => {
+            state.status = NotificationUserListStatus.LOADING
+            state.error = null
+        })
+        builder.addCase(fetchNotificationUsers.fulfilled, (state, action: PayloadAction<ListNotificationUsersResponse>) => {
+            state.status = NotificationUserListStatus.SUCCEEDED
+            state.data = action.payload.data
+            state.links = action.payload.links
+            state.meta = action.payload.meta
+        })
+        builder.addCase(fetchNotificationUsers.rejected, (state, action: PayloadAction<any>) => {
+            state.status = NotificationUserListStatus.FAILED
+            state.error = action.payload || 'Fetch notification users failed'
+        })
+    },
+})
+
+export default notificationUsersListSlice.reducer

--- a/src/slices/notificationusers/list/thunk.tsx
+++ b/src/slices/notificationusers/list/thunk.tsx
@@ -1,0 +1,24 @@
+// file: src/slices/notificationusers/list/thunk.tsx
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { NOTIFICATIONUSERS } from '../../../helpers/url_helper'
+import { ListNotificationUsersResponse, ListNotificationUserArg } from '../../../types/notificationusers/list'
+
+export const fetchNotificationUsers = createAsyncThunk<ListNotificationUsersResponse, ListNotificationUserArg>(
+    'notificationusers/fetchNotificationUsers',
+    async (queryParams, { rejectWithValue }) => {
+        try {
+            const query = new URLSearchParams()
+            Object.entries(queryParams).forEach(([key, value]) => {
+                if (value !== undefined && value !== null && key !== 'enabled') {
+                    query.append(key, String(value))
+                }
+            })
+            const url = `${NOTIFICATIONUSERS}?${query.toString()}`
+            const resp = await axiosInstance.get(url)
+            return resp.data as ListNotificationUsersResponse
+        } catch (err: any) {
+            return rejectWithValue(err.response?.data?.message || 'Fetch notification users failed')
+        }
+    }
+)

--- a/src/slices/notificationusers/update/reducer.tsx
+++ b/src/slices/notificationusers/update/reducer.tsx
@@ -1,0 +1,35 @@
+// file: src/slices/notificationusers/update/reducer.tsx
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { updateNotificationUser } from './thunk'
+import { NotificationUsersUpdateState } from '../../../types/notificationusers/update'
+import { NotificationUserListStatus } from '../../../enums/notificationusers/list'
+import { NotificationUsersData } from '../../../types/notificationusers/list'
+
+const initialState: NotificationUsersUpdateState = {
+    data: null,
+    status: NotificationUserListStatus.IDLE,
+    error: null,
+}
+
+const notificationUsersUpdateSlice = createSlice({
+    name: 'notificationUsersUpdate',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(updateNotificationUser.pending, (state) => {
+                state.status = NotificationUserListStatus.LOADING
+                state.error = null
+            })
+            .addCase(updateNotificationUser.fulfilled, (state, action: PayloadAction<NotificationUsersData>) => {
+                state.status = NotificationUserListStatus.SUCCEEDED
+                state.data = action.payload
+            })
+            .addCase(updateNotificationUser.rejected, (state, action: PayloadAction<any>) => {
+                state.status = NotificationUserListStatus.FAILED
+                state.error = action.payload
+            })
+    },
+})
+
+export default notificationUsersUpdateSlice.reducer

--- a/src/slices/notificationusers/update/thunk.tsx
+++ b/src/slices/notificationusers/update/thunk.tsx
@@ -1,0 +1,18 @@
+// file: src/slices/notificationusers/update/thunk.tsx
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { NOTIFICATIONUSERS } from '../../../helpers/url_helper'
+import { NotificationUsersUpdatePayload } from '../../../types/notificationusers/update'
+import { NotificationUsersData } from '../../../types/notificationusers/list'
+
+export const updateNotificationUser = createAsyncThunk<NotificationUsersData, NotificationUsersUpdatePayload>(
+    'notificationusers/updateNotificationUser',
+    async ({ notificationUserId, payload }, { rejectWithValue }) => {
+        try {
+            const resp = await axiosInstance.put(`${NOTIFICATIONUSERS}/${notificationUserId}`, payload)
+            return resp.data.data as NotificationUsersData
+        } catch (err: any) {
+            return rejectWithValue(err.response?.data?.message || 'Update notification user failed')
+        }
+    }
+)

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -529,6 +529,11 @@ import notificationsShowReducer from '../slices/notifications/detail/reducer';
 import notificationsAddReducer from '../slices/notifications/add/reducer';
 import notificationsUpdateReducer from '../slices/notifications/update/reducer';
 import notificationsDeleteReducer from '../slices/notifications/delete/reducer';
+import notificationUsersListReducer from '../slices/notificationusers/list/reducer';
+import notificationUsersShowReducer from '../slices/notificationusers/detail/reducer';
+import notificationUsersAddReducer from '../slices/notificationusers/add/reducer';
+import notificationUsersUpdateReducer from '../slices/notificationusers/update/reducer';
+import notificationUsersDeleteReducer from '../slices/notificationusers/delete/reducer';
 
 //sourceTypes
 import sourceTypesAddSlice from '../slices/sourceTypes/add/reducer';
@@ -1134,6 +1139,11 @@ const combinedReducer = combineReducers({
   notificationAdd: notificationsAddReducer,
   notificationUpdate: notificationsUpdateReducer,
   notificationDelete: notificationsDeleteReducer,
+  notificationUserList: notificationUsersListReducer,
+  notificationUserShow: notificationUsersShowReducer,
+  notificationUserAdd: notificationUsersAddReducer,
+  notificationUserUpdate: notificationUsersUpdateReducer,
+  notificationUserDelete: notificationUsersDeleteReducer,
 
   //sourcetypes
   sourceTypesAdd: sourceTypesAddSlice,

--- a/src/types/notificationusers/add.tsx
+++ b/src/types/notificationusers/add.tsx
@@ -1,0 +1,16 @@
+// file: src/types/notificationusers/add.tsx
+import { NotificationUsersData } from './list'
+import { NotificationUserListStatus } from '../../enums/notificationusers/list'
+
+export interface NotificationUsersAddPayload {
+    id?: number
+    notification_id: number
+    user_id: number
+    read_at?: string | null
+}
+
+export interface NotificationUsersAddState {
+    data: NotificationUsersData | null
+    status: NotificationUserListStatus
+    error: string | null
+}

--- a/src/types/notificationusers/delete.tsx
+++ b/src/types/notificationusers/delete.tsx
@@ -1,0 +1,13 @@
+// file: src/types/notificationusers/delete.tsx
+import { NotificationUsersData } from './list'
+import { NotificationUserListStatus } from '../../enums/notificationusers/list'
+
+export interface NotificationUsersDeletePayload {
+    id?: number
+}
+
+export interface NotificationUsersDeleteState {
+    data: NotificationUsersData | null
+    status: NotificationUserListStatus
+    error: string | null
+}

--- a/src/types/notificationusers/detail.tsx
+++ b/src/types/notificationusers/detail.tsx
@@ -1,0 +1,9 @@
+// file: src/types/notificationusers/detail.tsx
+import { NotificationUsersData } from './list'
+import { NotificationUserListStatus } from '../../enums/notificationusers/list'
+
+export interface NotificationUsersDetailState {
+    data: NotificationUsersData | null
+    status: NotificationUserListStatus
+    error: string | null
+}

--- a/src/types/notificationusers/list.tsx
+++ b/src/types/notificationusers/list.tsx
@@ -1,0 +1,82 @@
+// file: src/types/notificationusers/list.tsx
+export interface NotificationUsersNotification {
+    id: number
+    title: string | null
+    message: string
+    user_id: number
+    type_id: number
+    group_id: number | null
+    category_id: number | null
+    source_id: number | null
+    sender_id: number | null
+    send_time: string
+    type: number
+    is_read: number
+    status: number
+    created_at: string
+    updated_at: string | null
+    platform_id: number
+}
+
+export interface NotificationUsersUser {
+    id: number
+    first_name: string
+    last_name: string
+    email: string
+    username: string | null
+    status: number
+    confirmation_code: string
+    confirmed: number
+    is_term_accept: number
+    profile_img: string | null
+    cover: string | null
+    bio: string | null
+    country_id: number | null
+    city_id: number | null
+    timezone_id: number | null
+    lang_id: number | null
+    created_by: number
+    updated_by: number | null
+    created_at: string
+    updated_at: string
+    deleted_at: string | null
+    platform_id: number
+}
+
+export interface NotificationUsersData {
+    id: number
+    notification_id: number
+    notification: NotificationUsersNotification
+    user_id: number
+    user: NotificationUsersUser
+    read_at: string | null
+}
+
+export interface ListLinks {
+    first: string
+    last: string
+    prev: string | null
+    next: string | null
+}
+
+export interface ListMeta {
+    current_page: number
+    from: number
+    last_page: number
+    links: { url: string | null; label: string; active: boolean }[]
+    path: string
+    per_page: number
+    to: number
+    total: number
+}
+
+export interface ListNotificationUsersResponse {
+    data: NotificationUsersData[]
+    links: ListLinks
+    meta: ListMeta
+}
+
+export interface ListNotificationUserArg {
+    enabled?: boolean
+    [key: string]: any
+}

--- a/src/types/notificationusers/update.tsx
+++ b/src/types/notificationusers/update.tsx
@@ -1,0 +1,18 @@
+// file: src/types/notificationusers/update.tsx
+import { NotificationUsersData } from './list'
+import { NotificationUserListStatus } from '../../enums/notificationusers/list'
+
+export interface NotificationUsersUpdatePayload {
+    notificationUserId: number
+    payload: {
+        notification_id?: number | null
+        user_id?: number | null
+        read_at?: string | null
+    }
+}
+
+export interface NotificationUsersUpdateState {
+    data: NotificationUsersData | null
+    status: NotificationUserListStatus
+    error: string | null
+}


### PR DESCRIPTION
## Summary
- implement notificationusers Redux slice set (list/detail/add/update/delete)
- provide hooks for notificationusers operations
- integrate notificationusers reducers into rootReducer

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails with TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_685528508914832ca6a33dbb96f2ae0b