### PR TITLE
Implement SMS table and CRUD

### DIFF
--- a/src/components/common/contactPanel/pages/sms/crud.tsx
+++ b/src/components/common/contactPanel/pages/sms/crud.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Button } from 'react-bootstrap';
+import { FormikValues } from 'formik';
+
+import ReusableModalForm, { FieldDefinition } from '../../../ReusableModalForm';
+import { useNotificationAdd } from '../../../../hooks/notifications/useAdd';
+import { useNotificationUpdate } from '../../../../hooks/notifications/useUpdate';
+import { useNotificationDetail } from '../../../../hooks/notifications/useDetail';
+import { useUsersTable } from '../../../../hooks/user/useList';
+
+interface FormData extends FormikValues {
+    title: string;
+    message: string;
+    category_id: string;
+    sender_id: string;
+    send_option: 'now' | 'schedule';
+    send_date: string;
+    send_time: string;
+    status: string;
+    sent_count: string;
+    group_id: string;
+}
+
+export default function SmsCrud() {
+    const navigate = useNavigate();
+    const { id } = useParams<{ id?: string }>();
+    const mode: 'add' | 'edit' = id ? 'edit' : 'add';
+
+    const { addNewNotification, status: addStatus, error: addError } = useNotificationAdd();
+    const { updateExistingNotification, status: updStatus, error: updError } = useNotificationUpdate();
+    const { notification, status: detailStatus, error: detailError, getNotification } = useNotificationDetail();
+    const { usersData = [] } = useUsersTable({ enabled: true, pageSize: 999 });
+
+    const [initialValues, setInitialValues] = useState<FormData>({
+        title: '',
+        message: '',
+        category_id: '',
+        sender_id: '',
+        send_option: 'now',
+        send_date: '',
+        send_time: '',
+        status: '1',
+        sent_count: '0',
+        group_id: '',
+    });
+    const [showGroupModal, setShowGroupModal] = useState(false);
+
+    useEffect(() => {
+        if (mode === 'edit' && id) {
+            getNotification(Number(id));
+        }
+    }, [mode, id, getNotification]);
+
+    useEffect(() => {
+        if (mode === 'edit' && notification) {
+            setInitialValues({
+                title: notification.title ?? '',
+                message: notification.message ?? '',
+                category_id: String(notification.category_id ?? ''),
+                sender_id: String(notification.sender_id ?? ''),
+                send_option: 'schedule',
+                send_date: notification.send_time?.split(' ')[0] ?? '',
+                send_time: notification.send_time?.split(' ')[1] ?? '',
+                status: String(notification.status ?? '1'),
+                sent_count: '0',
+                group_id: String(notification.group_id ?? ''),
+            });
+        }
+    }, [notification, mode]);
+
+    const categoryOptions = [
+        { value: '1', label: 'Ödev' },
+        { value: '2', label: 'Sınav' },
+        { value: '3', label: 'Sistem' },
+        { value: '4', label: 'Duyuru' },
+    ];
+
+    const statusOptions = [
+        { value: '1', label: 'Gönderildi' },
+        { value: '2', label: 'Planlandı' },
+        { value: '3', label: 'Hata' },
+    ];
+
+    const userOptions = usersData.map((u) => ({ value: String(u.id), label: u.name_surname || `${u.first_name} ${u.last_name}` }));
+
+    const getFields = (values: FormData): FieldDefinition[] => {
+        return [
+            { name: 'title', label: 'Başlık', type: 'text', required: true },
+            { name: 'message', label: 'İçerik', type: 'textarea', required: true },
+            { name: 'category_id', label: 'Kategori', type: 'select', options: categoryOptions, required: true },
+            {
+                name: 'sender_id',
+                label: 'Gönderen',
+                type: 'select',
+                options: userOptions,
+            },
+            {
+                name: 'send_option',
+                label: 'Gönderim Tarihi',
+                renderForm: (formik) => (
+                    <div className="d-flex gap-3">
+                        <label className="form-check">
+                            <input
+                                type="radio"
+                                className="form-check-input"
+                                checked={formik.values.send_option === 'now'}
+                                onChange={() => formik.setFieldValue('send_option', 'now')}
+                            />
+                            <span className="form-check-label">Hemen Gönder</span>
+                        </label>
+                        <label className="form-check">
+                            <input
+                                type="radio"
+                                className="form-check-input"
+                                checked={formik.values.send_option === 'schedule'}
+                                onChange={() => formik.setFieldValue('send_option', 'schedule')}
+                            />
+                            <span className="form-check-label">Planla</span>
+                        </label>
+                    </div>
+                ),
+            },
+            ...(values.send_option === 'schedule'
+                ? [
+                      { name: 'send_date', label: 'Tarih', type: 'date', required: true },
+                      { name: 'send_time', label: 'Saat', type: 'time', required: true },
+                  ]
+                : []),
+            { name: 'status', label: 'Durum', type: 'select', options: statusOptions },
+            {
+                name: 'sent_count',
+                label: 'Gönderilen Kişi Sayısı',
+                renderForm: () => <span>{values.sent_count}</span>,
+            },
+            {
+                name: 'group_id',
+                label: 'Hedef Kitle',
+                renderForm: () => (
+                    <Button variant="outline-secondary" onClick={() => setShowGroupModal(true)}>
+                        <i className="ti ti-eye" />
+                    </Button>
+                ),
+            },
+        ];
+    };
+
+    const handleSubmit = async (values: FormData) => {
+        const payload = { ...(values as any) };
+        if (values.send_option === 'schedule') {
+            payload.send_time = `${values.send_date} ${values.send_time}`;
+        }
+        if (mode === 'add') {
+            await addNewNotification(payload as any);
+        } else if (mode === 'edit' && id) {
+            await updateExistingNotification({ notificationId: Number(id), payload: payload as any });
+        }
+        navigate(`${import.meta.env.BASE_URL}contact-panel/sms`);
+    };
+
+    const isLoading =
+        (mode === 'add' && addStatus === 'LOADING') ||
+        (mode === 'edit' && (updStatus === 'LOADING' || detailStatus === 'LOADING'));
+    const combinedError = mode === 'add' ? addError : updError || detailError;
+
+    return (
+        <ReusableModalForm<FormData>
+            show
+            title={mode === 'add' ? 'SMS Ekle' : 'SMS Düzenle'}
+            fields={(values) => getFields(values as FormData)}
+            initialValues={initialValues}
+            onSubmit={handleSubmit}
+            confirmButtonLabel={mode === 'add' ? 'Gönder' : 'Güncelle'}
+            cancelButtonLabel="Vazgeç"
+            isLoading={isLoading}
+            error={combinedError || undefined}
+            onClose={() => navigate(`${import.meta.env.BASE_URL}contact-panel/sms`)}
+            autoGoBackOnModalClose
+            mode="double"
+        />
+    );
+}

--- a/src/components/common/contactPanel/pages/sms/table.tsx
+++ b/src/components/common/contactPanel/pages/sms/table.tsx
@@ -1,0 +1,180 @@
+import { useState, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import dayjs from 'dayjs';
+
+import ReusableTable, { ColumnDefinition } from '../../../ReusableTable';
+import FilterGroup, { FilterDefinition } from '../../component/organisms/SearchFilters';
+import { useNotificationsList } from '../../../../hooks/notifications/useList';
+import { useGroupsTable } from '../../../../hooks/group/useList';
+import { useUsersTable } from '../../../../hooks/user/useList';
+import { useNotificationDelete } from '../../../../hooks/notifications/useDelete';
+import type { NotificationData } from '../../../../../types/notifications/list';
+
+const ROOT = `${import.meta.env.BASE_URL}contact-panel/sms`;
+
+export default function SmsTable() {
+    const navigate = useNavigate();
+    const [dateRange, setDateRange] = useState<{ startDate: string; endDate: string }>({ startDate: '', endDate: '' });
+    const [categoryId, setCategoryId] = useState('');
+    const [groupIds, setGroupIds] = useState<string[]>([]);
+    const [senderId, setSenderId] = useState('');
+    const [status, setStatus] = useState('');
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(10);
+    const [enabled, setEnabled] = useState({ groups: false, users: false });
+
+    const { groupsData = [] } = useGroupsTable({ enabled: enabled.groups, pageSize: 999 });
+    const { usersData = [] } = useUsersTable({ enabled: enabled.users, pageSize: 999 });
+    const { deleteExistingNotification } = useNotificationDelete();
+
+    const { notificationsData = [], loading, error, totalPages, totalItems } = useNotificationsList({
+        page,
+        pageSize,
+        start_date: dateRange.startDate || undefined,
+        end_date: dateRange.endDate || undefined,
+        category_id: categoryId || undefined,
+        group_id: groupIds.join(',') || undefined,
+        sender_id: senderId || undefined,
+        status: status || undefined,
+        enabled: true,
+    });
+
+    const categoryOptions = [
+        { value: '1', label: 'Ödev' },
+        { value: '2', label: 'Sınav' },
+        { value: '3', label: 'Sistem' },
+        { value: '4', label: 'Duyuru' },
+    ];
+
+    const statusOptions = [
+        { value: '1', label: 'Gönderildi' },
+        { value: '2', label: 'Planlandı' },
+        { value: '3', label: 'Hata' },
+    ];
+
+    const columns: ColumnDefinition<NotificationData>[] = useMemo(
+        () => [
+            { key: 'title', label: 'Başlık', render: (n) => n.title || '-' },
+            {
+                key: 'send_time',
+                label: 'Gönderim Tarihi',
+                render: (n) => dayjs(n.send_time).format('MM.DD.YYYY - HH:mm'),
+            },
+            {
+                key: 'category',
+                label: 'Kategori',
+                render: (n) => categoryOptions.find((c) => c.value === String(n.category_id))?.label || '-',
+            },
+            {
+                key: 'group',
+                label: 'Hedef Kitle',
+                render: (n) => (n.group as any)?.name || '-',
+            },
+            {
+                key: 'sender',
+                label: 'Gönderen',
+                render: (n) => (n.sender as any)?.name_surname || '-',
+            },
+            {
+                key: 'status',
+                label: 'Durum',
+                render: (n) => statusOptions.find((s) => s.value === String(n.status))?.label || '-',
+            },
+            {
+                key: 'read_count',
+                label: 'Okunan Kişi Sayısı',
+                render: () => '-',
+            },
+            {
+                key: 'actions',
+                label: 'İşlemler',
+                render: (row) => (
+                    <div className="d-flex gap-2">
+                        <button
+                            onClick={() => navigate(`${ROOT}/edit/${row.id}`)}
+                            className="btn btn-icon btn-sm btn-info-light rounded-pill"
+                        >
+                            <i className="ti ti-pencil" />
+                        </button>
+                        <button
+                            onClick={() => deleteExistingNotification(row.id)}
+                            className="btn btn-icon btn-sm btn-danger-light rounded-pill"
+                        >
+                            <i className="ti ti-trash" />
+                        </button>
+                    </div>
+                ),
+            },
+        ],
+        [navigate, deleteExistingNotification]
+    );
+
+    const filters: FilterDefinition[] = useMemo(
+        () => [
+            {
+                key: 'dateRange',
+                label: 'Tarih Aralığı',
+                type: 'doubledate',
+                value: dateRange,
+                onChange: (v) => setDateRange(v ?? { startDate: '', endDate: '' }),
+            },
+            {
+                key: 'category_id',
+                label: 'Kategori',
+                type: 'select',
+                value: categoryId,
+                onChange: setCategoryId,
+                options: categoryOptions,
+            },
+            {
+                key: 'group_id',
+                label: 'Hedef Kitle',
+                type: 'multiselect',
+                value: groupIds,
+                onClick: () => setEnabled((e) => ({ ...e, groups: true })),
+                onChange: setGroupIds,
+                options: groupsData.map((g) => ({ value: String(g.id), label: g.name })),
+            },
+            {
+                key: 'sender_id',
+                label: 'Gönderen',
+                type: 'select',
+                value: senderId,
+                onClick: () => setEnabled((e) => ({ ...e, users: true })),
+                onChange: setSenderId,
+                options: usersData.map((u) => ({ value: String(u.id), label: u.name_surname || `${u.first_name} ${u.last_name}` })),
+            },
+            {
+                key: 'status',
+                label: 'Gönderim Durumu',
+                type: 'select',
+                value: status,
+                onChange: setStatus,
+                options: statusOptions,
+            },
+        ],
+        [dateRange, categoryId, groupIds, senderId, status, groupsData, usersData]
+    );
+
+    return (
+        <>
+            <FilterGroup filters={filters} navigate={navigate} />
+            <ReusableTable<NotificationData>
+                tableMode="single"
+                columns={columns}
+                data={notificationsData}
+                loading={loading}
+                error={error}
+                currentPage={page}
+                totalPages={totalPages}
+                totalItems={totalItems}
+                pageSize={pageSize}
+                onPageChange={setPage}
+                onPageSizeChange={(s) => { setPageSize(s); setPage(1); }}
+                exportFileName="sms"
+                showExportButtons
+                onAdd={() => navigate(`${ROOT}/add`)}
+            />
+        </>
+    );
+}

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -91,6 +91,8 @@ const CurrentNewsletterCrud = lazy(() => import("../components/common/contactPan
 const NotificationsTable = lazy(() => import("../components/common/contactPanel/pages/notifications/table"));
 const NotificationAdd = lazy(() => import("../components/common/contactPanel/pages/notifications/add"));
 const NotificationEdit = lazy(() => import("../components/common/contactPanel/pages/notifications/edit"));
+const SmsTable = lazy(() => import("../components/common/contactPanel/pages/sms/table"));
+const SmsCrud = lazy(() => import("../components/common/contactPanel/pages/sms/crud"));
 
 const OverduePaymentDetailPage = lazy(
   () => import("../components/common/overduePayments/detail")
@@ -2280,6 +2282,21 @@ export const Routedata = [
     id: 781,
     path: `${import.meta.env.BASE_URL}contact-panel/notifications/edit/:id`,
     element: <NotificationEdit />,
+  },
+  {
+    id: 782,
+    path: `${import.meta.env.BASE_URL}contact-panel/sms`,
+    element: <SmsTable />,
+  },
+  {
+    id: 783,
+    path: `${import.meta.env.BASE_URL}contact-panel/sms/add`,
+    element: <SmsCrud />,
+  },
+  {
+    id: 784,
+    path: `${import.meta.env.BASE_URL}contact-panel/sms/edit/:id`,
+    element: <SmsCrud />,
   },
 
 


### PR DESCRIPTION
## Summary
- add `SmsTable` with filters and actions
- add `SmsCrud` modal for creating and editing SMS records
- add routing entries for SMS pages

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68555a325a78832cb255fda7f228ed03