### PR TITLE
Add email routes to routing data

### DIFF
--- a/src/components/common/contactPanel/pages/e-mail/crud.tsx
+++ b/src/components/common/contactPanel/pages/e-mail/crud.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { Button } from 'react-bootstrap'
+import { FormikValues } from 'formik'
+
+import ReusableModalForm, { FieldDefinition } from '../../../ReusableModalForm'
+import { useNotificationAdd } from '../../../../hooks/notifications/useAdd'
+import { useNotificationUpdate } from '../../../../hooks/notifications/useUpdate'
+import { useNotificationDetail as useNotificationShow } from '../../../../hooks/notifications/useDetail'
+
+interface FormData extends FormikValues {
+    title: string
+    message: string
+    category_id: string
+    sender_id: string
+    send_date: string
+    send_time: string
+    files: File | null
+    status: string
+    sent_count: string
+    group_id: string
+}
+
+export default function EmailCrud() {
+    const navigate = useNavigate()
+    const { id } = useParams<{ id?: string }>()
+    const mode: 'add' | 'update' = id ? 'update' : 'add'
+
+    const { addNewNotification, status: addStatus, error: addError } = useNotificationAdd()
+    const { updateExistingNotification, status: updStatus, error: updError } = useNotificationUpdate()
+    const { notification, status: detailStatus, error: detailError, getNotification } = useNotificationShow()
+
+    const [initialValues, setInitialValues] = useState<FormData>({
+        title: '',
+        message: '',
+        category_id: '',
+        sender_id: '',
+        send_date: '',
+        send_time: '',
+        files: null,
+        status: '1',
+        sent_count: '0',
+        group_id: '',
+    })
+    const [showGroupModal, setShowGroupModal] = useState(false)
+
+    useEffect(() => {
+        if (mode === 'update' && id) {
+            getNotification(Number(id))
+        }
+    }, [mode, id, getNotification])
+
+    useEffect(() => {
+        if (mode === 'update' && notification) {
+            const [d, t] = (notification.send_time || '').split(' ')
+            setInitialValues({
+                title: notification.title ?? '',
+                message: notification.message ?? '',
+                category_id: String(notification.category_id ?? ''),
+                sender_id: String(notification.sender_id ?? ''),
+                send_date: d ?? '',
+                send_time: t ?? '',
+                files: null,
+                status: String(notification.status ?? '1'),
+                sent_count: '0',
+                group_id: String(notification.group_id ?? ''),
+            })
+        }
+    }, [notification, mode])
+
+    const categoryOptions = [
+        { value: '1', label: 'Ödev' },
+        { value: '2', label: 'Sınav' },
+        { value: '3', label: 'Sistem' },
+        { value: '4', label: 'Duyuru' },
+    ]
+
+    const senderOptions = [
+        { value: '1', label: 'Sistem' },
+        { value: '2', label: 'Yönetici' },
+        { value: '3', label: 'Öğretmen' },
+    ]
+
+    const statusOptions = [
+        { value: '1', label: 'Gönderildi' },
+        { value: '2', label: 'Planlandı' },
+        { value: '3', label: 'Hata' },
+    ]
+
+    const getFields = (values: FormData): FieldDefinition[] => {
+        const base: FieldDefinition[] = [
+            { name: 'title', label: 'Başlık', type: 'text', required: true },
+            { name: 'message', label: 'İçerik', type: 'textarea', required: true },
+            { name: 'category_id', label: 'Kategori', type: 'select', options: categoryOptions, required: true },
+            { name: 'sender_id', label: 'Gönderen', type: 'select', options: senderOptions },
+            { name: 'send_date', label: 'Gönderim Tarihi', type: 'date', required: true },
+            { name: 'send_time', label: 'Gönderim Saati', type: 'time', required: true },
+            { name: 'files', label: 'Ek Dosyalar', type: 'file' },
+        ]
+        if (mode === 'update') {
+            base.push({ name: 'status', label: 'Durum', type: 'select', options: statusOptions })
+            base.push({ name: 'sent_count', label: 'Gönderilen Kişi Sayısı', renderForm: () => <span>{values.sent_count}</span> })
+        }
+        base.push({
+            name: 'group_id',
+            label: 'Hedef Kitle',
+            renderForm: () => (
+                <Button variant="outline-secondary" onClick={() => setShowGroupModal(true)}>
+                    <i className="ti ti-eye" />
+                </Button>
+            ),
+        })
+        return base
+    }
+
+    const handleSubmit = async (values: FormData) => {
+        const payload: any = {
+            title: values.title,
+            message: values.message,
+            category_id: values.category_id ? Number(values.category_id) : undefined,
+            sender_id: values.sender_id ? Number(values.sender_id) : undefined,
+            send_time: `${values.send_date} ${values.send_time}`,
+            group_id: values.group_id ? Number(values.group_id) : undefined,
+            status: mode === 'update' ? Number(values.status) : undefined,
+        }
+        if (mode === 'add') {
+            await addNewNotification(payload)
+        } else if (mode === 'update' && id) {
+            await updateExistingNotification({ notificationId: Number(id), payload })
+        }
+        navigate(`${import.meta.env.BASE_URL}contact-panel/e-mail`)
+    }
+
+    const isLoading =
+        (mode === 'add' && addStatus === 'LOADING') ||
+        (mode === 'update' && (updStatus === 'LOADING' || detailStatus === 'LOADING'))
+    const combinedError = mode === 'add' ? addError : updError || detailError
+
+    return (
+        <ReusableModalForm<FormData>
+            show
+            title={mode === 'add' ? 'E-posta Ekle' : 'E-posta Düzenle'}
+            fields={(values) => getFields(values as FormData)}
+            initialValues={initialValues}
+            onSubmit={handleSubmit}
+            confirmButtonLabel={mode === 'add' ? 'Gönder' : 'Tekrar Gönder'}
+            cancelButtonLabel="Vazgeç"
+            isLoading={isLoading}
+            error={combinedError || undefined}
+            onClose={() => navigate(`${import.meta.env.BASE_URL}contact-panel/e-mail`)}
+            autoGoBackOnModalClose
+            mode="double"
+        />
+    )
+}

--- a/src/components/common/contactPanel/pages/e-mail/table.tsx
+++ b/src/components/common/contactPanel/pages/e-mail/table.tsx
@@ -1,0 +1,186 @@
+import { useState, useMemo } from 'react'
+import { useNavigate } from 'react-router-dom'
+import dayjs from 'dayjs'
+
+import ReusableTable, { ColumnDefinition } from '../../../ReusableTable'
+import FilterGroup, { FilterDefinition } from '../../component/organisms/SearchFilters'
+import { useNotificationsList } from '../../../../hooks/notifications/useList'
+import { useGroupsTable } from '../../../../hooks/group/useList'
+import { useNotificationDelete } from '../../../../hooks/notifications/useDelete'
+import type { NotificationData } from '../../../../../types/notifications/list'
+
+const ROOT = `${import.meta.env.BASE_URL}contact-panel/e-mail`
+
+export default function EmailTable() {
+    const navigate = useNavigate()
+    const [dateRange, setDateRange] = useState<{ startDate: string; endDate: string }>({ startDate: '', endDate: '' })
+    const [category, setCategory] = useState('')
+    const [targetIds, setTargetIds] = useState<string[]>([])
+    const [sender, setSender] = useState('')
+    const [status, setStatus] = useState('')
+    const [page, setPage] = useState(1)
+    const [pageSize, setPageSize] = useState(10)
+    const [enabled, setEnabled] = useState({ groups: false })
+
+    const { groupsData = [] } = useGroupsTable({ enabled: enabled.groups, pageSize: 999 })
+    const { deleteExistingNotification } = useNotificationDelete()
+
+    const { notificationsData = [], loading, error, totalPages, totalItems } = useNotificationsList({
+        page,
+        pageSize,
+        start_date: dateRange.startDate || undefined,
+        end_date: dateRange.endDate || undefined,
+        category_id: category || undefined,
+        group_id: targetIds.join(',') || undefined,
+        sender_id: sender || undefined,
+        status: status || undefined,
+        enabled: true,
+    })
+
+    const categoryOptions = [
+        { value: '1', label: 'Ödev' },
+        { value: '2', label: 'Sınav' },
+        { value: '3', label: 'Sistem' },
+        { value: '4', label: 'Duyuru' },
+    ]
+
+    const senderOptions = [
+        { value: '1', label: 'Sistem' },
+        { value: '2', label: 'Yönetici' },
+        { value: '3', label: 'Öğretmen' },
+    ]
+
+    const statusOptions = [
+        { value: '1', label: 'Gönderildi' },
+        { value: '2', label: 'Planlandı' },
+        { value: '3', label: 'Hata' },
+    ]
+
+    const columns: ColumnDefinition<NotificationData>[] = useMemo(
+        () => [
+            { key: 'title', label: 'Başlık', render: (n) => n.title || '-' },
+            {
+                key: 'send_time',
+                label: 'Gönderim Tarihi',
+                render: (n) => dayjs(n.send_time).format('MM.DD.YYYY - HH:mm'),
+            },
+            {
+                key: 'category',
+                label: 'Kategori',
+                render: (n) => categoryOptions.find((c) => c.value === String(n.category_id))?.label || '-',
+            },
+            {
+                key: 'group',
+                label: 'Hedef Kitle',
+                render: (n) => (
+                    <div className="d-flex align-items-center gap-2">
+                        <span>{(n.group as any)?.name || '-'}</span>
+                        <i className="ti ti-eye" />
+                    </div>
+                ),
+            },
+            {
+                key: 'sender',
+                label: 'Gönderen',
+                render: (n) => (n.sender as any)?.name_surname || '-',
+            },
+            {
+                key: 'status',
+                label: 'Durum',
+                render: (n) => statusOptions.find((s) => s.value === String(n.status))?.label || '-',
+            },
+            {
+                key: 'actions',
+                label: 'İşlemler',
+                render: (row) => (
+                    <div className="d-flex gap-2">
+                        <button
+                            onClick={() => navigate(`${ROOT}/edit/${row.id}`)}
+                            className="btn btn-icon btn-sm btn-info-light rounded-pill"
+                        >
+                            <i className="ti ti-pencil" />
+                        </button>
+                        <button
+                            onClick={() => deleteExistingNotification(row.id)}
+                            className="btn btn-icon btn-sm btn-danger-light rounded-pill"
+                        >
+                            <i className="ti ti-trash" />
+                        </button>
+                    </div>
+                ),
+            },
+        ],
+        [navigate, deleteExistingNotification]
+    )
+
+    const filters: FilterDefinition[] = useMemo(
+        () => [
+            {
+                key: 'dateRange',
+                label: 'Tarih Aralığı',
+                type: 'doubledate',
+                value: dateRange,
+                onChange: (v) => setDateRange(v ?? { startDate: '', endDate: '' }),
+            },
+            {
+                key: 'category_id',
+                label: 'Kategori',
+                type: 'select',
+                value: category,
+                onChange: setCategory,
+                options: categoryOptions,
+            },
+            {
+                key: 'group_id',
+                label: 'Hedef Kitle',
+                type: 'multiselect',
+                value: targetIds,
+                onClick: () => setEnabled((e) => ({ ...e, groups: true })),
+                onChange: setTargetIds,
+                options: groupsData.map((g) => ({ value: String(g.id), label: g.name })),
+            },
+            {
+                key: 'sender_id',
+                label: 'Gönderen',
+                type: 'select',
+                value: sender,
+                onChange: setSender,
+                options: senderOptions,
+            },
+            {
+                key: 'status',
+                label: 'Durum',
+                type: 'select',
+                value: status,
+                onChange: setStatus,
+                options: statusOptions,
+            },
+        ],
+        [dateRange, category, targetIds, sender, status, groupsData]
+    )
+
+    return (
+        <>
+            <FilterGroup filters={filters} navigate={navigate} />
+            <ReusableTable<NotificationData>
+                tableMode="single"
+                columns={columns}
+                data={notificationsData}
+                loading={loading}
+                error={error}
+                currentPage={page}
+                totalPages={totalPages}
+                totalItems={totalItems}
+                pageSize={pageSize}
+                onPageChange={setPage}
+                onPageSizeChange={(s) => {
+                    setPageSize(s)
+                    setPage(1)
+                }}
+                exportFileName="e-mail"
+                showExportButtons
+                onAdd={() => navigate(`${ROOT}/add`)}
+            />
+        </>
+    )
+}

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -93,6 +93,8 @@ const NotificationAdd = lazy(() => import("../components/common/contactPanel/pag
 const NotificationEdit = lazy(() => import("../components/common/contactPanel/pages/notifications/edit"));
 const SmsTable = lazy(() => import("../components/common/contactPanel/pages/sms/table"));
 const SmsCrud = lazy(() => import("../components/common/contactPanel/pages/sms/crud"));
+const EmailTable = lazy(() => import("../components/common/contactPanel/pages/e-mail/table"));
+const EmailCrud = lazy(() => import("../components/common/contactPanel/pages/e-mail/crud"));
 
 const OverduePaymentDetailPage = lazy(
   () => import("../components/common/overduePayments/detail")
@@ -2297,6 +2299,21 @@ export const Routedata = [
     id: 784,
     path: `${import.meta.env.BASE_URL}contact-panel/sms/edit/:id`,
     element: <SmsCrud />,
+  },
+  {
+    id: 785,
+    path: `${import.meta.env.BASE_URL}contact-panel/e-mail`,
+    element: <EmailTable />,
+  },
+  {
+    id: 786,
+    path: `${import.meta.env.BASE_URL}contact-panel/e-mail/add`,
+    element: <EmailCrud />,
+  },
+  {
+    id: 787,
+    path: `${import.meta.env.BASE_URL}contact-panel/e-mail/edit/:id`,
+    element: <EmailCrud />,
   },
 
 


### PR DESCRIPTION
## Summary
- load e-mail components lazily in the router
- register new contact panel e-mail paths

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: TS errors and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6855618ef804832ca38d3ca6d6a05099