### PR TITLE
Update target audience modal

### DIFF
--- a/src/components/common/contactPanel/pages/currentNewsletter/TargetAudienceModal.tsx
+++ b/src/components/common/contactPanel/pages/currentNewsletter/TargetAudienceModal.tsx
@@ -1,114 +1,100 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Modal, Button, Row, Col, Form, ListGroup } from 'react-bootstrap';
+import { Modal, Button, Row, Col, ListGroup, Spinner } from 'react-bootstrap';
 import axios from 'axios';
 
 export interface Program { id: number; name: string }
 export interface Level { id: number; name: string }
 export interface Classroom { id: number; name: string }
-export interface Student { id: number; name: string }
+
+export type AudienceItemType = 'program' | 'level' | 'classroom';
+
+export interface AudienceItem {
+    id: number;
+    name: string;
+    type: AudienceItemType;
+}
 
 interface TargetAudienceModalProps {
     show: boolean;
     onClose: () => void;
-    onSave: (students: Student[]) => void;
+    onSave: (items: AudienceItem[]) => void;
 }
 
 const TargetAudienceModal: React.FC<TargetAudienceModalProps> = ({ show, onClose, onSave }) => {
     const [programs, setPrograms] = useState<Program[]>([]);
     const [levels, setLevels] = useState<Level[]>([]);
     const [classrooms, setClassrooms] = useState<Classroom[]>([]);
-    const [students, setStudents] = useState<Student[]>([]);
 
-    const [selectedProgramId, setSelectedProgramId] = useState<number | ''>('');
-    const [selectedLevelId, setSelectedLevelId] = useState<number | ''>('');
-    const [selectedClassroomId, setSelectedClassroomId] = useState<number | ''>('');
+    const [selectedProgramId, setSelectedProgramId] = useState<number | null>(null);
+    const [selectedLevelId, setSelectedLevelId] = useState<number | null>(null);
+    const [selectedItems, setSelectedItems] = useState<AudienceItem[]>([]);
 
-    const [selectedStudents, setSelectedStudents] = useState<Student[]>([]);
+    const [loading, setLoading] = useState({ programs: false, levels: false, classrooms: false });
 
     const toArray = <T,>(value: unknown): T[] => {
         if (Array.isArray(value)) return value as T[];
-        // some APIs wrap results in a `data` property
         if (value && typeof value === 'object' && Array.isArray((value as any).data)) {
             return (value as any).data as T[];
         }
         return [];
     };
 
-    // Fetch programs when modal opens
     useEffect(() => {
         if (!show) return;
+        setLoading((l) => ({ ...l, programs: true }));
         axios
             .get<Program[]>('/api/programs')
-            .then(res => {
-                setPrograms(toArray<Program>(res.data));
-            })
-            .catch(() => setPrograms([]));
+            .then((res) => setPrograms(toArray<Program>(res.data)))
+            .catch(() => setPrograms([]))
+            .finally(() => setLoading((l) => ({ ...l, programs: false })));
     }, [show]);
 
-    // Fetch levels when program changes
     useEffect(() => {
-        if (selectedProgramId === '') {
+        if (!show || selectedProgramId == null) {
             setLevels([]);
-            setSelectedLevelId('');
+            setSelectedLevelId(null);
             return;
         }
+        setLoading((l) => ({ ...l, levels: true }));
         axios
             .get<Level[]>(`/api/programs/${selectedProgramId}/levels`)
-            .then(res => {
-                setLevels(toArray<Level>(res.data));
-            })
-            .catch(() => setLevels([]));
-    }, [selectedProgramId]);
+            .then((res) => setLevels(toArray<Level>(res.data)))
+            .catch(() => setLevels([]))
+            .finally(() => setLoading((l) => ({ ...l, levels: false })));
+    }, [selectedProgramId, show]);
 
-    // Fetch classrooms when level changes
     useEffect(() => {
-        if (selectedLevelId === '') {
+        if (!show || selectedLevelId == null) {
             setClassrooms([]);
-            setSelectedClassroomId('');
             return;
         }
+        setLoading((l) => ({ ...l, classrooms: true }));
         axios
             .get<Classroom[]>(`/api/levels/${selectedLevelId}/classrooms`)
-            .then(res => {
-                setClassrooms(toArray<Classroom>(res.data));
-            })
-            .catch(() => setClassrooms([]));
-    }, [selectedLevelId]);
+            .then((res) => setClassrooms(toArray<Classroom>(res.data)))
+            .catch(() => setClassrooms([]))
+            .finally(() => setLoading((l) => ({ ...l, classrooms: false })));
+    }, [selectedLevelId, show]);
 
-    // Fetch students when classroom changes
-    useEffect(() => {
-        if (selectedClassroomId === '') {
-            setStudents([]);
-            return;
-        }
-        axios
-            .get<Student[]>(`/api/classrooms/${selectedClassroomId}/students`)
-            .then(res => setStudents(toArray<Student>(res.data)))
-            .catch(() => setStudents([]));
-    }, [selectedClassroomId]);
+    const addItem = useCallback((item: { id: number; name: string }, type: AudienceItemType) => {
+        setSelectedItems((prev) => {
+            if (prev.find((p) => p.id === item.id && p.type === type)) return prev;
+            return [...prev, { ...item, type }];
+        });
+    }, []);
 
-    const addStudent = useCallback(
-        (student: Student) => {
-            setSelectedStudents(prev => {
-                if (prev.find(s => s.id === student.id)) return prev;
-                return [...prev, student];
-            });
-        },
-        []
-    );
-
-    const removeStudent = useCallback((id: number) => {
-        setSelectedStudents(prev => prev.filter(s => s.id !== id));
+    const removeItem = useCallback((id: number, type: AudienceItemType) => {
+        setSelectedItems((prev) => prev.filter((p) => !(p.id === id && p.type === type)));
     }, []);
 
     const handleSave = () => {
-        onSave(selectedStudents);
+        onSave(selectedItems);
         onClose();
     };
 
-    const handleClear = () => {
-        setSelectedStudents([]);
-    };
+    const handleClear = () => setSelectedItems([]);
+
+    const renderLoading = (flag: boolean) => (flag ? <Spinner animation="border" size="sm" className="ms-2" /> : null);
 
     return (
         <Modal show={show} onHide={onClose} size="lg" centered>
@@ -118,61 +104,82 @@ const TargetAudienceModal: React.FC<TargetAudienceModalProps> = ({ show, onClose
             <Modal.Body>
                 <Row>
                     <Col md={6}>
-                        <Form.Select
-                            className="mb-2"
-                            value={selectedProgramId}
-                            onChange={e => setSelectedProgramId(e.target.value ? Number(e.target.value) : '')}
-                        >
-                            <option value="">Okul Türü Seçiniz</option>
-                            {programs.map(p => (
-                                <option key={p.id} value={p.id}>
-                                    {p.name}
-                                </option>
-                            ))}
-                        </Form.Select>
-                        <Form.Select
-                            className="mb-2"
-                            value={selectedLevelId}
-                            onChange={e => setSelectedLevelId(e.target.value ? Number(e.target.value) : '')}
-                            disabled={levels.length === 0}
-                        >
-                            <option value="">Seviye Seçiniz</option>
-                            {levels.map(l => (
-                                <option key={l.id} value={l.id}>
-                                    {l.name}
-                                </option>
-                            ))}
-                        </Form.Select>
-                        <Form.Select
-                            className="mb-2"
-                            value={selectedClassroomId}
-                            onChange={e => setSelectedClassroomId(e.target.value ? Number(e.target.value) : '')}
-                            disabled={classrooms.length === 0}
-                        >
-                            <option value="">Sınıf Seçiniz</option>
-                            {classrooms.map(c => (
-                                <option key={c.id} value={c.id}>
-                                    {c.name}
-                                </option>
-                            ))}
-                        </Form.Select>
-                        <ListGroup>
-                            {students.map(s => (
-                                <ListGroup.Item key={s.id} className="d-flex justify-content-between align-items-center">
-                                    <span>{s.name}</span>
-                                    <Button size="sm" variant="success" onClick={() => addStudent(s)}>
+                        <h6 className="mb-2">Program Seç</h6>
+                        <ListGroup className="mb-3">
+                            {programs.map((p) => (
+                                <ListGroup.Item
+                                    key={p.id}
+                                    className="d-flex justify-content-between align-items-center"
+                                >
+                                    <span
+                                        role="button"
+                                        onClick={() => setSelectedProgramId(p.id)}
+                                        style={{ cursor: 'pointer' }}
+                                    >
+                                        {p.name}
+                                    </span>
+                                    <Button size="sm" variant="success" onClick={() => addItem(p, 'program')}>
                                         +
                                     </Button>
                                 </ListGroup.Item>
                             ))}
+                            {renderLoading(loading.programs)}
                         </ListGroup>
+                        {levels.length > 0 && (
+                            <>
+                                <h6 className="mb-2">Level Seç</h6>
+                                <ListGroup className="mb-3">
+                                    {levels.map((l) => (
+                                        <ListGroup.Item
+                                            key={l.id}
+                                            className="d-flex justify-content-between align-items-center"
+                                        >
+                                            <span
+                                                role="button"
+                                                onClick={() => setSelectedLevelId(l.id)}
+                                                style={{ cursor: 'pointer' }}
+                                            >
+                                                {l.name}
+                                            </span>
+                                            <Button size="sm" variant="success" onClick={() => addItem(l, 'level')}>
+                                                +
+                                            </Button>
+                                        </ListGroup.Item>
+                                    ))}
+                                    {renderLoading(loading.levels)}
+                                </ListGroup>
+                            </>
+                        )}
+                        {classrooms.length > 0 && (
+                            <>
+                                <h6 className="mb-2">Sınıf Seç</h6>
+                                <ListGroup className="mb-3">
+                                    {classrooms.map((c) => (
+                                        <ListGroup.Item
+                                            key={c.id}
+                                            className="d-flex justify-content-between align-items-center"
+                                        >
+                                            <span>{c.name}</span>
+                                            <Button size="sm" variant="success" onClick={() => addItem(c, 'classroom')}>
+                                                +
+                                            </Button>
+                                        </ListGroup.Item>
+                                    ))}
+                                    {renderLoading(loading.classrooms)}
+                                </ListGroup>
+                            </>
+                        )}
                     </Col>
                     <Col md={6}>
+                        <h6 className="mb-2">Eklenenler</h6>
                         <ListGroup>
-                            {selectedStudents.map(s => (
-                                <ListGroup.Item key={s.id} className="d-flex justify-content-between align-items-center">
-                                    <span>{s.name}</span>
-                                    <Button size="sm" variant="danger" onClick={() => removeStudent(s.id)}>
+                            {selectedItems.map((item) => (
+                                <ListGroup.Item
+                                    key={`${item.type}-${item.id}`}
+                                    className="d-flex justify-content-between align-items-center"
+                                >
+                                    <span>{item.name}</span>
+                                    <Button size="sm" variant="danger" onClick={() => removeItem(item.id, item.type)}>
                                         -
                                     </Button>
                                 </ListGroup.Item>

--- a/src/components/common/contactPanel/pages/currentNewsletter/crud.tsx
+++ b/src/components/common/contactPanel/pages/currentNewsletter/crud.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { FormikValues, Field } from 'formik';
 import { Button } from 'react-bootstrap';
-import TargetAudienceModal, { Student } from './TargetAudienceModal';
+import TargetAudienceModal, { AudienceItem } from './TargetAudienceModal';
 
 import ReusableModalForm, { FieldDefinition } from '../../../ReusableModalForm';
 import { useBulletinAdd } from '../../../../hooks/bulletin/useAdd';
@@ -52,7 +52,7 @@ export default function CurrentNewsletterCrud() {
         send_sms_email: false,
     });
     const [showGroupModal, setShowGroupModal] = useState(false);
-    const [selectedStudents, setSelectedStudents] = useState<Student[]>([]);
+    const [selectedAudience, setSelectedAudience] = useState<AudienceItem[]>([]);
 
     useEffect(() => {
         if (mode === 'update' && id) {
@@ -203,8 +203,8 @@ export default function CurrentNewsletterCrud() {
             <TargetAudienceModal
                 show={showGroupModal}
                 onClose={() => setShowGroupModal(false)}
-                onSave={(students) => {
-                    setSelectedStudents(students);
+                onSave={(items) => {
+                    setSelectedAudience(items);
                     setShowGroupModal(false);
                 }}
             />


### PR DESCRIPTION
## Summary
- update TargetAudienceModal to allow selecting programs, levels and classrooms
- adapt crud page to new AudienceItem type

## Testing
- `npm run build` *(fails: missing modules)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68559130d73c832c8940b7421826cef0