### PR TITLE
Rewrite TargetAudienceModal using tree view

### DIFF
--- a/src/components/common/contactPanel/pages/currentNewsletter/TargetAudienceModal.tsx
+++ b/src/components/common/contactPanel/pages/currentNewsletter/TargetAudienceModal.tsx
@@ -1,10 +1,16 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { Modal, Button, Row, Col, ListGroup, Spinner } from 'react-bootstrap';
-import axios from 'axios';
+import { useCallback, useState } from 'react';
+import {
+    Modal,
+    Button,
+    Row,
+    Col,
+    ListGroup,
+    Spinner,
+} from 'react-bootstrap';
 
-export interface Program { id: number; name: string }
-export interface Level { id: number; name: string }
-export interface Classroom { id: number; name: string }
+import { useProgramsTable as useProgramsList } from '../../../../hooks/program/useList';
+import { useLevelsTable as useLevelsList } from '../../../../hooks/levels/useList';
+import { useClassroomList as useClassroomsList } from '../../../../hooks/classrooms/useList';
 
 export type AudienceItemType = 'program' | 'level' | 'classroom';
 
@@ -17,84 +23,66 @@ export interface AudienceItem {
 interface TargetAudienceModalProps {
     show: boolean;
     onClose: () => void;
-    onSave: (items: AudienceItem[]) => void;
+    onSave: (selected: AudienceItem[]) => void;
 }
 
-const TargetAudienceModal: React.FC<TargetAudienceModalProps> = ({ show, onClose, onSave }) => {
-    const [programs, setPrograms] = useState<Program[]>([]);
-    const [levels, setLevels] = useState<Level[]>([]);
-    const [classrooms, setClassrooms] = useState<Classroom[]>([]);
-
-    const [selectedProgramId, setSelectedProgramId] = useState<number | null>(null);
-    const [selectedLevelId, setSelectedLevelId] = useState<number | null>(null);
+const TargetAudienceModal: React.FC<TargetAudienceModalProps> = ({
+    show,
+    onClose,
+    onSave,
+}) => {
+    const [openProgramId, setOpenProgramId] = useState<number | null>(null);
+    const [openLevelId, setOpenLevelId] = useState<number | null>(null);
     const [selectedItems, setSelectedItems] = useState<AudienceItem[]>([]);
 
-    const [loading, setLoading] = useState({ programs: false, levels: false, classrooms: false });
+    const {
+        programsData: programs = [],
+        loading: loadingPrograms,
+    } = useProgramsList({ enabled: show });
 
-    const toArray = <T,>(value: unknown): T[] => {
-        if (Array.isArray(value)) return value as T[];
-        if (value && typeof value === 'object' && Array.isArray((value as any).data)) {
-            return (value as any).data as T[];
-        }
-        return [];
-    };
+    const { levelsData: levels = [], loading: loadingLevels } = useLevelsList({
+        enabled: show && openProgramId !== null,
+        program_id: openProgramId ?? undefined,
+    });
 
-    useEffect(() => {
-        if (!show) return;
-        setLoading((l) => ({ ...l, programs: true }));
-        axios
-            .get<Program[]>('/api/programs')
-            .then((res) => setPrograms(toArray<Program>(res.data)))
-            .catch(() => setPrograms([]))
-            .finally(() => setLoading((l) => ({ ...l, programs: false })));
-    }, [show]);
+    const {
+        classroomData: classrooms = [],
+        loading: loadingClassrooms,
+    } = useClassroomsList({
+        enabled: show && openLevelId !== null,
+        program_id: openProgramId ?? undefined,
+        level_id: openLevelId ?? undefined,
+    });
 
-    useEffect(() => {
-        if (!show || selectedProgramId == null) {
-            setLevels([]);
-            setSelectedLevelId(null);
-            return;
-        }
-        setLoading((l) => ({ ...l, levels: true }));
-        axios
-            .get<Level[]>(`/api/programs/${selectedProgramId}/levels`)
-            .then((res) => setLevels(toArray<Level>(res.data)))
-            .catch(() => setLevels([]))
-            .finally(() => setLoading((l) => ({ ...l, levels: false })));
-    }, [selectedProgramId, show]);
-
-    useEffect(() => {
-        if (!show || selectedLevelId == null) {
-            setClassrooms([]);
-            return;
-        }
-        setLoading((l) => ({ ...l, classrooms: true }));
-        axios
-            .get<Classroom[]>(`/api/levels/${selectedLevelId}/classrooms`)
-            .then((res) => setClassrooms(toArray<Classroom>(res.data)))
-            .catch(() => setClassrooms([]))
-            .finally(() => setLoading((l) => ({ ...l, classrooms: false })));
-    }, [selectedLevelId, show]);
-
-    const addItem = useCallback((item: { id: number; name: string }, type: AudienceItemType) => {
-        setSelectedItems((prev) => {
-            if (prev.find((p) => p.id === item.id && p.type === type)) return prev;
-            return [...prev, { ...item, type }];
-        });
-    }, []);
+    const addItem = useCallback(
+        (type: AudienceItemType, id: number, name: string) => {
+            setSelectedItems((prev) => {
+                if (prev.some((p) => p.id === id && p.type === type)) {
+                    return prev;
+                }
+                return [...prev, { type, id, name }];
+            });
+        },
+        []
+    );
 
     const removeItem = useCallback((id: number, type: AudienceItemType) => {
         setSelectedItems((prev) => prev.filter((p) => !(p.id === id && p.type === type)));
     }, []);
+
+    const handleClear = () => {
+        setSelectedItems([]);
+        setOpenProgramId(null);
+        setOpenLevelId(null);
+    };
 
     const handleSave = () => {
         onSave(selectedItems);
         onClose();
     };
 
-    const handleClear = () => setSelectedItems([]);
-
-    const renderLoading = (flag: boolean) => (flag ? <Spinner animation="border" size="sm" className="ms-2" /> : null);
+    const renderLoading = (flag: boolean) =>
+        flag ? <Spinner animation="border" size="sm" /> : null;
 
     return (
         <Modal show={show} onHide={onClose} size="lg" centered>
@@ -103,75 +91,96 @@ const TargetAudienceModal: React.FC<TargetAudienceModalProps> = ({ show, onClose
             </Modal.Header>
             <Modal.Body>
                 <Row>
-                    <Col md={6}>
-                        <h6 className="mb-2">Program Seç</h6>
-                        <ListGroup className="mb-3">
+                    <Col md={6} className="mb-3">
+                        <style>
+                            {`
+                            .tree ul { padding-left: 1rem; }
+                            .tree li { list-style: none; cursor: pointer; }
+                            `}
+                        </style>
+                        <ul className="tree">
+                            {renderLoading(loadingPrograms)}
                             {programs.map((p) => (
-                                <ListGroup.Item
-                                    key={p.id}
-                                    className="d-flex justify-content-between align-items-center"
-                                >
-                                    <span
-                                        role="button"
-                                        onClick={() => setSelectedProgramId(p.id)}
-                                        style={{ cursor: 'pointer' }}
-                                    >
-                                        {p.name}
-                                    </span>
-                                    <Button size="sm" variant="success" onClick={() => addItem(p, 'program')}>
-                                        +
-                                    </Button>
-                                </ListGroup.Item>
+                                <li key={p.id}>
+                                    <div className="d-flex align-items-center py-1 px-2">
+                                        <i
+                                            className={`bi ${
+                                                openProgramId === p.id
+                                                    ? 'bi-chevron-down'
+                                                    : 'bi-chevron-right'
+                                            } me-1`}
+                                            onClick={() => {
+                                                setOpenProgramId(openProgramId === p.id ? null : p.id);
+                                                setOpenLevelId(null);
+                                            }}
+                                        />
+                                        <span className="flex-grow-1">
+                                            {p.name}
+                                        </span>
+                                        <Button
+                                            size="sm"
+                                            variant="success"
+                                            onClick={() => addItem('program', p.id, p.name)}
+                                        >
+                                            +
+                                        </Button>
+                                    </div>
+                                    {openProgramId === p.id && (
+                                        <ul>
+                                            {renderLoading(loadingLevels)}
+                                            {levels.map((l) => (
+                                                <li key={l.id}>
+                                                    <div className="d-flex align-items-center py-1 px-2">
+                                                        <i
+                                                            className={`bi ${
+                                                                openLevelId === l.id
+                                                                    ? 'bi-chevron-down'
+                                                                    : 'bi-chevron-right'
+                                                            } me-1`}
+                                                            onClick={() => {
+                                                                setOpenLevelId(openLevelId === l.id ? null : l.id);
+                                                            }}
+                                                        />
+                                                        <span className="flex-grow-1">
+                                                            {l.name}
+                                                        </span>
+                                                        <Button
+                                                            size="sm"
+                                                            variant="success"
+                                                            onClick={() => addItem('level', l.id, l.name)}
+                                                        >
+                                                            +
+                                                        </Button>
+                                                    </div>
+                                                    {openLevelId === l.id && (
+                                                        <ul>
+                                                            {renderLoading(loadingClassrooms)}
+                                                            {classrooms.map((c) => (
+                                                                <li key={c.id} className="py-1 px-2 d-flex align-items-center">
+                                                                    <span className="flex-grow-1">
+                                                                        {c.name}
+                                                                    </span>
+                                                                    <Button
+                                                                        size="sm"
+                                                                        variant="success"
+                                                                        onClick={() => addItem('classroom', c.id, c.name)}
+                                                                    >
+                                                                        +
+                                                                    </Button>
+                                                                </li>
+                                                            ))}
+                                                        </ul>
+                                                    )}
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    )}
+                                </li>
                             ))}
-                            {renderLoading(loading.programs)}
-                        </ListGroup>
-                        {levels.length > 0 && (
-                            <>
-                                <h6 className="mb-2">Level Seç</h6>
-                                <ListGroup className="mb-3">
-                                    {levels.map((l) => (
-                                        <ListGroup.Item
-                                            key={l.id}
-                                            className="d-flex justify-content-between align-items-center"
-                                        >
-                                            <span
-                                                role="button"
-                                                onClick={() => setSelectedLevelId(l.id)}
-                                                style={{ cursor: 'pointer' }}
-                                            >
-                                                {l.name}
-                                            </span>
-                                            <Button size="sm" variant="success" onClick={() => addItem(l, 'level')}>
-                                                +
-                                            </Button>
-                                        </ListGroup.Item>
-                                    ))}
-                                    {renderLoading(loading.levels)}
-                                </ListGroup>
-                            </>
-                        )}
-                        {classrooms.length > 0 && (
-                            <>
-                                <h6 className="mb-2">Sınıf Seç</h6>
-                                <ListGroup className="mb-3">
-                                    {classrooms.map((c) => (
-                                        <ListGroup.Item
-                                            key={c.id}
-                                            className="d-flex justify-content-between align-items-center"
-                                        >
-                                            <span>{c.name}</span>
-                                            <Button size="sm" variant="success" onClick={() => addItem(c, 'classroom')}>
-                                                +
-                                            </Button>
-                                        </ListGroup.Item>
-                                    ))}
-                                    {renderLoading(loading.classrooms)}
-                                </ListGroup>
-                            </>
-                        )}
+                        </ul>
                     </Col>
-                    <Col md={6}>
-                        <h6 className="mb-2">Eklenenler</h6>
+                    <Col md={6} className="mb-3">
+                        <h6 className="mb-2">Eklentiler</h6>
                         <ListGroup>
                             {selectedItems.map((item) => (
                                 <ListGroup.Item
@@ -179,7 +188,11 @@ const TargetAudienceModal: React.FC<TargetAudienceModalProps> = ({ show, onClose
                                     className="d-flex justify-content-between align-items-center"
                                 >
                                     <span>{item.name}</span>
-                                    <Button size="sm" variant="danger" onClick={() => removeItem(item.id, item.type)}>
+                                    <Button
+                                        size="sm"
+                                        variant="danger"
+                                        onClick={() => removeItem(item.id, item.type)}
+                                    >
                                         -
                                     </Button>
                                 </ListGroup.Item>
@@ -201,3 +214,4 @@ const TargetAudienceModal: React.FC<TargetAudienceModalProps> = ({ show, onClose
 };
 
 export default TargetAudienceModal;
+


### PR DESCRIPTION
## Summary
- replace Accordion with tree view in TargetAudienceModal
- implement program/level/classroom hierarchy with toggle icons

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68559492efd0832c8cacba832a9c0907