### PR TITLE
Refactor TargetAudienceModal to tree layout

### DIFF
--- a/src/components/common/contactPanel/pages/currentNewsletter/TargetAudienceModal.tsx
+++ b/src/components/common/contactPanel/pages/currentNewsletter/TargetAudienceModal.tsx
@@ -1,19 +1,12 @@
 import { useCallback, useState } from 'react';
-import {
-    Modal,
-    Button,
-    Row,
-    Col,
-    Accordion,
-    ListGroup,
-    Spinner,
-} from 'react-bootstrap';
+import { Modal, Button, Row, Col, ListGroup, Spinner } from 'react-bootstrap';
 
 import { useProgramsTable as useProgramsList } from '../../../../hooks/program/useList';
 import { useLevelsTable as useLevelsList } from '../../../../hooks/levels/useList';
 import { useClassroomList as useClassroomsList } from '../../../../hooks/classrooms/useList';
+import { useListStudents as useStudentsList } from '../../../../hooks/student/useList';
 
-export type AudienceItemType = 'program' | 'level' | 'classroom';
+export type AudienceItemType = 'program' | 'level' | 'classroom' | 'student';
 
 export interface AudienceItem {
     id: number;
@@ -34,15 +27,14 @@ const TargetAudienceModal: React.FC<TargetAudienceModalProps> = ({
 }) => {
     const [selectedProgram, setSelectedProgram] = useState<number | null>(null);
     const [selectedLevel, setSelectedLevel] = useState<number | null>(null);
-    const [selectedItems, setSelectedItems] = useState<AudienceItem[]>([]);
+    const [selectedClass, setSelectedClass] = useState<number | null>(null);
+    const [items, setItems] = useState<AudienceItem[]>([]);
 
-    const {
-        programsData: programs = [],
-        loading: loadingPrograms,
-    } = useProgramsList({ enabled: show });
+    const { programsData: programs = [], loading: loadingPrograms } =
+        useProgramsList({ enabled: show });
 
     const { levelsData: levels = [], loading: loadingLevels } = useLevelsList({
-        enabled: show && selectedProgram !== null,
+        enabled: !!selectedProgram,
         program_id: selectedProgram ?? undefined,
     });
 
@@ -50,35 +42,42 @@ const TargetAudienceModal: React.FC<TargetAudienceModalProps> = ({
         classroomData: classrooms = [],
         loading: loadingClassrooms,
     } = useClassroomsList({
-        enabled: show && selectedLevel !== null,
-        program_id: selectedProgram ?? undefined,
+        enabled: !!selectedLevel,
         level_id: selectedLevel ?? undefined,
+    });
+
+    const { data: students = [], loading: loadingStudents } = useStudentsList({
+        enabled: !!selectedClass,
+        classroom_id: selectedClass ?? undefined,
     });
 
     const addItem = useCallback(
         (type: AudienceItemType, id: number, name: string) => {
-            setSelectedItems((prev) => {
-                if (prev.some((p) => p.id === id && p.type === type)) {
-                    return prev;
-                }
-                return [...prev, { type, id, name }];
-            });
+            setItems((prev) =>
+                prev.some((p) => p.id === id && p.type === type)
+                    ? prev
+                    : [...prev, { type, id, name }]
+            );
         },
         []
     );
 
-    const removeItem = useCallback((id: number, type: AudienceItemType) => {
-        setSelectedItems((prev) => prev.filter((p) => !(p.id === id && p.type === type)));
-    }, []);
+    const removeItem = useCallback(
+        (id: number, type: AudienceItemType) => {
+            setItems((prev) => prev.filter((p) => !(p.id === id && p.type === type)));
+        },
+        []
+    );
 
     const handleClear = () => {
-        setSelectedItems([]);
+        setItems([]);
         setSelectedProgram(null);
         setSelectedLevel(null);
+        setSelectedClass(null);
     };
 
     const handleSave = () => {
-        onSave(selectedItems);
+        onSave(items);
         onClose();
     };
 
@@ -86,123 +85,92 @@ const TargetAudienceModal: React.FC<TargetAudienceModalProps> = ({
         flag ? <Spinner animation="border" size="sm" /> : null;
 
     return (
-        <Modal
-            show={show}
-            onHide={onClose}
-            centered
-            dialogClassName="target-audience-modal"
-        >
+        <Modal show={show} onHide={onClose} centered dialogClassName="target-audience-modal" size="lg">
             <Modal.Header closeButton>
                 <Modal.Title>Hedef Kitle</Modal.Title>
             </Modal.Header>
             <Modal.Body>
                 <Row>
-                    <Col md={6} className="mb-3">
-                        <Accordion
-                            alwaysOpen
-                            className="accordion-customicon1 customized-accordion accordions-items-seperate"
-                        >
-                            <Accordion.Item eventKey="program" className="custom-accordion-primary">
-                                <Accordion.Header>Program</Accordion.Header>
-                                <Accordion.Body>
-                                    {renderLoading(loadingPrograms)}
-                                    <ListGroup className="mb-3">
-                                        {programs.map((p) => (
-                                            <ListGroup.Item
-                                                key={p.id}
-                                                className="d-flex justify-content-between align-items-center"
-                                            >
-                                                <span
-                                                    role="button"
-                                                    onClick={() => setSelectedProgram(p.id)}
-                                                    style={{ cursor: 'pointer' }}
-                                                >
-                                                    {p.name}
-                                                </span>
-                                                <Button
-                                                    size="sm"
-                                                    variant="success"
-                                                    onClick={() => addItem('program', p.id, p.name)}
-                                                >
+                    <Col md={6} style={{ maxHeight: '60vh', overflowY: 'auto' }}>
+                        <div className="tree-section">
+                            <div className="tree-header" onClick={() => setSelectedProgram(null)}>
+                                Program{' '}
+                                <Button size="sm" onClick={() => addItem('program', -1, 'Tümü')}>
+                                    +
+                                </Button>
+                            </div>
+                            {loadingPrograms ? (
+                                <Spinner animation="border" />
+                            ) : (
+                                programs.map((p) => (
+                                    <div key={p.id} className="tree-node" style={{ marginLeft: 0 }}>
+                                        <span onClick={() => setSelectedProgram(p.id)}>{p.name}</span>
+                                        <Button size="sm" variant="success" onClick={() => addItem('program', p.id, p.name)}>
+                                            +
+                                        </Button>
+                                    </div>
+                                ))
+                            )}
+                            {selectedProgram && (
+                                <>
+                                    <div className="tree-header level-header">Seviye</div>
+                                    {loadingLevels ? (
+                                        <Spinner animation="border" />
+                                    ) : (
+                                        levels.map((l) => (
+                                            <div key={l.id} className="tree-node" style={{ marginLeft: 15 }}>
+                                                <span onClick={() => setSelectedLevel(l.id)}>{l.name}</span>
+                                                <Button size="sm" variant="success" onClick={() => addItem('level', l.id, l.name)}>
                                                     +
                                                 </Button>
-                                            </ListGroup.Item>
-                                        ))}
-                                    </ListGroup>
-                                </Accordion.Body>
-                            </Accordion.Item>
-                            {selectedProgram !== null && (
-                                <Accordion.Item eventKey="level" className="custom-accordion-success ms-4">
-                                    <Accordion.Header>Seviye</Accordion.Header>
-                                    <Accordion.Body>
-                                        {renderLoading(loadingLevels)}
-                                        <ListGroup className="mb-3">
-                                            {levels.map((l) => (
-                                                <ListGroup.Item
-                                                    key={l.id}
-                                                    className="d-flex justify-content-between align-items-center"
-                                                >
-                                                    <span
-                                                        role="button"
-                                                        onClick={() => setSelectedLevel(l.id)}
-                                                        style={{ cursor: 'pointer' }}
-                                                    >
-                                                        {l.name}
-                                                    </span>
-                                                    <Button
-                                                        size="sm"
-                                                        variant="success"
-                                                        onClick={() => addItem('level', l.id, l.name)}
-                                                    >
-                                                        +
-                                                    </Button>
-                                                </ListGroup.Item>
-                                            ))}
-                                        </ListGroup>
-                                    </Accordion.Body>
-                                </Accordion.Item>
+                                            </div>
+                                        ))
+                                    )}
+                                </>
                             )}
-                            {selectedLevel !== null && (
-                                <Accordion.Item eventKey="classroom" className="custom-accordion-warning ms-5">
-                                    <Accordion.Header>Sınıf</Accordion.Header>
-                                    <Accordion.Body>
-                                        {renderLoading(loadingClassrooms)}
-                                        <ListGroup>
-                                            {classrooms.map((c) => (
-                                                <ListGroup.Item
-                                                    key={c.id}
-                                                    className="d-flex justify-content-between align-items-center"
-                                                >
-                                                    <span>{c.name}</span>
-                                                    <Button
-                                                        size="sm"
-                                                        variant="success"
-                                                        onClick={() => addItem('classroom', c.id, c.name)}
-                                                    >
-                                                        +
-                                                    </Button>
-                                                </ListGroup.Item>
-                                            ))}
-                                        </ListGroup>
-                                    </Accordion.Body>
-                                </Accordion.Item>
+                            {selectedLevel && (
+                                <>
+                                    <div className="tree-header class-header">Sınıf</div>
+                                    {loadingClassrooms ? (
+                                        <Spinner animation="border" />
+                                    ) : (
+                                        classrooms.map((c) => (
+                                            <div key={c.id} className="tree-node" style={{ marginLeft: 30 }}>
+                                                <span onClick={() => setSelectedClass(c.id)}>{c.name}</span>
+                                                <Button size="sm" variant="success" onClick={() => addItem('classroom', c.id, c.name)}>
+                                                    +
+                                                </Button>
+                                            </div>
+                                        ))
+                                    )}
+                                </>
                             )}
-                        </Accordion>
+                            {selectedClass && (
+                                <>
+                                    <div className="tree-header student-header">Öğrenci</div>
+                                    {loadingStudents ? (
+                                        <Spinner animation="border" />
+                                    ) : (
+                                        students.map((s) => (
+                                            <div key={s.id} className="tree-node" style={{ marginLeft: 45 }}>
+                                                <span>{s.name}</span>
+                                                <Button size="sm" variant="success" onClick={() => addItem('student', s.id, s.name)}>
+                                                    +
+                                                </Button>
+                                            </div>
+                                        ))
+                                    )}
+                                </>
+                            )}
+                        </div>
                     </Col>
-                    <Col md={6} className="mb-3">
-                        <h6 className="mb-2">Eklentiler</h6>
+                    <Col md={6}>
+                        <h6>Eklentiler</h6>
                         <ListGroup>
-                            {selectedItems.map((item) => (
-                                <ListGroup.Item
-                                    key={`${item.type}-${item.id}`}
-                                    className="d-flex justify-content-between align-items-center"
-                                >
-                                    <span>{item.name}</span>
-                                    <Button
-                                        size="sm"
-                                        variant="danger"
-                                        onClick={() => removeItem(item.id, item.type)}
-                                    >
+                            {items.map((item) => (
+                                <ListGroup.Item key={`${item.type}-${item.id}`} className="d-flex justify-content-between">
+                                    {item.name}{' '}
+                                    <Button size="sm" variant="danger" onClick={() => removeItem(item.id, item.type)}>
                                         -
                                     </Button>
                                 </ListGroup.Item>

--- a/src/index.scss
+++ b/src/index.scss
@@ -27,6 +27,19 @@
   --bs-modal-width: 600px;
 }
 
+.tree-section {
+  .tree-header {
+    font-weight: 600;
+    margin-top: 0.5rem;
+  }
+  .tree-node {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 2px 0;
+  }
+}
+
 
 
 


### PR DESCRIPTION
## Summary
- switch `TargetAudienceModal` to tree-style layout instead of accordions
- add optional student level and manage selections
- include basic tree-section styles

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68564a40dc60832ca82012e189c973c4