### PR TITLE
Add custom target audience modal

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -22,30 +22,93 @@
 @import "@simonwep/pickr/dist/themes/monolith.min.css";
 @import "@simonwep/pickr/dist/themes/nano.min.css";
 
-.target-audience-modal .modal-dialog {
-  --bs-modal-width: 500px;
+.ta-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
 }
 
-.tree-section {
-  .tree-header {
-    font-weight: 600;
-    margin-top: 0.5rem;
-  }
-
-  .tree-node {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 2px 0;
-  }
+.ta-modal {
+  background: #fff;
+  width: 600px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  border-radius: 4px;
 }
 
-.target-audience-modal .btn-circle {
+.ta-header {
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid #eee;
+  display: flex;
+  justify-content: space-between;
+}
+
+.ta-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+}
+
+.ta-columns {
+  display: flex;
+  gap: 1rem;
+}
+
+.ta-footer {
+  padding: 0.5rem 1rem;
+  border-top: 1px solid #eee;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.tree-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 2px 0;
+  cursor: pointer;
+}
+
+.tree-header {
+  font-weight: 600;
+  margin-top: 0.5rem;
+}
+
+.btn-circle {
   border-radius: 50%;
   width: 24px;
   height: 24px;
   padding: 0;
+  border: 1px solid #666;
+  background: #fff;
   display: flex;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
+}
+
+.btn-circle:hover {
+  background: #eee;
+}
+
+.indent-1 {
+  margin-left: 1rem;
+}
+
+.indent-2 {
+  margin-left: 2rem;
+}
+
+.indent-3 {
+  margin-left: 3rem;
+}
+
+.indent-4 {
+  margin-left: 4rem;
 }


### PR DESCRIPTION
## Summary
- create new TargetAudienceModal with nested tree hierarchy
- style the modal with custom CSS instead of Bootstrap

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_685650a9bb84832ca22add5fc925e36b