### PR TITLE
Improve TargetAudienceModal styling

### DIFF
--- a/src/components/common/contactPanel/pages/currentNewsletter/TargetAudienceModal.tsx
+++ b/src/components/common/contactPanel/pages/currentNewsletter/TargetAudienceModal.tsx
@@ -1,6 +1,6 @@
 // file: src/components/common/contactPanel/pages/currentNewsletter/TargetAudienceModal.tsx
 import React, { useCallback, useState } from 'react';
-import { Spinner } from 'react-bootstrap';
+import { Modal, Button, Spinner } from 'react-bootstrap';
 import { useProgramsTable as useProgramsList } from '../../../../hooks/program/useList';
 import { useLevelsTable as useLevelsList } from '../../../../hooks/levels/useList';
 import { useClassroomList as useClassroomsList } from '../../../../hooks/classrooms/useList';
@@ -15,32 +15,9 @@ interface TargetAudienceModalProps {
     onSave: (selected: AudienceItem[]) => void;
 }
 
-const overlayStyle: React.CSSProperties = {
-    position: 'fixed', top: 0, left: 0, width: '100%', height: '100%',
-    background: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
-};
-const modalStyle: React.CSSProperties = {
-    background: '#fff', color: '#000', borderRadius: 6, width: '90%', maxWidth: 800,
-    boxShadow: '0 4px 12px rgba(0,0,0,0.15)', display: 'flex', flexDirection: 'column',
-    overflow: 'hidden',
-};
-const headerStyle: React.CSSProperties = {
-    padding: '1rem', borderBottom: '1px solid #eee', display: 'flex', justifyContent: 'space-between', alignItems: 'center'
-};
-const bodyStyle: React.CSSProperties = { padding: '1rem', flex: 1, overflowY: 'auto' };
 const columnsStyle: React.CSSProperties = { display: 'flex' };
 const treeSectionStyle: React.CSSProperties = { flex: 1, borderRight: '1px solid #f0f0f0', paddingRight: '1rem' };
 const selectedSectionStyle: React.CSSProperties = { flex: 1, paddingLeft: '1rem' };
-const footerStyle: React.CSSProperties = {
-    padding: '1rem', borderTop: '1px solid #eee', display: 'flex', justifyContent: 'flex-end'
-};
-const btnCircleStyle: React.CSSProperties = {
-    width: 28, height: 28, borderRadius: '50%', border: 'none',
-    display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
-    cursor: 'pointer', fontSize: '1rem',
-};
-const addBtnStyle: React.CSSProperties = { ...btnCircleStyle, background: '#e6fffb', color: '#13c2c2' };
-const removeBtnStyle: React.CSSProperties = { ...btnCircleStyle, background: '#fff1f0', color: '#f5222d' };
 const treeRowStyle: React.CSSProperties = { display: 'flex', justifyContent: 'space-between', alignItems: 'center', margin: '0.25rem 0' };
 const indent = (level: number): React.CSSProperties => ({ paddingLeft: `${level * 1}rem` });
 
@@ -91,81 +68,88 @@ const TargetAudienceModal: React.FC<TargetAudienceModalProps> = ({ show, onClose
     };
     const save = () => { onSave(selectedItems); onClose(); };
 
-    if (!show) return null;
     return (
-        <div style={overlayStyle} onClick={onClose}>
-            <div style={modalStyle} onClick={e => e.stopPropagation()}>
-                <div style={headerStyle}>
-                    <span>Hedef Kitle</span>
-                    <button style={btnCircleStyle} onClick={onClose}>×</button>
-                </div>
-                <div style={bodyStyle}>
-                    <div style={columnsStyle}>
-                        <div style={treeSectionStyle}>
-                            {lp && <Spinner animation="border" size="sm" />}
-                            {programs.map(p => (
-                                <React.Fragment key={p.id}>
-                                    <div style={{ ...treeRowStyle }}>
-                                        <span onClick={() => toggleProgram(p.id)}>{p.name}</span>
-                                        <button style={addBtnStyle} onClick={() => addItem('program', p.id, p.name)}>＋</button>
-                                    </div>
-                                    {expandedProgram === p.id && (
-                                        <>
-                                            {ll && <div style={{ ...indent(1) }}><Spinner animation="border" size="sm" /></div>}
-                                            {levels.map(l => (
-                                                <React.Fragment key={l.id}>
-                                                    <div style={{ ...treeRowStyle, ...indent(1) }}>
-                                                        <span onClick={() => toggleLevel(l.id)}>{l.name}</span>
-                                                        <button style={addBtnStyle} onClick={() => addItem('level', l.id, l.name)}>＋</button>
-                                                    </div>
-                                                    {expandedLevel === l.id && (
-                                                        <>
-                                                            {lc && <div style={{ ...indent(2) }}><Spinner animation="border" size="sm" /></div>}
-                                                            {classes.map(c => (
-                                                                <React.Fragment key={c.id}>
-                                                                    <div style={{ ...treeRowStyle, ...indent(2) }}>
-                                                                        <span onClick={() => toggleClassroom(c.id)}>{c.name}</span>
-                                                                        <button style={addBtnStyle} onClick={() => addItem('classroom', c.id, c.name)}>＋</button>
-                                                                    </div>
-                                                                    {expandedClassroom === c.id && (
-                                                                        <>
-                                                                            {ls && <div style={{ ...indent(3) }}><Spinner animation="border" size="sm" /></div>}
-                                                                            {students.map((s: any) => (
-                                                                                <div key={s.id} style={{ ...treeRowStyle, ...indent(3) }}>
-                                                                                    <span>{s.first_name} {s.last_name}</span>
-                                                                                    <button style={addBtnStyle} onClick={() => addItem('student', s.id, `${s.first_name} ${s.last_name}`)}>＋</button>
-                                                                                </div>
-                                                                            ))}
-                                                                        </>
-                                                                    )}
-                                                                </React.Fragment>
-                                                            ))}
-                                                        </>
-                                                    )}
-                                                </React.Fragment>
-                                            ))}
-                                        </>
-                                    )}
-                                </React.Fragment>
-                            ))}
-                        </div>
-                        <div style={selectedSectionStyle}>
-                            <h4 style={{ marginBottom: 8 }}>Eklentiler</h4>
-                            {selectedItems.map(it => (
-                                <div key={`${it.type}-${it.id}`} style={treeRowStyle}>
-                                    <span>{it.name}</span>
-                                    <button style={removeBtnStyle} onClick={() => removeItem(it.type, it.id)}>－</button>
+        <Modal show={show} onHide={onClose} size="lg" centered>
+            <Modal.Header closeButton>
+                <Modal.Title>Hedef Kitle</Modal.Title>
+            </Modal.Header>
+            <Modal.Body style={{ maxHeight: '60vh', overflowY: 'auto' }}>
+                <div style={columnsStyle}>
+                    <div style={treeSectionStyle}>
+                        <h5 className="mb-2">Seçilebilir Kişiler</h5>
+                        {lp && <Spinner animation="border" size="sm" />}
+                        {programs.map(p => (
+                            <React.Fragment key={p.id}>
+                                <div style={{ ...treeRowStyle }}>
+                                    <span onClick={() => toggleProgram(p.id)}>{p.name}</span>
+                                    <Button size="sm" variant="light-success" className="rounded-circle" onClick={() => addItem('program', p.id, p.name)}>
+                                        <i className="ti ti-plus" />
+                                    </Button>
                                 </div>
-                            ))}
-                        </div>
+                                {expandedProgram === p.id && (
+                                    <>
+                                        {ll && <div style={{ ...indent(1) }}><Spinner animation="border" size="sm" /></div>}
+                                        {levels.map(l => (
+                                            <React.Fragment key={l.id}>
+                                                <div style={{ ...treeRowStyle, ...indent(1) }}>
+                                                    <span onClick={() => toggleLevel(l.id)}>{l.name}</span>
+                                                    <Button size="sm" variant="light-success" className="rounded-circle" onClick={() => addItem('level', l.id, l.name)}>
+                                                        <i className="ti ti-plus" />
+                                                    </Button>
+                                                </div>
+                                                {expandedLevel === l.id && (
+                                                    <>
+                                                        {lc && <div style={{ ...indent(2) }}><Spinner animation="border" size="sm" /></div>}
+                                                        {classes.map(c => (
+                                                            <React.Fragment key={c.id}>
+                                                                <div style={{ ...treeRowStyle, ...indent(2) }}>
+                                                                    <span onClick={() => toggleClassroom(c.id)}>{c.name}</span>
+                                                                    <Button size="sm" variant="light-success" className="rounded-circle" onClick={() => addItem('classroom', c.id, c.name)}>
+                                                                        <i className="ti ti-plus" />
+                                                                    </Button>
+                                                                </div>
+                                                                {expandedClassroom === c.id && (
+                                                                    <>
+                                                                        {ls && <div style={{ ...indent(3) }}><Spinner animation="border" size="sm" /></div>}
+                                                                        {students.map((s: any) => (
+                                                                            <div key={s.id} style={{ ...treeRowStyle, ...indent(3) }}>
+                                                                                <span>{s.first_name} {s.last_name}</span>
+                                                                                <Button size="sm" variant="light-success" className="rounded-circle" onClick={() => addItem('student', s.id, `${s.first_name} ${s.last_name}`)}>
+                                                                                    <i className="ti ti-plus" />
+                                                                                </Button>
+                                                                            </div>
+                                                                        ))}
+                                                                    </>
+                                                                )}
+                                                            </React.Fragment>
+                                                        ))}
+                                                    </>
+                                                )}
+                                            </React.Fragment>
+                                        ))}
+                                    </>
+                                )}
+                            </React.Fragment>
+                        ))}
+                    </div>
+                    <div style={selectedSectionStyle}>
+                        <h5 className="mb-2">Eklenenler</h5>
+                        {selectedItems.map(it => (
+                            <div key={`${it.type}-${it.id}`} style={treeRowStyle}>
+                                <span>{it.name}</span>
+                                <Button size="sm" variant="light-danger" className="rounded-circle" onClick={() => removeItem(it.type, it.id)}>
+                                    <i className="ti ti-minus" />
+                                </Button>
+                            </div>
+                        ))}
                     </div>
                 </div>
-                <div style={footerStyle}>
-                    <button onClick={clearAll} style={{ marginRight: 8, padding: '6px 12px' }}>Temizle</button>
-                    <button onClick={save} style={{ padding: '6px 12px', background: '#722ed1', color: '#fff', border: 'none' }}>Kaydet</button>
-                </div>
-            </div>
-        </div>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="outline-secondary" onClick={clearAll}>Temizle</Button>
+                <Button variant="primary" onClick={save}>Kaydet</Button>
+            </Modal.Footer>
+        </Modal>
     );
 };
 


### PR DESCRIPTION
## Summary
- convert TargetAudienceModal to use react‑bootstrap `Modal` and `Button`
- add scrolling to modal body and update button styling
- display column headers with `<h5>` elements

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68565937ca90832c938f650d9aaee3bb