### PR TITLE
Revamp TargetAudienceModal UI

### DIFF
--- a/src/components/common/contactPanel/pages/currentNewsletter/TargetAudienceModal.tsx
+++ b/src/components/common/contactPanel/pages/currentNewsletter/TargetAudienceModal.tsx
@@ -16,10 +16,22 @@ interface TargetAudienceModalProps {
 }
 
 const columnsStyle: React.CSSProperties = { display: 'flex' };
-const treeSectionStyle: React.CSSProperties = { flex: 1, borderRight: '1px solid #f0f0f0', paddingRight: '1rem' };
+const treeSectionStyle: React.CSSProperties = {
+    flex: 1,
+    borderRight: '1px solid #f0f0f0',
+    paddingRight: '1rem',
+};
 const selectedSectionStyle: React.CSSProperties = { flex: 1, paddingLeft: '1rem' };
-const treeRowStyle: React.CSSProperties = { display: 'flex', justifyContent: 'space-between', alignItems: 'center', margin: '0.25rem 0' };
-const indent = (level: number): React.CSSProperties => ({ paddingLeft: `${level * 1}rem` });
+const rowStyle: React.CSSProperties = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    margin: '0.25rem 0',
+};
+const indent = (level: number): React.CSSProperties => ({
+    paddingLeft: `${level}rem`,
+    borderLeft: '2px solid #6c757d',
+});
 
 const TargetAudienceModal: React.FC<TargetAudienceModalProps> = ({ show, onClose, onSave }) => {
     const [expandedProgram, setExpandedProgram] = useState<number | null>(null);
@@ -60,63 +72,113 @@ const TargetAudienceModal: React.FC<TargetAudienceModalProps> = ({ show, onClose
     const removeItem = useCallback((type: AudienceItemType, id: number) => {
         setSelectedItems(prev => prev.filter(x => !(x.id === id && x.type === type)));
     }, []);
+    const isSelected = useCallback(
+        (type: AudienceItemType, id: number) =>
+            selectedItems.some(item => item.type === type && item.id === id),
+        [selectedItems]
+    );
     const clearAll = () => {
         setExpandedProgram(null);
         setExpandedLevel(null);
         setExpandedClassroom(null);
         setSelectedItems([]);
     };
-    const save = () => { onSave(selectedItems); onClose(); };
+    const save = () => {
+        onSave(selectedItems);
+        onClose();
+    };
 
     return (
         <Modal show={show} onHide={onClose} size="lg" centered>
-            <Modal.Header closeButton>
-                <Modal.Title>Hedef Kitle</Modal.Title>
+            <Modal.Header closeButton className="bg-white">
+                <Modal.Title className="text-dark">Hedef Kitle</Modal.Title>
             </Modal.Header>
-            <Modal.Body style={{ maxHeight: '60vh', overflowY: 'auto' }}>
+            <Modal.Body style={{ maxHeight: '60vh', overflowY: 'auto' }} className="bg-white">
                 <div style={columnsStyle}>
                     <div style={treeSectionStyle}>
-                        <h5 className="mb-2">Seçilebilir Kişiler</h5>
-                        {lp && <Spinner animation="border" size="sm" />}
+                        <h5 className="mb-3 text-dark fw-bold">Seçilebilir Kişiler</h5>
+                        {lp && <Spinner size="sm" />}
                         {programs.map(p => (
                             <React.Fragment key={p.id}>
-                                <div style={{ ...treeRowStyle }}>
-                                    <span onClick={() => toggleProgram(p.id)}>{p.name}</span>
-                                    <Button size="sm" variant="light-success" className="rounded-circle" onClick={() => addItem('program', p.id, p.name)}>
-                                        <i className="ti ti-plus" />
-                                    </Button>
+                                <div style={{ ...rowStyle, ...indent(0) }}>
+                                    <span
+                                        onClick={() => toggleProgram(p.id)}
+                                        className="text-dark link-offset-2 link-underline link-underline-opacity-0-hover"
+                                        style={{ cursor: 'pointer' }}
+                                    >
+                                        {p.name}
+                                    </span>
+                                    {isSelected('program', p.id) ? (
+                                        <Button size="sm" variant="light-danger" className="btn-icon rounded-circle" onClick={() => removeItem('program', p.id)}>
+                                            <i className="ti ti-minus" />
+                                        </Button>
+                                    ) : (
+                                        <Button size="sm" variant="light-success" className="btn-icon rounded-circle" onClick={() => addItem('program', p.id, p.name)}>
+                                            <i className="ti ti-plus" />
+                                        </Button>
+                                    )}
                                 </div>
                                 {expandedProgram === p.id && (
                                     <>
-                                        {ll && <div style={{ ...indent(1) }}><Spinner animation="border" size="sm" /></div>}
+                                        {ll && <div style={{ ...indent(1) }}><Spinner size="sm" /></div>}
                                         {levels.map(l => (
                                             <React.Fragment key={l.id}>
-                                                <div style={{ ...treeRowStyle, ...indent(1) }}>
-                                                    <span onClick={() => toggleLevel(l.id)}>{l.name}</span>
-                                                    <Button size="sm" variant="light-success" className="rounded-circle" onClick={() => addItem('level', l.id, l.name)}>
-                                                        <i className="ti ti-plus" />
-                                                    </Button>
+                                                <div style={{ ...rowStyle, ...indent(1) }}>
+                                                    <span
+                                                        onClick={() => toggleLevel(l.id)}
+                                                        className="text-dark link-offset-2 link-underline link-underline-opacity-0-hover"
+                                                        style={{ cursor: 'pointer' }}
+                                                    >
+                                                        {l.name}
+                                                    </span>
+                                                    {isSelected('level', l.id) ? (
+                                                        <Button size="sm" variant="light-danger" className="btn-icon rounded-circle" onClick={() => removeItem('level', l.id)}>
+                                                            <i className="ti ti-minus" />
+                                                        </Button>
+                                                    ) : (
+                                                        <Button size="sm" variant="light-success" className="btn-icon rounded-circle" onClick={() => addItem('level', l.id, l.name)}>
+                                                            <i className="ti ti-plus" />
+                                                        </Button>
+                                                    )}
                                                 </div>
                                                 {expandedLevel === l.id && (
                                                     <>
-                                                        {lc && <div style={{ ...indent(2) }}><Spinner animation="border" size="sm" /></div>}
+                                                        {lc && <div style={{ ...indent(2) }}><Spinner size="sm" /></div>}
                                                         {classes.map(c => (
                                                             <React.Fragment key={c.id}>
-                                                                <div style={{ ...treeRowStyle, ...indent(2) }}>
-                                                                    <span onClick={() => toggleClassroom(c.id)}>{c.name}</span>
-                                                                    <Button size="sm" variant="light-success" className="rounded-circle" onClick={() => addItem('classroom', c.id, c.name)}>
-                                                                        <i className="ti ti-plus" />
-                                                                    </Button>
+                                                                <div style={{ ...rowStyle, ...indent(2) }}>
+                                                                    <span
+                                                                        onClick={() => toggleClassroom(c.id)}
+                                                                        className="text-dark link-offset-2 link-underline link-underline-opacity-0-hover"
+                                                                        style={{ cursor: 'pointer' }}
+                                                                    >
+                                                                        {c.name}
+                                                                    </span>
+                                                                    {isSelected('classroom', c.id) ? (
+                                                                        <Button size="sm" variant="light-danger" className="btn-icon rounded-circle" onClick={() => removeItem('classroom', c.id)}>
+                                                                            <i className="ti ti-minus" />
+                                                                        </Button>
+                                                                    ) : (
+                                                                        <Button size="sm" variant="light-success" className="btn-icon rounded-circle" onClick={() => addItem('classroom', c.id, c.name)}>
+                                                                            <i className="ti ti-plus" />
+                                                                        </Button>
+                                                                    )}
                                                                 </div>
                                                                 {expandedClassroom === c.id && (
                                                                     <>
-                                                                        {ls && <div style={{ ...indent(3) }}><Spinner animation="border" size="sm" /></div>}
+                                                                        {ls && <div style={{ ...indent(3) }}><Spinner size="sm" /></div>}
                                                                         {students.map((s: any) => (
-                                                                            <div key={s.id} style={{ ...treeRowStyle, ...indent(3) }}>
-                                                                                <span>{s.first_name} {s.last_name}</span>
-                                                                                <Button size="sm" variant="light-success" className="rounded-circle" onClick={() => addItem('student', s.id, `${s.first_name} ${s.last_name}`)}>
-                                                                                    <i className="ti ti-plus" />
-                                                                                </Button>
+                                                                            <div key={s.id} style={{ ...rowStyle, ...indent(3) }}>
+                                                                                <span className="text-dark">{s.first_name} {s.last_name}</span>
+                                                                                {isSelected('student', s.id) ? (
+                                                                                    <Button size="sm" variant="light-danger" className="btn-icon rounded-circle" onClick={() => removeItem('student', s.id)}>
+                                                                                        <i className="ti ti-minus" />
+                                                                                    </Button>
+                                                                                ) : (
+                                                                                    <Button size="sm" variant="light-success" className="btn-icon rounded-circle" onClick={() => addItem('student', s.id, `${s.first_name} ${s.last_name}`)}>
+                                                                                        <i className="ti ti-plus" />
+                                                                                    </Button>
+                                                                                )}
                                                                             </div>
                                                                         ))}
                                                                     </>
@@ -133,11 +195,11 @@ const TargetAudienceModal: React.FC<TargetAudienceModalProps> = ({ show, onClose
                         ))}
                     </div>
                     <div style={selectedSectionStyle}>
-                        <h5 className="mb-2">Eklenenler</h5>
+                        <h5 className="mb-3 text-dark fw-bold">Eklenenler</h5>
                         {selectedItems.map(it => (
-                            <div key={`${it.type}-${it.id}`} style={treeRowStyle}>
-                                <span>{it.name}</span>
-                                <Button size="sm" variant="light-danger" className="rounded-circle" onClick={() => removeItem(it.type, it.id)}>
+                            <div key={`${it.type}-${it.id}`} style={rowStyle}>
+                                <span className="text-dark">{it.name}</span>
+                                <Button size="sm" variant="light-danger" className="btn-icon rounded-circle" onClick={() => removeItem(it.type, it.id)}>
                                     <i className="ti ti-minus" />
                                 </Button>
                             </div>
@@ -145,7 +207,7 @@ const TargetAudienceModal: React.FC<TargetAudienceModalProps> = ({ show, onClose
                     </div>
                 </div>
             </Modal.Body>
-            <Modal.Footer>
+            <Modal.Footer className="bg-white">
                 <Button variant="outline-secondary" onClick={clearAll}>Temizle</Button>
                 <Button variant="primary" onClick={save}>Kaydet</Button>
             </Modal.Footer>


### PR DESCRIPTION
## Summary
- rework TargetAudienceModal to match new staircase layout
- support nested lists with add/remove buttons and spinners

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68566a25dffc832c8b94557efed5b1fb