### PR TITLE
Delay groups API fetch

### DIFF
--- a/src/components/common/contactPanel/pages/currentNewsletter/table.tsx
+++ b/src/components/common/contactPanel/pages/currentNewsletter/table.tsx
@@ -19,7 +19,8 @@ export default function CurrentNewsletterTable() {
     const [page, setPage] = useState(1);
     const [paginate, setPaginate] = useState(10);
 
-    const { groupsData = [] } = useGroupsTable({ enabled: true, pageSize: 999 });
+    const [groupsEnabled, setGroupsEnabled] = useState(false);
+    const { groupsData = [] } = useGroupsTable({ enabled: groupsEnabled, pageSize: 999 });
 
     const groupMap = useMemo(() => {
         const map: Record<number, string> = {};
@@ -116,6 +117,7 @@ export default function CurrentNewsletterTable() {
                 label: 'Hedef Kitle',
                 type: 'select',
                 value: groupId,
+                onClick: () => setGroupsEnabled(true),
                 onChange: setGroupId,
                 options: groupsData.map((g) => ({ value: String(g.id), label: g.name })),
             },

--- a/src/components/common/contactPanel/pages/e-mail/table.tsx
+++ b/src/components/common/contactPanel/pages/e-mail/table.tsx
@@ -21,7 +21,8 @@ export default function EmailTable() {
     const [page, setPage] = useState(1)
     const [pageSize, setPageSize] = useState(10)
 
-    const { groupsData = [] } = useGroupsTable({ enabled: true, pageSize: 999 })
+    const [groupsEnabled, setGroupsEnabled] = useState(false)
+    const { groupsData = [] } = useGroupsTable({ enabled: groupsEnabled, pageSize: 999 })
     const groupMap = useMemo(() => {
         const map: Record<number, string> = {}
         groupsData.forEach((g) => {
@@ -146,6 +147,7 @@ export default function EmailTable() {
                 label: 'Hedef Kitle',
                 type: 'select',
                 value: groupId,
+                onClick: () => setGroupsEnabled(true),
                 onChange: setGroupId,
                 options: groupsData.map((g) => ({ value: String(g.id), label: g.name })),
             },

--- a/src/components/common/contactPanel/pages/notifications/table.tsx
+++ b/src/components/common/contactPanel/pages/notifications/table.tsx
@@ -20,7 +20,8 @@ export default function NotificationsTable() {
     const [senderId, setSenderId] = useState('');
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(10);
-    const { groupsData = [] } = useGroupsTable({ enabled: true, pageSize: 999 });
+    const [groupsEnabled, setGroupsEnabled] = useState(false);
+    const { groupsData = [] } = useGroupsTable({ enabled: groupsEnabled, pageSize: 999 });
     const groupMap = useMemo(() => {
         const map: Record<number, string> = {};
         groupsData.forEach((g) => {
@@ -137,6 +138,7 @@ export default function NotificationsTable() {
                 label: 'Hedef Kitle',
                 type: 'select',
                 value: groupId,
+                onClick: () => setGroupsEnabled(true),
                 onChange: setGroupId,
                 options: groupsData.map((g) => ({ value: String(g.id), label: g.name })),
             },

--- a/src/components/common/contactPanel/pages/sms/table.tsx
+++ b/src/components/common/contactPanel/pages/sms/table.tsx
@@ -20,7 +20,8 @@ export default function SmsTable() {
     const [status, setStatus] = useState('');
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(10);
-    const { groupsData = [] } = useGroupsTable({ enabled: true, pageSize: 999 });
+    const [groupsEnabled, setGroupsEnabled] = useState(false);
+    const { groupsData = [] } = useGroupsTable({ enabled: groupsEnabled, pageSize: 999 });
     const groupMap = useMemo(() => {
         const map: Record<number, string> = {};
         groupsData.forEach((g) => {
@@ -138,6 +139,7 @@ export default function SmsTable() {
                 label: 'Hedef Kitle',
                 type: 'select',
                 value: groupId,
+                onClick: () => setGroupsEnabled(true),
                 onChange: setGroupId,
                 options: groupsData.map((g) => ({ value: String(g.id), label: g.name })),
             },


### PR DESCRIPTION
## Summary
- prevent immediate groups fetch in contactPanel tables

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68569a6ca7e0832cb1ab96ad37a9e19d