### PR TITLE
Add static sender filter options

### DIFF
--- a/src/components/common/contactPanel/pages/notifications/table.tsx
+++ b/src/components/common/contactPanel/pages/notifications/table.tsx
@@ -56,6 +56,12 @@ export default function NotificationsTable() {
         { value: '2', label: 'Manuel' },
     ];
 
+    const senderOptions = [
+        { value: '1', label: 'Sistem' },
+        { value: '2', label: 'Yönetici' },
+        { value: '3', label: 'Öğretmen' },
+    ];
+
     const columns: ColumnDefinition<NotificationData>[] = useMemo(
         () => [
             { key: 'title', label: 'Başlık', render: (n) => n.title || '-' },
@@ -156,16 +162,10 @@ export default function NotificationsTable() {
                 type: 'select',
                 value: senderId,
                 onChange: setSenderId,
-                options: Array.from(
-                    new Map(
-                        notificationsData
-                            .filter((n) => n.sender && n.sender_id != null)
-                            .map((n) => [n.sender_id, { value: String(n.sender_id), label: n.sender.name_surname }])
-                    ).values()
-                ),
+                options: senderOptions,
             },
         ],
-        [dateRange, categoryId, groupId, sourceId, senderId, notificationsData, groupsData, groupMap]
+        [dateRange, categoryId, groupId, sourceId, senderId, groupsData, groupMap]
     );
 
     return (

--- a/src/components/common/contactPanel/pages/sms/table.tsx
+++ b/src/components/common/contactPanel/pages/sms/table.tsx
@@ -57,6 +57,12 @@ export default function SmsTable() {
         { value: '3', label: 'Hata' },
     ];
 
+    const senderOptions = [
+        { value: '1', label: 'Sistem' },
+        { value: '2', label: 'Yönetici' },
+        { value: '3', label: 'Öğretmen' },
+    ];
+
     const columns: ColumnDefinition<NotificationData>[] = useMemo(
         () => [
             { key: 'title', label: 'Başlık', render: (n) => n.title || '-' },
@@ -149,13 +155,7 @@ export default function SmsTable() {
                 type: 'select',
                 value: senderId,
                 onChange: setSenderId,
-                options: Array.from(
-                    new Map(
-                        notificationsData
-                            .filter((n) => n.sender && n.sender_id != null)
-                            .map((n) => [n.sender_id, { value: String(n.sender_id), label: n.sender.name_surname }])
-                    ).values()
-                ),
+                options: senderOptions,
             },
             {
                 key: 'status',
@@ -166,7 +166,7 @@ export default function SmsTable() {
                 options: statusOptions,
             },
         ],
-        [dateRange, categoryId, groupId, senderId, status, notificationsData, groupsData, groupMap]
+        [dateRange, categoryId, groupId, senderId, status, groupsData, groupMap]
     );
 
     return (


### PR DESCRIPTION
## Summary
- add constant sender dropdown options in notification and SMS tables
- use these options in filter definitions

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: multiple TypeScript and module errors)*

------
https://chatgpt.com/codex/tasks/task_e_6858f3c78804832ca40e59ac4e134495