### PR TITLE
Fix end date validation when creating bulletin

### DIFF
--- a/src/components/common/contactPanel/pages/currentNewsletter/crud.tsx
+++ b/src/components/common/contactPanel/pages/currentNewsletter/crud.tsx
@@ -184,12 +184,16 @@ export default function CurrentNewsletterCrud() {
                 : null;
 
     const handleSubmit = async (values: FormData) => {
+        const payload = {
+            ...(values as any),
+            end_date: values.end_date || values.start_date,
+        };
         if (mode === 'add') {
-            await addNewBulletin({ ...(values as any) });
+            await addNewBulletin(payload);
         } else if (mode === 'update' && id) {
             await updateExistingBulletin({
                 bulletinId: Number(id),
-                payload: { ...(values as any) },
+                payload,
             });
         }
         navigate(`${import.meta.env.BASE_URL}contact-panel/current-newsletter`);


### PR DESCRIPTION
## Summary
- prevent API error by ensuring bulletin end date defaults to start date if left blank

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6858fd01cbbc832c9bf2119a270acea9