### PR TITLE
Update notification forms to use sender API

### DIFF
--- a/src/components/common/contactPanel/pages/notifications/add.tsx
+++ b/src/components/common/contactPanel/pages/notifications/add.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { FormikValues } from 'formik';
 import ReusableModalForm, { FieldDefinition } from '../../../ReusableModalForm';
 import { useNotificationAdd } from '../../../../hooks/notifications/useAdd';
-import { useUsersTable } from '../../../../hooks/user/useList';
+import { useNotificationsList } from '../../../../hooks/notifications/useList';
 import { Button } from 'react-bootstrap';
 import TargetAudienceModal, { AudienceItem } from './TargetAudienceModal';
 
@@ -21,8 +21,11 @@ interface FormData extends FormikValues {
 export default function NotificationAdd() {
     const navigate = useNavigate();
     const { addNewNotification, status, error } = useNotificationAdd();
-    const [enabled, setEnabled] = useState({ users: false });
-    const { usersData = [] } = useUsersTable({ enabled: enabled.users, pageSize: 999 });
+    const [enabled, setEnabled] = useState({ notifications: false });
+    const { notificationsData = [] } = useNotificationsList({
+        enabled: enabled.notifications,
+        pageSize: 999,
+    });
     const [showAudienceModal, setShowAudienceModal] = useState(false);
     const [selectedAudience, setSelectedAudience] = useState<AudienceItem[]>([]);
 
@@ -49,7 +52,9 @@ export default function NotificationAdd() {
         { value: '2', label: 'Manuel' },
     ];
 
-    const userOptions = usersData.map((u) => ({ value: String(u.id), label: u.name_surname || `${u.first_name} ${u.last_name}` }));
+    const senderOptions = notificationsData
+        .map((n) => ({ value: String(n.sender_id), label: (n as any).sender?.name_surname || '-' }))
+        .filter((opt, idx, arr) => arr.findIndex((o) => o.value === opt.value) === idx);
 
     const fields: FieldDefinition[] = [
         { name: 'title', label: 'Başlık', type: 'text', required: true },
@@ -60,8 +65,8 @@ export default function NotificationAdd() {
             name: 'sender_id',
             label: 'Gönderen',
             type: 'select',
-            options: userOptions,
-            onClick: () => setEnabled((e) => ({ ...e, users: true })),
+            options: senderOptions,
+            onClick: () => setEnabled((e) => ({ ...e, notifications: true })),
         },
         { name: 'send_time', label: 'Gönderim Zamanı', type: 'date', required: true },
         { name: 'send_sms_email', label: 'SMS/E-posta ile gönderilsin mi?', type: 'checkbox' },

--- a/src/components/common/contactPanel/pages/notifications/edit.tsx
+++ b/src/components/common/contactPanel/pages/notifications/edit.tsx
@@ -5,7 +5,7 @@ import { FormikValues } from 'formik';
 import ReusableModalForm, { FieldDefinition } from '../../../ReusableModalForm';
 import { useNotificationUpdate } from '../../../../hooks/notifications/useUpdate';
 import { useNotificationDetail } from '../../../../hooks/notifications/useDetail';
-import { useUsersTable } from '../../../../hooks/user/useList';
+import { useNotificationsList } from '../../../../hooks/notifications/useList';
 import TargetAudienceModal, { AudienceItem } from './TargetAudienceModal';
 
 interface FormData extends FormikValues {
@@ -25,8 +25,11 @@ export default function NotificationEdit() {
     const { id } = useParams<{ id?: string }>();
     const { notification, getNotification, status: detailStatus, error: detailError } = useNotificationDetail();
     const { updateExistingNotification, status: updStatus, error: updError } = useNotificationUpdate();
-    const [enabled, setEnabled] = useState({ users: false });
-    const { usersData = [] } = useUsersTable({ enabled: enabled.users, pageSize: 999 });
+    const [enabled, setEnabled] = useState({ notifications: false });
+    const { notificationsData = [] } = useNotificationsList({
+        enabled: enabled.notifications,
+        pageSize: 999,
+    });
     const [showAudienceModal, setShowAudienceModal] = useState(false);
     const [selectedAudience, setSelectedAudience] = useState<AudienceItem[]>([]);
 
@@ -82,7 +85,9 @@ export default function NotificationEdit() {
         { value: '3', label: 'Hata' },
     ];
 
-    const userOptions = usersData.map((u) => ({ value: String(u.id), label: u.name_surname || `${u.first_name} ${u.last_name}` }));
+    const senderOptions = notificationsData
+        .map((n) => ({ value: String(n.sender_id), label: (n as any).sender?.name_surname || '-' }))
+        .filter((opt, idx, arr) => arr.findIndex((o) => o.value === opt.value) === idx);
 
     const fields: FieldDefinition[] = [
         { name: 'title', label: 'Başlık', type: 'text', required: true },
@@ -93,8 +98,8 @@ export default function NotificationEdit() {
             name: 'sender_id',
             label: 'Gönderen',
             type: 'select',
-            options: userOptions,
-            onClick: () => setEnabled((e) => ({ ...e, users: true })),
+            options: senderOptions,
+            onClick: () => setEnabled((e) => ({ ...e, notifications: true })),
         },
         { name: 'send_time', label: 'Gönderim Zamanı', type: 'date', required: true },
         { name: 'send_sms_email', label: 'SMS/E-posta ile gönderilsin mi?', type: 'checkbox' },


### PR DESCRIPTION
## Summary
- switch notifications add/edit forms to fetch sender options from notification API instead of users

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_685901c5046c832cb16741ebbb7cbc7e