### PR TITLE
Fix missing sender ID validation

### DIFF
--- a/src/components/common/contactPanel/pages/sms/crud.tsx
+++ b/src/components/common/contactPanel/pages/sms/crud.tsx
@@ -96,6 +96,7 @@ export default function SmsCrud() {
                 label: 'Gönderen',
                 type: 'select',
                 options: userOptions,
+                required: true,
             },
             {
                 name: 'send_option',


### PR DESCRIPTION
## Summary
- make `sender_id` a required field so the API doesn't reject the payload

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68590a065424832c823a2bb29e4ad964