### PR TITLE
Fix send_time when SMS is sent immediately

### DIFF
--- a/src/components/common/contactPanel/pages/sms/crud.tsx
+++ b/src/components/common/contactPanel/pages/sms/crud.tsx
@@ -158,9 +158,12 @@ export default function SmsCrud() {
     };
 
     const handleSubmit = async (values: FormData) => {
-        const payload = { ...(values as any) };
+        const payload: any = { ...(values as any) };
         if (values.send_option === 'schedule') {
             payload.send_time = `${values.send_date} ${values.send_time}`;
+        } else {
+            delete payload.send_time;
+            delete payload.send_date;
         }
         if (mode === 'add') {
             await addNewNotification(payload as any);


### PR DESCRIPTION
## Summary
- fix `send_time` validation when scheduling SMS

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68590eee1d34832cb712a91dd32fca00