### PR TITLE
Fix contact panel redirect

### DIFF
--- a/src/components/common/contactPanel/index.tsx
+++ b/src/components/common/contactPanel/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import Pageheader from '../../page-header/pageheader';
 import TabsContainer from './component/organisms/TabsContainer';
+import { useSearchParams } from 'react-router-dom';
 
 import CurrentNewsletterTable from './pages/currentNewsletter/table';
 import NotificationsTable from './pages/notifications/table';
@@ -8,11 +9,12 @@ import SmsTable from './pages/sms/table';
 import EmailTable from './pages/e-mail/table';
 
 const ContactPanelIndex: React.FC = () => {
-    const [activeIdx, setActiveIdx] = useState<number>(0);
+    const [searchParams, setSearchParams] = useSearchParams();
 
     const tabs = [
         {
             label: 'G\u00fcncel B\u00fclten',
+            path: 'current-newsletter',
             content: <CurrentNewsletterTable />,
             activeBgColor: '#5C67F7',
             activeTextColor: '#FFFFFF',
@@ -21,6 +23,7 @@ const ContactPanelIndex: React.FC = () => {
         },
         {
             label: 'Bildirimler',
+            path: 'notifications',
             content: <NotificationsTable />,
             activeBgColor: '#5C67F7',
             activeTextColor: '#FFFFFF',
@@ -29,6 +32,7 @@ const ContactPanelIndex: React.FC = () => {
         },
         {
             label: 'SMS',
+            path: 'sms',
             content: <SmsTable />,
             activeBgColor: '#5C67F7',
             activeTextColor: '#FFFFFF',
@@ -37,6 +41,7 @@ const ContactPanelIndex: React.FC = () => {
         },
         {
             label: 'E-Posta',
+            path: 'e-mail',
             content: <EmailTable />,
             activeBgColor: '#5C67F7',
             activeTextColor: '#FFFFFF',
@@ -44,6 +49,15 @@ const ContactPanelIndex: React.FC = () => {
             passiveTextColor: '#5C67F7',
         },
     ];
+
+    const initialTab = searchParams.get('tab');
+    const initialIdx = tabs.findIndex((t) => t.path === initialTab);
+    const [activeIdx, setActiveIdx] = useState<number>(initialIdx >= 0 ? initialIdx : 0);
+
+    const handleTabChange = (parentIdx: number) => {
+        setActiveIdx(parentIdx);
+        setSearchParams({ tab: tabs[parentIdx].path });
+    };
 
     return (
         <div>
@@ -53,7 +67,7 @@ const ContactPanelIndex: React.FC = () => {
             />
             <TabsContainer
                 tabs={tabs}
-                onTabChange={(parentIdx) => setActiveIdx(parentIdx)}
+                onTabChange={(parentIdx) => handleTabChange(parentIdx)}
             />
         </div>
     );

--- a/src/components/common/contactPanel/pages/currentNewsletter/crud.tsx
+++ b/src/components/common/contactPanel/pages/currentNewsletter/crud.tsx
@@ -196,7 +196,7 @@ export default function CurrentNewsletterCrud() {
                 payload,
             });
         }
-        navigate(`${import.meta.env.BASE_URL}contact-panel`);
+        navigate(`${import.meta.env.BASE_URL}contact-panel?tab=current-newsletter`);
     };
 
     return (
@@ -211,7 +211,7 @@ export default function CurrentNewsletterCrud() {
                 cancelButtonLabel="Vazgeç"
                 isLoading={isLoading}
                 error={combinedError || undefined}
-                onClose={() => navigate(`${import.meta.env.BASE_URL}contact-panel`)}
+                onClose={() => navigate(`${import.meta.env.BASE_URL}contact-panel?tab=current-newsletter`)}
                 autoGoBackOnModalClose
                 mode="double"
             />

--- a/src/components/common/contactPanel/pages/e-mail/crud.tsx
+++ b/src/components/common/contactPanel/pages/e-mail/crud.tsx
@@ -135,7 +135,7 @@ export default function EmailCrud() {
         } else if (mode === 'update' && id) {
             await updateExistingNotification({ notificationId: Number(id), payload })
         }
-        navigate(`${import.meta.env.BASE_URL}contact-panel/e-mail`)
+        navigate(`${import.meta.env.BASE_URL}contact-panel?tab=e-mail`)
     }
 
     const isLoading =
@@ -155,7 +155,7 @@ export default function EmailCrud() {
                 cancelButtonLabel="Vazgeç"
                 isLoading={isLoading}
                 error={combinedError || undefined}
-                onClose={() => navigate(`${import.meta.env.BASE_URL}contact-panel/e-mail`)}
+                onClose={() => navigate(`${import.meta.env.BASE_URL}contact-panel?tab=e-mail`)}
                 autoGoBackOnModalClose
                 mode="double"
             />

--- a/src/components/common/contactPanel/pages/notifications/add.tsx
+++ b/src/components/common/contactPanel/pages/notifications/add.tsx
@@ -95,7 +95,7 @@ export default function NotificationAdd() {
             send_time: `${values.send_date} ${values.send_time}`,
             group_ids: selectedAudience.map((a) => a.id),
         });
-        navigate(`${import.meta.env.BASE_URL}contact-panel/notifications`);
+        navigate(`${import.meta.env.BASE_URL}contact-panel?tab=notifications`);
     };
 
     const isLoading = status === 'LOADING';
@@ -114,7 +114,7 @@ export default function NotificationAdd() {
                 cancelButtonLabel="Vazgeç"
                 isLoading={isLoading}
                 error={error || undefined}
-                onClose={() => navigate(`${import.meta.env.BASE_URL}contact-panel/notifications`)}
+                onClose={() => navigate(`${import.meta.env.BASE_URL}contact-panel?tab=notifications`)}
                 autoGoBackOnModalClose
                 mode="double"
             />

--- a/src/components/common/contactPanel/pages/notifications/edit.tsx
+++ b/src/components/common/contactPanel/pages/notifications/edit.tsx
@@ -145,7 +145,7 @@ export default function NotificationEdit() {
                 },
             });
         }
-        navigate(`${import.meta.env.BASE_URL}contact-panel/notifications`);
+        navigate(`${import.meta.env.BASE_URL}contact-panel?tab=notifications`);
     };
 
     const isLoading = updStatus === 'LOADING' || detailStatus === 'LOADING';
@@ -163,7 +163,7 @@ export default function NotificationEdit() {
                 cancelButtonLabel="Vazgeç"
                 isLoading={isLoading}
                 error={combinedError || undefined}
-                onClose={() => navigate(`${import.meta.env.BASE_URL}contact-panel/notifications`)}
+                onClose={() => navigate(`${import.meta.env.BASE_URL}contact-panel?tab=notifications`)}
                 autoGoBackOnModalClose
                 mode="double"
             />

--- a/src/components/common/contactPanel/pages/sms/crud.tsx
+++ b/src/components/common/contactPanel/pages/sms/crud.tsx
@@ -170,7 +170,7 @@ export default function SmsCrud() {
         } else if (mode === 'edit' && id) {
             await updateExistingNotification({ notificationId: Number(id), payload: payload as any });
         }
-        navigate(`${import.meta.env.BASE_URL}contact-panel`);
+        navigate(`${import.meta.env.BASE_URL}contact-panel?tab=sms`);
     };
 
     const isLoading =
@@ -190,7 +190,7 @@ export default function SmsCrud() {
                 cancelButtonLabel="Vazgeç"
                 isLoading={isLoading}
                 error={combinedError || undefined}
-                onClose={() => navigate(`${import.meta.env.BASE_URL}contact-panel/sms`)}
+                onClose={() => navigate(`${import.meta.env.BASE_URL}contact-panel?tab=sms`)}
                 autoGoBackOnModalClose
                 mode="double"
             />


### PR DESCRIPTION
## Summary
- preserve selected tab on contact panel via query param
- navigate back to correct tab after submitting modals

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6859137be26c832cb250afcfcc44f372