### PR TITLE
Split send time fields in notification forms

### DIFF
--- a/src/components/common/contactPanel/pages/notifications/add.tsx
+++ b/src/components/common/contactPanel/pages/notifications/add.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { FormikValues, Field } from 'formik';
+import { FormikValues } from 'formik';
 import ReusableModalForm, { FieldDefinition } from '../../../ReusableModalForm';
 import { useNotificationAdd } from '../../../../hooks/notifications/useAdd';
 import { useNotificationsList } from '../../../../hooks/notifications/useList';
@@ -13,6 +13,7 @@ interface FormData extends FormikValues {
     category_id: string;
     source_id: string;
     sender_id: string;
+    send_date: string;
     send_time: string;
     send_sms_email?: boolean;
     group_ids: string[];
@@ -35,6 +36,7 @@ export default function NotificationAdd() {
         category_id: '',
         source_id: '',
         sender_id: '',
+        send_date: '',
         send_time: '',
         send_sms_email: false,
         group_ids: [],
@@ -68,23 +70,8 @@ export default function NotificationAdd() {
             options: senderOptions,
             onClick: () => setEnabled((e) => ({ ...e, notifications: true })),
         },
-        {
-            name: 'send_time',
-            label: 'Gönderim Zamanı',
-            required: true,
-            renderForm: () => (
-                <Field name="send_time">
-                    {({ field, form }: { field: any; form: any }) => (
-                        <input
-                            type="datetime-local"
-                            className="form-control"
-                            value={field.value || ''}
-                            onChange={(e) => form.setFieldValue('send_time', e.target.value)}
-                        />
-                    )}
-                </Field>
-            ),
-        },
+        { name: 'send_date', label: 'Gönderim Tarihi', type: 'date', required: true },
+        { name: 'send_time', label: 'Gönderim Saati', type: 'time', required: true },
         { name: 'send_sms_email', label: 'SMS/E-posta ile gönderilsin mi?', type: 'checkbox' },
         {
             name: 'group_ids',
@@ -105,10 +92,10 @@ export default function NotificationAdd() {
     const handleSubmit = async (values: FormData) => {
         await addNewNotification({
             ...(values as any),
-            send_time: values.send_time,
+            send_time: `${values.send_date} ${values.send_time}`,
             group_ids: selectedAudience.map((a) => a.id),
         });
-        navigate(`${import.meta.env.BASE_URL}contact-panel?tab=notifications`);
+        navigate(`${import.meta.env.BASE_URL}contact-panel/notifications`);
     };
 
     const isLoading = status === 'LOADING';
@@ -127,7 +114,7 @@ export default function NotificationAdd() {
                 cancelButtonLabel="Vazgeç"
                 isLoading={isLoading}
                 error={error || undefined}
-                onClose={() => navigate(`${import.meta.env.BASE_URL}contact-panel?tab=notifications`)}
+                onClose={() => navigate(`${import.meta.env.BASE_URL}contact-panel/notifications`)}
                 autoGoBackOnModalClose
                 mode="double"
             />

--- a/src/components/common/contactPanel/pages/notifications/edit.tsx
+++ b/src/components/common/contactPanel/pages/notifications/edit.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Button } from 'react-bootstrap';
-import { FormikValues, Field } from 'formik';
+import { FormikValues } from 'formik';
 import ReusableModalForm, { FieldDefinition } from '../../../ReusableModalForm';
 import { useNotificationUpdate } from '../../../../hooks/notifications/useUpdate';
 import { useNotificationDetail } from '../../../../hooks/notifications/useDetail';
@@ -14,6 +14,7 @@ interface FormData extends FormikValues {
     category_id: string;
     source_id: string;
     sender_id: string;
+    send_date: string;
     send_time: string;
     send_sms_email?: boolean;
     status: string;
@@ -40,6 +41,7 @@ export default function NotificationEdit() {
         category_id: '',
         source_id: '',
         sender_id: '',
+        send_date: '',
         send_time: '',
         send_sms_email: false,
         status: '1',
@@ -55,14 +57,15 @@ export default function NotificationEdit() {
 
     useEffect(() => {
         if (notification) {
-            const dt = (notification.send_time || '').replace(' ', 'T');
+            const [d, t] = (notification.send_time || '').split(' ');
             setInitialValues({
                 title: notification.title ?? '',
                 message: notification.message ?? '',
                 category_id: String(notification.category_id ?? ''),
                 source_id: String(notification.source_id ?? ''),
                 sender_id: String(notification.sender_id ?? ''),
-                send_time: dt ?? '',
+                send_date: d ?? '',
+                send_time: t ?? '',
                 send_sms_email: false,
                 status: String(notification.status ?? '1'),
                 group_ids: [],
@@ -105,23 +108,8 @@ export default function NotificationEdit() {
             options: senderOptions,
             onClick: () => setEnabled((e) => ({ ...e, notifications: true })),
         },
-        {
-            name: 'send_time',
-            label: 'Gönderim Zamanı',
-            required: true,
-            renderForm: () => (
-                <Field name="send_time">
-                    {({ field, form }: { field: any; form: any }) => (
-                        <input
-                            type="datetime-local"
-                            className="form-control"
-                            value={field.value || ''}
-                            onChange={(e) => form.setFieldValue('send_time', e.target.value)}
-                        />
-                    )}
-                </Field>
-            ),
-        },
+        { name: 'send_date', label: 'Gönderim Tarihi', type: 'date', required: true },
+        { name: 'send_time', label: 'Gönderim Saati', type: 'time', required: true },
         { name: 'send_sms_email', label: 'SMS/E-posta ile gönderilsin mi?', type: 'checkbox' },
         { name: 'status', label: 'Durum', type: 'select', options: statusOptions },
         {
@@ -147,11 +135,11 @@ export default function NotificationEdit() {
                 notificationId: Number(id),
                 payload: {
                     ...(values as any),
-                    send_time: values.send_time,
+                    send_time: `${values.send_date} ${values.send_time}`,
                 },
             });
         }
-        navigate(`${import.meta.env.BASE_URL}contact-panel?tab=notifications`);
+        navigate(`${import.meta.env.BASE_URL}contact-panel/notifications`);
     };
 
     const isLoading = updStatus === 'LOADING' || detailStatus === 'LOADING';
@@ -169,7 +157,7 @@ export default function NotificationEdit() {
                 cancelButtonLabel="Vazgeç"
                 isLoading={isLoading}
                 error={combinedError || undefined}
-                onClose={() => navigate(`${import.meta.env.BASE_URL}contact-panel?tab=notifications`)}
+                onClose={() => navigate(`${import.meta.env.BASE_URL}contact-panel/notifications`)}
                 autoGoBackOnModalClose
                 mode="double"
             />


### PR DESCRIPTION
## Summary
- split send time into separate date and time fields for notification add/edit forms
- redirect to the notifications table after saving or closing

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68591a4679e0832cbd5c13ac4fb25a8d