### PR TITLE
Keep contact panel tab after modal close

### DIFF
--- a/src/components/common/contactPanel/pages/currentNewsletter/crud.tsx
+++ b/src/components/common/contactPanel/pages/currentNewsletter/crud.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { FormikValues, Field } from 'formik';
 import TargetAudienceModal, { AudienceItem } from './TargetAudienceModal';
 
@@ -26,6 +26,7 @@ interface FormData extends FormikValues {
 
 export default function CurrentNewsletterCrud() {
     const navigate = useNavigate();
+    const [, setSearchParams] = useSearchParams();
     const { id } = useParams<{ id?: string }>();
     const mode: 'add' | 'update' = id ? 'update' : 'add';
 
@@ -196,7 +197,8 @@ export default function CurrentNewsletterCrud() {
                 payload,
             });
         }
-        navigate(`${import.meta.env.BASE_URL}contact-panel?tab=current-newsletter`);
+        navigate(`${import.meta.env.BASE_URL}contact-panel`, { replace: true });
+        setSearchParams({ tab: 'current-newsletter' });
     };
 
     return (
@@ -211,7 +213,10 @@ export default function CurrentNewsletterCrud() {
                 cancelButtonLabel="Vazgeç"
                 isLoading={isLoading}
                 error={combinedError || undefined}
-                onClose={() => navigate(`${import.meta.env.BASE_URL}contact-panel?tab=current-newsletter`)}
+                onClose={() => {
+                    navigate(`${import.meta.env.BASE_URL}contact-panel`, { replace: true });
+                    setSearchParams({ tab: 'current-newsletter' });
+                }}
                 autoGoBackOnModalClose
                 mode="double"
             />

--- a/src/components/common/contactPanel/pages/e-mail/crud.tsx
+++ b/src/components/common/contactPanel/pages/e-mail/crud.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { FormikValues } from 'formik'
 
 import ReusableModalForm, { FieldDefinition } from '../../../ReusableModalForm'
@@ -24,6 +24,7 @@ interface FormData extends FormikValues {
 
 export default function EmailCrud() {
     const navigate = useNavigate()
+    const [, setSearchParams] = useSearchParams()
     const { id } = useParams<{ id?: string }>()
     const mode: 'add' | 'update' = id ? 'update' : 'add'
 
@@ -135,7 +136,8 @@ export default function EmailCrud() {
         } else if (mode === 'update' && id) {
             await updateExistingNotification({ notificationId: Number(id), payload })
         }
-        navigate(`${import.meta.env.BASE_URL}contact-panel?tab=e-mail`)
+        navigate(`${import.meta.env.BASE_URL}contact-panel`, { replace: true })
+        setSearchParams({ tab: 'e-mail' })
     }
 
     const isLoading =
@@ -155,7 +157,10 @@ export default function EmailCrud() {
                 cancelButtonLabel="Vazgeç"
                 isLoading={isLoading}
                 error={combinedError || undefined}
-                onClose={() => navigate(`${import.meta.env.BASE_URL}contact-panel?tab=e-mail`)}
+                onClose={() => {
+                    navigate(`${import.meta.env.BASE_URL}contact-panel`, { replace: true })
+                    setSearchParams({ tab: 'e-mail' })
+                }}
                 autoGoBackOnModalClose
                 mode="double"
             />

--- a/src/components/common/contactPanel/pages/notifications/add.tsx
+++ b/src/components/common/contactPanel/pages/notifications/add.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { FormikValues } from 'formik';
 import ReusableModalForm, { FieldDefinition } from '../../../ReusableModalForm';
 import { useNotificationAdd } from '../../../../hooks/notifications/useAdd';
@@ -21,6 +21,7 @@ interface FormData extends FormikValues {
 
 export default function NotificationAdd() {
     const navigate = useNavigate();
+    const [, setSearchParams] = useSearchParams();
     const { addNewNotification, status, error } = useNotificationAdd();
     const [enabled, setEnabled] = useState({ notifications: false });
     const { notificationsData = [] } = useNotificationsList({
@@ -95,7 +96,8 @@ export default function NotificationAdd() {
             send_time: `${values.send_date} ${values.send_time}`,
             group_ids: selectedAudience.map((a) => a.id),
         });
-        navigate(`${import.meta.env.BASE_URL}contact-panel/notifications`);
+        navigate(`${import.meta.env.BASE_URL}contact-panel`, { replace: true });
+        setSearchParams({ tab: 'notifications' });
     };
 
     const isLoading = status === 'LOADING';
@@ -114,7 +116,10 @@ export default function NotificationAdd() {
                 cancelButtonLabel="Vazgeç"
                 isLoading={isLoading}
                 error={error || undefined}
-                onClose={() => navigate(`${import.meta.env.BASE_URL}contact-panel/notifications`)}
+                onClose={() => {
+                    navigate(`${import.meta.env.BASE_URL}contact-panel`, { replace: true });
+                    setSearchParams({ tab: 'notifications' });
+                }}
                 autoGoBackOnModalClose
                 mode="double"
             />

--- a/src/components/common/contactPanel/pages/notifications/edit.tsx
+++ b/src/components/common/contactPanel/pages/notifications/edit.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { Button } from 'react-bootstrap';
 import { FormikValues } from 'formik';
 import ReusableModalForm, { FieldDefinition } from '../../../ReusableModalForm';
@@ -24,6 +24,7 @@ interface FormData extends FormikValues {
 
 export default function NotificationEdit() {
     const navigate = useNavigate();
+    const [, setSearchParams] = useSearchParams();
     const { id } = useParams<{ id?: string }>();
     const { notification, getNotification, status: detailStatus, error: detailError } = useNotificationDetail();
     const { updateExistingNotification, status: updStatus, error: updError } = useNotificationUpdate();
@@ -139,7 +140,8 @@ export default function NotificationEdit() {
                 },
             });
         }
-        navigate(`${import.meta.env.BASE_URL}contact-panel/notifications`);
+        navigate(`${import.meta.env.BASE_URL}contact-panel`, { replace: true });
+        setSearchParams({ tab: 'notifications' });
     };
 
     const isLoading = updStatus === 'LOADING' || detailStatus === 'LOADING';
@@ -157,7 +159,10 @@ export default function NotificationEdit() {
                 cancelButtonLabel="Vazgeç"
                 isLoading={isLoading}
                 error={combinedError || undefined}
-                onClose={() => navigate(`${import.meta.env.BASE_URL}contact-panel/notifications`)}
+                onClose={() => {
+                    navigate(`${import.meta.env.BASE_URL}contact-panel`, { replace: true });
+                    setSearchParams({ tab: 'notifications' });
+                }}
                 autoGoBackOnModalClose
                 mode="double"
             />

--- a/src/components/common/contactPanel/pages/sms/crud.tsx
+++ b/src/components/common/contactPanel/pages/sms/crud.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { FormikValues } from 'formik';
 import TargetAudienceModal, { AudienceItem } from './TargetAudienceModal';
 
@@ -25,6 +25,7 @@ interface FormData extends FormikValues {
 
 export default function SmsCrud() {
     const navigate = useNavigate();
+    const [, setSearchParams] = useSearchParams();
     const { id } = useParams<{ id?: string }>();
     const mode: 'add' | 'edit' = id ? 'edit' : 'add';
 
@@ -170,7 +171,8 @@ export default function SmsCrud() {
         } else if (mode === 'edit' && id) {
             await updateExistingNotification({ notificationId: Number(id), payload: payload as any });
         }
-        navigate(`${import.meta.env.BASE_URL}contact-panel?tab=sms`);
+        navigate(`${import.meta.env.BASE_URL}contact-panel`, { replace: true });
+        setSearchParams({ tab: 'sms' });
     };
 
     const isLoading =
@@ -190,7 +192,10 @@ export default function SmsCrud() {
                 cancelButtonLabel="Vazgeç"
                 isLoading={isLoading}
                 error={combinedError || undefined}
-                onClose={() => navigate(`${import.meta.env.BASE_URL}contact-panel?tab=sms`)}
+                onClose={() => {
+                    navigate(`${import.meta.env.BASE_URL}contact-panel`, { replace: true });
+                    setSearchParams({ tab: 'sms' });
+                }}
                 autoGoBackOnModalClose
                 mode="double"
             />


### PR DESCRIPTION
## Summary
- preserve active tab when closing modals in contact panel
- send search params back to `/contact-panel` so user stays on same tab

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68591d663964832cb7cf52bf682e8936