### PR TITLE
Fix navigation after sending contact panel forms

### DIFF
--- a/src/components/common/contactPanel/pages/e-mail/crud.tsx
+++ b/src/components/common/contactPanel/pages/e-mail/crud.tsx
@@ -136,11 +136,8 @@ export default function EmailCrud() {
         } else if (mode === 'update' && id) {
             await updateExistingNotification({ notificationId: Number(id), payload })
         }
-        navigate(
-            `${import.meta.env.BASE_URL}contact-panel/e-mail`,
-            { replace: true }
-        )
-        setSearchParams({})
+        navigate(`${import.meta.env.BASE_URL}contact-panel`, { replace: true })
+        setSearchParams({ tab: 'e-mail' })
     }
 
     const isLoading =

--- a/src/components/common/contactPanel/pages/notifications/add.tsx
+++ b/src/components/common/contactPanel/pages/notifications/add.tsx
@@ -96,11 +96,8 @@ export default function NotificationAdd() {
             send_time: `${values.send_date} ${values.send_time}`,
             group_ids: selectedAudience.map((a) => a.id),
         });
-        navigate(
-            `${import.meta.env.BASE_URL}contact-panel/notifications`,
-            { replace: true }
-        );
-        setSearchParams({});
+        navigate(`${import.meta.env.BASE_URL}contact-panel`, { replace: true });
+        setSearchParams({ tab: 'notifications' });
     };
 
     const isLoading = status === 'LOADING';

--- a/src/components/common/contactPanel/pages/notifications/edit.tsx
+++ b/src/components/common/contactPanel/pages/notifications/edit.tsx
@@ -140,11 +140,8 @@ export default function NotificationEdit() {
                 },
             });
         }
-        navigate(
-            `${import.meta.env.BASE_URL}contact-panel/notifications`,
-            { replace: true }
-        );
-        setSearchParams({});
+        navigate(`${import.meta.env.BASE_URL}contact-panel`, { replace: true });
+        setSearchParams({ tab: 'notifications' });
     };
 
     const isLoading = updStatus === 'LOADING' || detailStatus === 'LOADING';

--- a/src/components/common/contactPanel/pages/sms/crud.tsx
+++ b/src/components/common/contactPanel/pages/sms/crud.tsx
@@ -171,11 +171,8 @@ export default function SmsCrud() {
         } else if (mode === 'edit' && id) {
             await updateExistingNotification({ notificationId: Number(id), payload: payload as any });
         }
-        navigate(
-            `${import.meta.env.BASE_URL}contact-panel/sms`,
-            { replace: true }
-        );
-        setSearchParams({});
+        navigate(`${import.meta.env.BASE_URL}contact-panel`, { replace: true });
+        setSearchParams({ tab: 'sms' });
     };
 
     const isLoading =


### PR DESCRIPTION
## Summary
- ensure email, notification, and SMS CRUD pages navigate back to the main contact panel tab after submit
- redirect users to the correct tab when closing the modal after submit

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685931a68e9c832c9077aca0d18323ce