### PR TITLE
Fix send buttons in notification modals

### DIFF
--- a/src/components/common/contactPanel/pages/notifications/add.tsx
+++ b/src/components/common/contactPanel/pages/notifications/add.tsx
@@ -77,6 +77,7 @@ export default function NotificationAdd() {
         {
             name: 'group_ids',
             label: 'Hedef Kitle',
+            type: 'multiselect',
             renderForm: () => (
                 <Button
                     variant="primary-light"

--- a/src/components/common/contactPanel/pages/notifications/edit.tsx
+++ b/src/components/common/contactPanel/pages/notifications/edit.tsx
@@ -116,6 +116,7 @@ export default function NotificationEdit() {
         {
             name: 'group_ids',
             label: 'Hedef Kitle',
+            type: 'multiselect',
             renderForm: () => (
                 <Button
                     variant="primary-light"


### PR DESCRIPTION
## Summary
- ensure `group_ids` fields are recognized as arrays in notification add/edit modals

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` *(fails due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6859397515e8832ca62eba8d0a41fa46