### PR TITLE
Add extra operations page

### DIFF
--- a/src/components/common/extraOperations/index.tsx
+++ b/src/components/common/extraOperations/index.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import TabsContainer from '../guidance/components/organisms/TabsContainer';
+import Pageheader from '../page-header/pageheader';
+
+// Existing tabs from personnel detail
+import PersonelPrimTab from '../personel/personelDetail/tabs/prim/table';
+import KesintiTab from '../personel/personelDetail/tabs/kesinti/table';
+import PersonelTazminatTab from '../personel/personelDetail/tabs/tazminat/table';
+import PersonelIadeTab from '../personel/personelDetail/tabs/iade/table';
+
+const ExtraOperationsPage: React.FC = () => {
+  const [, setActiveIdx] = useState<number>(0);
+  const { id } = useParams<{ id?: string }>();
+  const personelId = id ? Number(id) : undefined;
+
+  const tabsConfig = [
+    {
+      label: 'Prim',
+      content: <PersonelPrimTab personelId={personelId} enabled={!!personelId} />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#5C67F726',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Kesinti',
+      content: <KesintiTab personelId={personelId} enabled={!!personelId} />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#5C67F726',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'Tazminat',
+      content: <PersonelTazminatTab personelId={personelId} enabled={!!personelId} />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#5C67F726',
+      passiveTextColor: '#5C67F7',
+    },
+    {
+      label: 'İade',
+      content: <PersonelIadeTab personelId={personelId} enabled={!!personelId} />,
+      activeBgColor: '#5C67F7',
+      activeTextColor: '#FFFFFF',
+      passiveBgColor: '#5C67F726',
+      passiveTextColor: '#5C67F7',
+    },
+  ];
+
+  return (
+    <div>
+      <Pageheader title="Personel Yönetimi" currentpage="Ekstra İşlemler" />
+      <TabsContainer tabs={tabsConfig} onTabChange={setActiveIdx} />
+    </div>
+  );
+};
+
+export default ExtraOperationsPage;

--- a/src/components/sidebar/nav.tsx
+++ b/src/components/sidebar/nav.tsx
@@ -281,13 +281,8 @@ export const MENUITEMS: any = [
             },
             {
               title: "Ekstra İşlemler",
-              type: "sub",
-              children: [
-                { title: "Prim", path: "/personel/:id/prim", type: "link" },
-                { title: "Kesinti", path: "/personel/:id/kesinti", type: "link" },
-                { title: "Tazminat", path: "/personel/:id/tazminat", type: "link" },
-                { title: "İade", path: "/personel/:id/iade", type: "link" },
-              ],
+              path: "extraOperations/index",
+              type: "link",
             },
           ],
         },

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -241,6 +241,9 @@ const PersonelSalaryPaymentCrud = lazy(
 const PersonelPrimlerCrud = lazy(
   () => import("../components/common/personel/personelDetail/tabs/prim/crud")
 );
+const ExtraOperationsIndex = lazy(
+  () => import("../components/common/extraOperations/index")
+);
 // Service Management
 const ServiceManagement = lazy(
   () => import("../components/common/student/service_management/index")
@@ -949,6 +952,11 @@ export const Routedata = [
     id: 10,
     path: `${import.meta.env.BASE_URL}personel/:id/iade`,
     element: <IadeTab />,
+  },
+  {
+    id: 10,
+    path: `${import.meta.env.BASE_URL}extraOperations/index`,
+    element: <ExtraOperationsIndex />,
   },
 
   {


### PR DESCRIPTION
## Summary
- create `extraOperations` page to consolidate personnel actions
- link new page in sidebar navigation
- register route for extra operations index

## Testing
- `npx eslint -c .eslintrc.json .` *(fails: Module needs JSON import attribute)*

------
https://chatgpt.com/codex/tasks/task_e_685952b0db74832cbf786bb8202057ec