### PR TITLE
Fix prim tab loading and dynamic header

### DIFF
--- a/src/components/common/extraOperations/index.tsx
+++ b/src/components/common/extraOperations/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import TabsContainer from '../guidance/components/organisms/TabsContainer';
 import Pageheader from '../../page-header/pageheader';
@@ -8,16 +8,24 @@ import PersonelPrimTab from '../personel/personelDetail/tabs/prim/table';
 import KesintiTab from '../personel/personelDetail/tabs/kesinti/table';
 import PersonelTazminatTab from '../personel/personelDetail/tabs/tazminat/table';
 import PersonelIadeTab from '../personel/personelDetail/tabs/iade/table';
+import { usePrimlerShow } from '../../hooks/employee/prim/usePrimlerShow';
 
 const ExtraOperationsPage: React.FC = () => {
-    const [, setActiveIdx] = useState<number>(0);
+    const [activeIdx, setActiveIdx] = useState<number>(0);
     const { id } = useParams<{ id?: string }>();
     const personelId = id ? Number(id) : undefined;
+    const { getPrimler } = usePrimlerShow();
+
+    useEffect(() => {
+        if (personelId) {
+            getPrimler(personelId);
+        }
+    }, [personelId, getPrimler]);
 
     const tabsConfig = [
         {
             label: 'Prim',
-            content: <PersonelPrimTab personelId={personelId} enabled={!!personelId} />,
+            content: <PersonelPrimTab personelId={personelId} enabled={activeIdx === 0 && !!personelId} />,
             activeBgColor: '#5C67F7',
             activeTextColor: '#FFFFFF',
             passiveBgColor: '#5C67F726',
@@ -25,7 +33,7 @@ const ExtraOperationsPage: React.FC = () => {
         },
         {
             label: 'Kesinti',
-            content: <KesintiTab personelId={personelId} enabled={!!personelId} />,
+            content: <KesintiTab personelId={personelId} enabled={activeIdx === 1 && !!personelId} />,
             activeBgColor: '#5C67F7',
             activeTextColor: '#FFFFFF',
             passiveBgColor: '#5C67F726',
@@ -33,7 +41,7 @@ const ExtraOperationsPage: React.FC = () => {
         },
         {
             label: 'Tazminat',
-            content: <PersonelTazminatTab personelId={personelId} enabled={!!personelId} />,
+            content: <PersonelTazminatTab personelId={personelId} enabled={activeIdx === 2 && !!personelId} />,
             activeBgColor: '#5C67F7',
             activeTextColor: '#FFFFFF',
             passiveBgColor: '#5C67F726',
@@ -41,7 +49,7 @@ const ExtraOperationsPage: React.FC = () => {
         },
         {
             label: 'İade',
-            content: <PersonelIadeTab personelId={personelId} enabled={!!personelId} />,
+            content: <PersonelIadeTab personelId={personelId} enabled={activeIdx === 3 && !!personelId} />,
             activeBgColor: '#5C67F7',
             activeTextColor: '#FFFFFF',
             passiveBgColor: '#5C67F726',
@@ -51,8 +59,8 @@ const ExtraOperationsPage: React.FC = () => {
 
     return (
         <div>
-            <Pageheader title="Personel Yönetimi" currentpage="Ekstra İşlemler" />
-            <TabsContainer tabs={tabsConfig} onTabChange={setActiveIdx} />
+            <Pageheader title="Ekstra İşlemler" currentpage={tabsConfig[activeIdx]?.label} />
+            <TabsContainer tabs={tabsConfig} onTabChange={(idx) => setActiveIdx(idx)} />
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- prefetch prim info when `ExtraOperationsPage` mounts
- enable dynamic breadcrumbs for extra operations tabs

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: TypeScript errors and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_685958d42f98832cba1399563047d13a