### PR TITLE
Add bank account field to refund management

### DIFF
--- a/src/components/common/personel/personelDetail/tabs/iade/crud.tsx
+++ b/src/components/common/personel/personelDetail/tabs/iade/crud.tsx
@@ -8,8 +8,9 @@ import { Refund } from "../../../../../../types/employee/refund/list";
 
 type FormValues = {
   tarih: string;
-  miktar: string;
   odeme_sekli: string;
+  miktar: string;
+  banka_hesap_adi: string;
   aciklama: string;
 };
 
@@ -26,8 +27,9 @@ export default function PersonelIadeCrud() {
 
   const [initialValues, setInitialValues] = useState<FormValues>({
     tarih: "",
-    miktar: "",
     odeme_sekli: "",
+    miktar: "",
+    banka_hesap_adi: "",
     aciklama: "",
   });
 
@@ -35,8 +37,9 @@ export default function PersonelIadeCrud() {
     if (mode === "update" && selectedIade) {
       setInitialValues({
         tarih: selectedIade.tarih || "",
-        miktar: selectedIade.miktar,
         odeme_sekli: selectedIade.odeme_sekli || "",
+        miktar: selectedIade.miktar,
+        banka_hesap_adi: selectedIade.banka_hesap_adi || "",
         aciklama: selectedIade.aciklama || "",
       });
     }
@@ -50,20 +53,25 @@ export default function PersonelIadeCrud() {
       required: true,
     },
     {
-      name: "miktar",
-      label: "Miktar",
-      type: "currency",
-      required: true,
-    },
-    {
       name: "odeme_sekli",
-      label: "Ödeme Şekli",
+      label: "Ödeme Şekli",
       type: "select",
       required: true,
       options: [
         { label: "Nakit", value: "Nakit" },
         { label: "Banka", value: "Banka" },
       ],
+    },
+    {
+      name: "miktar",
+      label: "Alınan Tutar (₺)",
+      type: "currency",
+      required: true,
+    },
+    {
+      name: "banka_hesap_adi",
+      label: "Banka Hesap Adı",
+      type: "text",
     },
     {
       name: "aciklama",
@@ -79,8 +87,9 @@ export default function PersonelIadeCrud() {
       await addNewRefund({
         personel_id: personelId,
         tarih: vals.tarih,
-        miktar: vals.miktar,
         odeme_sekli: vals.odeme_sekli,
+        miktar: vals.miktar,
+        banka_hesap_adi: vals.banka_hesap_adi,
         aciklama: vals.aciklama,
       });
     } else if (id) {
@@ -88,8 +97,9 @@ export default function PersonelIadeCrud() {
         refundId: Number(id),
         payload: {
           tarih: vals.tarih,
-          miktar: vals.miktar,
           odeme_sekli: vals.odeme_sekli,
+          miktar: vals.miktar,
+          banka_hesap_adi: vals.banka_hesap_adi,
           aciklama: vals.aciklama,
         },
       });

--- a/src/components/common/personel/personelDetail/tabs/iade/table.tsx
+++ b/src/components/common/personel/personelDetail/tabs/iade/table.tsx
@@ -31,20 +31,25 @@ export default function IadeTab({ personelId, enabled = true }: IadeTabProps) {
   const columns: ColumnDefinition<Refund>[] = useMemo(
     () => [
       {
-        key: "donem",
-        label: "Dönem",
-        render: (row) => (row as any).donem || (row as any).vade || "-",
+        key: "tarih",
+        label: "Tarih",
+        render: (row) => row.tarih || "-",
+      },
+      {
+        key: "odeme_sekli",
+        label: "Ödeme Şekli",
+        render: (row) => row.odeme_sekli || "-",
       },
       {
         key: "miktar",
-        label: "Prim Tutarı (₺)",
+        label: "Alınan Tutar (₺)",
         render: (row) =>
           row.miktar ? `${Number(row.miktar).toLocaleString()} ₺` : "0,00 ₺",
       },
       {
-        key: "tarih",
-        label: "Tarih",
-        render: (row) => (row as any).tarih || "-",
+        key: "banka_hesap_adi",
+        label: "Banka Hesap Adı",
+        render: (row) => row.banka_hesap_adi || "-",
       },
       {
         key: "aciklama",

--- a/src/types/employee/refund/add.tsx
+++ b/src/types/employee/refund/add.tsx
@@ -6,6 +6,7 @@ export interface RefundAddPayload {
   personel_id : number;
   miktar: string;
   odeme_sekli: string;
+  banka_hesap_adi: string;
   aciklama: string;
 }
 

--- a/src/types/employee/refund/update.tsx
+++ b/src/types/employee/refund/update.tsx
@@ -7,6 +7,7 @@ export interface RefundUpdatePayload {
     tarih: string;
     miktar: string;
     odeme_sekli: string;
+    banka_hesap_adi: string;
     aciklama: string;
   };
 }


### PR DESCRIPTION
## Summary
- include `banka_hesap_adi` in refund add/update types
- adjust refund CRUD modal to handle bank account name and re-order fields
- update refund table columns to show payment info

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_685967a4d590832ca110f9387f850eb1