### PR TITLE
Fix Add actions in personnel tabs

### DIFF
--- a/src/components/common/personel/personelDetail/tabs/kesinti/table.tsx
+++ b/src/components/common/personel/personelDetail/tabs/kesinti/table.tsx
@@ -155,7 +155,9 @@ export default function KesintiTab({ personelId, enabled = true }: KesintiTabPro
 
       <ReusableTable<Interruption>
         columns={columns}
-        onAdd={() => navigate("/personelKesintiCrud")}
+        onAdd={() =>
+          navigate("/personelKesintiCrud", { state: { personelId: actualId } })
+        }
         data={data}
         loading={loading}
         tableMode="single"

--- a/src/components/common/personel/personelDetail/tabs/prim/table.tsx
+++ b/src/components/common/personel/personelDetail/tabs/prim/table.tsx
@@ -100,7 +100,9 @@ export default function PersonelPrimTab({
       </div>
 
       <ReusableTable<Primler>
-        onAdd={() => navigate("/personelPrimlerCrud")}
+        onAdd={() =>
+          navigate("/personelPrimlerCrud", { state: { personelId: actualId } })
+        }
         columns={columns}
         tableMode="single"
         data={data}

--- a/src/components/common/personel/personelDetail/tabs/tazminat/table.tsx
+++ b/src/components/common/personel/personelDetail/tabs/tazminat/table.tsx
@@ -115,7 +115,9 @@ export default function CompensationTab({
       <ReusableTable<Compensation>
         columns={columns}
         data={data}
-        onAdd={() => navigate("/personelCompensationCrud")}
+        onAdd={() =>
+          navigate("/personelCompensationCrud", { state: { personelId: actualId } })
+        }
         tableMode="single"
         loading={loading}
         error={error || deleteError}


### PR DESCRIPTION
## Summary
- pass the employee id when opening CRUD pages from Prim/Kesinti/Tazminat tabs

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: missing modules and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68596b437b34832ca82e7a744edb9d11