### PR TITLE
Use list hooks for personel subtabs

### DIFF
--- a/src/components/common/personel/personelDetail/tabs/iade/table.tsx
+++ b/src/components/common/personel/personelDetail/tabs/iade/table.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useState, useMemo } from "react";
+import { useMemo } from "react";
 import { Button } from "react-bootstrap";
 import { useNavigate, useParams } from "react-router-dom";
 import ReusableTable, { ColumnDefinition } from "../../../../ReusableTable";
-import { useRefundShow } from "../../../../../hooks/employee/refund/useRefundShow";
 import { useRefundDelete } from "../../../../../hooks/employee/refund/useRefundDelete";
 import { useRefundList } from "../../../../../hooks/employee/refund/useRefundList";
 import { Refund } from "../../../../../../types/employee/refund/list";
@@ -16,18 +15,11 @@ export default function IadeTab({ personelId, enabled = true }: IadeTabProps) {
   const { id } = useParams<{ id?: string }>();
   const actualId = personelId ?? (id ? Number(id) : 0);
   const navigate = useNavigate();
-  const [data, setData] = useState<Refund[]>([]);
-  const { getRefund, loading, error } = useRefundShow();
+  const { refunds: data, loading, error } = useRefundList({
+    enabled: true,
+    personel_id: actualId,
+  });
   const { deleteExistingRefund, error: deleteError } = useRefundDelete();
-
-  useEffect(() => {
-    if (!enabled) return;
-    (async () => {
-      const res = await getRefund(actualId);
-      const arr = Array.isArray(res) ? res : res ? [res] : [];
-      setData(arr);
-    })();
-  }, [enabled, actualId]);
 
   const columns: ColumnDefinition<Refund>[] = useMemo(
     () => [
@@ -111,7 +103,9 @@ export default function IadeTab({ personelId, enabled = true }: IadeTabProps) {
       </div>
 
       <ReusableTable<Refund>
-        onAdd={() => navigate("/personelIadeCrud")}
+        onAdd={() =>
+          navigate("/personelIadeCrud", { state: { personelId: actualId } })
+        }
         columns={columns}
         data={data}
         tableMode="single"

--- a/src/components/common/personel/personelDetail/tabs/kesinti/table.tsx
+++ b/src/components/common/personel/personelDetail/tabs/kesinti/table.tsx
@@ -1,5 +1,5 @@
 // src/components/common/personel/personelDetail/tabs/kesinti/table.tsx
-import { useEffect, useState, useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "react-bootstrap";
 import { useNavigate, useParams } from "react-router-dom";
 import ReusableTable, { ColumnDefinition } from "../../../../ReusableTable";
@@ -8,7 +8,6 @@ import odemeAlHover from "../../../../../../assets/images/media/ödeme-al-hover.
 import { KesintiPaymentModal } from "./crud";
 import darkcontrol from "../../../../../../utils/darkmodecontroller";
 import { useInterruptionList } from "../../../../../hooks/employee/interruption/useList";
-import { useInterruptionShow } from "../../../../../hooks/employee/interruption/useInterruptionShow";
 import { useInterruptionDelete } from "../../../../../hooks/employee/interruption/useInterruptionDelete";
 import { Interruption } from "../../../../../../types/employee/interruption/list";
 
@@ -21,20 +20,13 @@ export default function KesintiTab({ personelId, enabled = true }: KesintiTabPro
   const { id } = useParams<{ id?: string }>();
   const actualId = personelId ?? (id ? Number(id) : 0);
   const navigate = useNavigate();
-  const [data, setData] = useState<Interruption[]>([]);
   const [showPayment, setShowPayment] = useState(false);
   const [selected, setSelected] = useState<Interruption | null>(null);
-  const { getInterruption, loading, error } = useInterruptionShow();
+  const { interruptions: data, loading, error } = useInterruptionList({
+    enabled: true,
+    personel_id: actualId,
+  });
   const { deleteExistingInterruption, error: deleteError } = useInterruptionDelete();
-
-  useEffect(() => {
-    if (!enabled) return;
-    (async () => {
-      const res = await getInterruption(actualId);
-      const arr = Array.isArray(res) ? res : res ? [res] : [];
-      setData(arr);
-    })();
-  }, [enabled, actualId]);
 
   const columns: ColumnDefinition<Interruption>[] = useMemo(() => [
     {

--- a/src/components/common/personel/personelDetail/tabs/tazminat/table.tsx
+++ b/src/components/common/personel/personelDetail/tabs/tazminat/table.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { Button } from "react-bootstrap";
 import { useNavigate, useParams } from "react-router-dom";
 import ReusableTable, { ColumnDefinition } from "../../../../ReusableTable";
 import { Compensation } from "../../../../../../types/employee/compensation/list";
-import { useCompensationShow } from "../../../../../hooks/employee/compensation/useDetail";
 import { useCompensationDelete } from "../../../../../hooks/employee/compensation/useDelete";
 import { useCompensationList } from "../../../../../hooks/employee/compensation/useList";
 
@@ -19,21 +18,11 @@ export default function CompensationTab({
   const { id } = useParams<{ id?: string }>();
   const actualId = personelId ?? (id ? Number(id) : 0);
   const navigate = useNavigate();
-  const [data, setData] = useState<Compensation[]>([]);
-
-  const { getCompensation, loading, error } = useCompensationShow();
-  const { deleteExistingCompensation, error: deleteError } =
-    useCompensationDelete();
-
-  useEffect(() => {
-    if (!enabled) return;
-
-    (async () => {
-      const res = await getCompensation(actualId);
-      const arr = Array.isArray(res) ? res : res ? [res] : [];
-      setData(arr);
-    })();
-  }, [enabled, actualId]);
+  const { compensations: data, loading, error } = useCompensationList({
+    enabled: true,
+    personel_id: actualId,
+  });
+  const { deleteExistingCompensation, error: deleteError } = useCompensationDelete();
 
   const columns: ColumnDefinition<Compensation>[] = useMemo(
     () => [


### PR DESCRIPTION
## Summary
- standardize employee subtab tables to use the list hooks
- clean up unneeded effect logic
- pass personelId on add navigation

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685a4714a0f4832c9ad1821ab332750c