### PR TITLE
Fix ChatUser imports

### DIFF
--- a/src/components/common/contactPanel/pages/messages/chat.tsx
+++ b/src/components/common/contactPanel/pages/messages/chat.tsx
@@ -5,7 +5,7 @@ import EmojiPicker from "emoji-picker-react";
 import dayjs from "dayjs";
 import { useMessagesList } from "../../../../hooks/messages/useList";
 import { useMessageAdd } from "../../../../hooks/messages/useAdd";
-import { ChatUser, ChatMessage } from "../../../../../types/messages/chat";
+import { ChatUser, ChatMessage } from "../../../../../types/messages/list";
 
 interface Props {
   conversationId: string;

--- a/src/components/common/contactPanel/pages/messages/index.tsx
+++ b/src/components/common/contactPanel/pages/messages/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import Conversations from "./conversations";
 import Chat from "./chat";
-import { ChatUser } from "../../../../../types/messages/chat";
+import { ChatUser } from "../../../../../types/messages/list";
 import { MessageConversation } from "../../../../../types/messages/list";
 
 const MessagesIndex: React.FC<{ currentUserId: string }> = ({ currentUserId }) => {


### PR DESCRIPTION
## Summary
- use types/messages/list for ChatUser imports
- remove added ChatUser definitions from list.tsx

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: several missing packages and TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_685be063b79c832cbb7687eaa6604e8a