### PR TITLE
Update chat message types and conversation tabs

### DIFF
--- a/src/components/common/contactPanel/pages/messages/chat.tsx
+++ b/src/components/common/contactPanel/pages/messages/chat.tsx
@@ -5,7 +5,23 @@ import EmojiPicker from "emoji-picker-react";
 import dayjs from "dayjs";
 import { useMessagesList } from "../../../../hooks/messages/useList";
 import { useMessageAdd } from "../../../../hooks/messages/useAdd";
-import { ChatUser, ChatMessage } from "../../../../../types/messages/list";
+// Local chat types based on component needs
+interface ChatUser {
+  id: string;
+  name: string;
+  imageUrl: string;
+  status: string;
+  isGroup?: boolean;
+  lastMessage?: string;
+  lastTimestamp?: string;
+}
+
+interface ChatMessage {
+  id: string;
+  senderId: string;
+  text: string;
+  timestamp: string;
+}
 
 interface Props {
   conversationId: string;

--- a/src/components/common/contactPanel/pages/messages/conversations.tsx
+++ b/src/components/common/contactPanel/pages/messages/conversations.tsx
@@ -3,23 +3,38 @@ import { Form, Nav, Spinner } from "react-bootstrap";
 import SimpleBar from "simplebar-react";
 import dayjs from "dayjs";
 import { useConversationsList } from "../../../../hooks/conversations/useList";
+import { useUsersTable } from "../../../../hooks/user/useList";
 import { MessageConversation } from "../../../../../types/messages/list";
+import { UserData } from "../../../../../types/user/list";
 
 interface Props {
   onSelect: (conversation: MessageConversation) => void;
 }
 
 const Conversations: React.FC<Props> = ({ onSelect }) => {
-  const [activeTab, setActiveTab] = useState<'personal' | 'group'>('personal');
+  const [activeTab, setActiveTab] = useState<'chats' | 'groups' | 'users'>('chats');
   const [search, setSearch] = useState('');
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
+  const conversationParams: any = { search, enabled: activeTab !== 'users' };
+  if (activeTab === 'groups') conversationParams.type = 'group';
+
   const {
-    conversationsData: data = [],
-    loading: isLoading,
-    error: isError,
-  } = useConversationsList({ type: activeTab, search, enabled: true }) as unknown as {
+    conversationsData: conversations = [],
+    loading: isConvLoading,
+    error: isConvError,
+  } = useConversationsList(conversationParams) as unknown as {
     conversationsData: MessageConversation[];
+    loading: boolean;
+    error: boolean;
+  };
+
+  const {
+    usersData: users = [],
+    loading: isUsersLoading,
+    error: isUsersError,
+  } = useUsersTable({ enabled: activeTab === 'users', search, page: 1, paginate: 50 }) as unknown as {
+    usersData: UserData[];
     loading: boolean;
     error: boolean;
   };
@@ -36,43 +51,63 @@ const Conversations: React.FC<Props> = ({ onSelect }) => {
       </div>
       <Nav variant="tabs" className="tab-style-6 px-3">
         <Nav.Item>
-          <Nav.Link active={activeTab === 'personal'} onClick={() => setActiveTab('personal')}>
-            Kişisel
+          <Nav.Link active={activeTab === 'chats'} onClick={() => setActiveTab('chats')}>
+            Sohbetler
           </Nav.Link>
         </Nav.Item>
         <Nav.Item>
-          <Nav.Link active={activeTab === 'group'} onClick={() => setActiveTab('group')}>
+          <Nav.Link active={activeTab === 'groups'} onClick={() => setActiveTab('groups')}>
             Gruplar
           </Nav.Link>
         </Nav.Item>
+        <Nav.Item>
+          <Nav.Link active={activeTab === 'users'} onClick={() => setActiveTab('users')}>
+            Kişiler
+          </Nav.Link>
+        </Nav.Item>
       </Nav>
-      {isLoading && (
+      {(isConvLoading || isUsersLoading) && (
         <div className="text-center p-2">
           <Spinner animation="border" size="sm" />
         </div>
       )}
-      {isError && <div className="text-danger text-center p-2">Yükleme hatası</div>}
-      <SimpleBar className={`${activeTab === 'personal' ? 'chat-users-tab' : 'chat-groups-tab'} list-unstyled mb-0`}>
+      {(isConvError || isUsersError) && (
+        <div className="text-danger text-center p-2">Yükleme hatası</div>
+      )}
+      <SimpleBar className="list-unstyled mb-0">
         <ul className="list-unstyled mb-0">
-          {data.map((c: MessageConversation) => (
-            <li
-              key={c.id}
-              onClick={() => {
-                setSelectedId(String(c.id));
-                onSelect(c);
-              }}
-              className={`${selectedId === String(c.id) ? 'active' : ''}`}
-            >
-              <div className="d-flex align-items-center">
-                <div className="flex-fill">
-                  <div className="d-flex justify-content-between">
-                    <span className="fw-semibold">{c.name}</span>
-                    <span className="fs-12 text-muted">{dayjs(c.created_at).format('HH:mm')}</span>
+          {activeTab !== 'users' &&
+            conversations.map((c: MessageConversation) => (
+              <li
+                key={c.id}
+                onClick={() => {
+                  setSelectedId(String(c.id));
+                  onSelect(c);
+                }}
+                className={`${selectedId === String(c.id) ? 'active' : ''}`}
+              >
+                <div className="d-flex align-items-center">
+                  <div className="flex-fill">
+                    <div className="d-flex justify-content-between">
+                      <span className="fw-semibold">{c.name}</span>
+                      <span className="fs-12 text-muted">{dayjs(c.created_at).format('HH:mm')}</span>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </li>
-          ))}
+              </li>
+            ))}
+          {activeTab === 'users' &&
+            users.map((u: UserData) => (
+              <li key={u.id} className="">
+                <div className="d-flex align-items-center">
+                  <div className="flex-fill">
+                    <div className="d-flex justify-content-between">
+                      <span className="fw-semibold">{u.first_name} {u.last_name}</span>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            ))}
         </ul>
       </SimpleBar>
     </div>

--- a/src/components/common/contactPanel/pages/messages/index.tsx
+++ b/src/components/common/contactPanel/pages/messages/index.tsx
@@ -1,8 +1,17 @@
 import React, { useState } from "react";
 import Conversations from "./conversations";
 import Chat from "./chat";
-import { ChatUser } from "../../../../../types/messages/list";
 import { MessageConversation } from "../../../../../types/messages/list";
+
+interface ChatUser {
+  id: string;
+  name: string;
+  imageUrl: string;
+  status: string;
+  isGroup?: boolean;
+  lastMessage?: string;
+  lastTimestamp?: string;
+}
 
 const MessagesIndex: React.FC<{ currentUserId: string }> = ({ currentUserId }) => {
   const [activeConversation, setActiveConversation] = useState<MessageConversation | null>(null);


### PR DESCRIPTION
## Summary
- define local `ChatUser` and `ChatMessage` interfaces instead of importing non-existent types
- add `ChatUser` interface in messages index
- refactor Conversations component to show tabs `Sohbetler`, `Gruplar` and `Kişiler`
- load users list when `Kişiler` tab is active

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: missing typings and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_685bee1746f0832c9ab7a0f52defc2d1