### PR TITLE
Refactor messaging flow

### DIFF
--- a/src/components/common/contactPanel/pages/messages/chat.tsx
+++ b/src/components/common/contactPanel/pages/messages/chat.tsx
@@ -1,18 +1,14 @@
-import React, { useState, useEffect, useRef } from "react";
-import { Form, Offcanvas, Spinner } from "react-bootstrap";
+import React, { useEffect, useRef, useState } from "react";
+import { Form, Spinner } from "react-bootstrap";
 import SimpleBar from "simplebar-react";
-import EmojiPicker from "emoji-picker-react";
-import dayjs from "dayjs";
 import { useMessagesList } from "../../../../hooks/messages/useList";
 import { useMessageAdd } from "../../../../hooks/messages/useAdd";
-interface ChatUser {
-  id: string;
-  name: string;
-  imageUrl: string;
-  status: string;
-  isGroup?: boolean;
-  lastMessage?: string;
-  lastTimestamp?: string;
+import { ChatUser } from "../../../../../types/messages/list";
+
+interface Props {
+  conversationId: string;
+  currentUserId: string;
+  user: ChatUser;
 }
 
 interface ChatMessage {
@@ -22,33 +18,18 @@ interface ChatMessage {
   timestamp: string;
 }
 
-const formatTime = (timestamp: string) => {
-  const d = dayjs(timestamp);
-  return d.isValid() ? d.format('HH:mm') : dayjs().format('HH:mm');
-};
-
-interface Props {
-  conversationId: string;
-  currentUserId: string;
-  user: ChatUser;
-}
-
 const Chat: React.FC<Props> = ({ conversationId, currentUserId, user }) => {
-  const {
-    messagesData = [],
-    loading: isLoading,
-  } = useMessagesList({
-    enabled: Boolean(conversationId),
+  const { messagesData = [], loading } = useMessagesList({
+    enabled: !!conversationId,
     conversation_id: Number(conversationId),
     page: 1,
     pageSize: 50,
   });
+
   const { addNewMessage } = useMessageAdd();
-  const [text, setText] = useState('');
-  const [showEmoji, setShowEmoji] = useState(false);
-  const [showInfo, setShowInfo] = useState(false);
+  const [text, setText] = useState("");
   const [messages, setMessages] = useState<ChatMessage[]>([]);
-  const chatContainerRef = useRef<HTMLDivElement | null>(null);
+  const chatRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const mapped = messagesData.map((m): ChatMessage => ({
@@ -61,34 +42,30 @@ const Chat: React.FC<Props> = ({ conversationId, currentUserId, user }) => {
   }, [messagesData]);
 
   useEffect(() => {
-    if (chatContainerRef.current) {
-      chatContainerRef.current.scrollTop = chatContainerRef.current.scrollHeight;
+    if (chatRef.current) {
+      chatRef.current.scrollTop = chatRef.current.scrollHeight;
     }
   }, [messages]);
 
   const handleSend = async () => {
     if (!text.trim()) return;
-
-    const optimisticMessage: ChatMessage = {
+    const optimistic: ChatMessage = {
       id: `temp-${Date.now()}`,
       senderId: currentUserId,
       text,
       timestamp: new Date().toISOString(),
     };
-
-    setMessages((prev) => [...prev, optimisticMessage]);
-
+    setMessages((prev) => [...prev, optimistic]);
     await addNewMessage({
       conversation_id: Number(conversationId),
       sender_id: Number(currentUserId),
       body: text,
     });
-    setText('');
-    setShowEmoji(false);
+    setText("");
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
+    if (e.key === "Enter") {
       e.preventDefault();
       handleSend();
     }
@@ -96,7 +73,7 @@ const Chat: React.FC<Props> = ({ conversationId, currentUserId, user }) => {
 
   return (
     <div className="main-chat-area border position-relative flex-fill">
-      <div className="main-chat-head d-flex align-items-center justify-content-between border-bottom">
+      <div className="main-chat-head d-flex align-items-center border-bottom">
         <div className="d-flex align-items-center">
           <span className="avatar avatar-md avatar-rounded me-2">
             <img src={user.imageUrl} alt="" />
@@ -106,25 +83,25 @@ const Chat: React.FC<Props> = ({ conversationId, currentUserId, user }) => {
             <span className="fs-12 text-muted">{user.status}</span>
           </div>
         </div>
-        <button className="btn btn-icon btn-sm btn-outline-light" onClick={() => setShowInfo(true)}>
-          <i className="ti ti-info-circle" />
-        </button>
       </div>
-      <SimpleBar className="chat-content" scrollableNodeProps={{ ref: chatContainerRef }}>
+      <SimpleBar className="chat-content" scrollableNodeProps={{ ref: chatRef }}>
         <ul className="list-unstyled mb-0">
-          {isLoading && (
+          {loading && (
             <li className="text-center py-4">
               <Spinner animation="border" size="sm" />
             </li>
           )}
-          {messages.map((msg: ChatMessage) => (
-            <li key={msg.id} className={msg.senderId === currentUserId ? 'chat-item-end' : 'chat-item-start'}>
+          {messages.map((msg) => (
+            <li
+              key={msg.id}
+              className={msg.senderId === currentUserId ? "chat-item-end" : "chat-item-start"}
+            >
               <div className="chat-list-inner">
                 <div className="main-chat-msg">
                   <div>
                     <p className="mb-0">{msg.text}</p>
                   </div>
-                  <span className="msg-sent-time">{formatTime(msg.timestamp)}</span>
+                  <span className="msg-sent-time">{msg.timestamp}</span>
                 </div>
               </div>
             </li>
@@ -132,19 +109,6 @@ const Chat: React.FC<Props> = ({ conversationId, currentUserId, user }) => {
         </ul>
       </SimpleBar>
       <div className="chat-footer">
-        <button className="btn btn-icon btn-sm btn-outline-light me-2">
-          <i className="ti ti-paperclip" />
-        </button>
-        <div className="position-relative me-2">
-          <button className="btn btn-icon btn-sm btn-outline-light" onClick={() => setShowEmoji(!showEmoji)}>
-            <i className="ti ti-mood-smile" />
-          </button>
-          {showEmoji && (
-            <div className="position-absolute bottom-100 z-3">
-              <EmojiPicker onEmojiClick={(e) => setText((t) => t + e.emoji)} />
-            </div>
-          )}
-        </div>
         <Form.Control
           type="text"
           className="flex-fill me-2"
@@ -157,23 +121,8 @@ const Chat: React.FC<Props> = ({ conversationId, currentUserId, user }) => {
           <i className="ri-send-plane-2-line" />
         </button>
       </div>
-      <Offcanvas placement="end" show={showInfo} onHide={() => setShowInfo(false)} className="chat-user-details">
-        <Offcanvas.Header closeButton>
-          <Offcanvas.Title>{user.name}</Offcanvas.Title>
-        </Offcanvas.Header>
-        <Offcanvas.Body>
-          <div className="text-center">
-            <span className="avatar avatar-xl avatar-rounded mb-2">
-              <img src={user.imageUrl} alt="" />
-            </span>
-            <p className="mb-0 fw-semibold">{user.name}</p>
-            <p className="text-muted fs-12">{user.status}</p>
-          </div>
-        </Offcanvas.Body>
-      </Offcanvas>
     </div>
   );
 };
 
 export default Chat;
-

--- a/src/components/common/contactPanel/pages/messages/conversations.tsx
+++ b/src/components/common/contactPanel/pages/messages/conversations.tsx
@@ -1,246 +1,63 @@
-import React, { useMemo, useState, useEffect } from "react";
-import { Form, Nav, Spinner, Tab, Button, Collapse } from "react-bootstrap";
+import React, { useState } from "react";
 import SimpleBar from "simplebar-react";
-import dayjs from "dayjs";
 import { useConversationsList } from "../../../../hooks/conversations/useList";
-import { useUsersTable } from "../../../../hooks/user/useList";
 import { MessageConversation } from "../../../../../types/messages/list";
-import { ConversationData } from "../../../../../types/conversations/list";
-import { UserData } from "../../../../../types/user/list";
 
 interface Props {
   currentUserId: string;
-  onSelect: (conversation: MessageConversation) => void;
+  onSelect: (c: MessageConversation) => void;
 }
 
 const Conversations: React.FC<Props> = ({ currentUserId, onSelect }) => {
   const [activeTab, setActiveTab] = useState<'chats' | 'groups' | 'users'>('chats');
-  const [search, setSearch] = useState('');
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [showGroupPanel, setShowGroupPanel] = useState(false);
-  const [groupSearch, setGroupSearch] = useState('');
 
-  const conversationParams: any = { search, enabled: activeTab !== 'users' };
-  if (activeTab === 'groups') conversationParams.type = 'group';
-  if (activeTab === 'chats') conversationParams.user_id = currentUserId;
-
-  const {
-    conversationsData: conversations = [],
-    loading: isConvLoading,
-    error: isConvError,
-  } = useConversationsList(conversationParams) as unknown as {
-    conversationsData: ConversationData[];
-    loading: boolean;
-    error: boolean;
-  };
-
-  const {
-    usersData: users = [],
-    loading: isUsersLoading,
-    error: isUsersError,
-  } = useUsersTable({
-    enabled: activeTab === 'users' || (activeTab === 'groups' && showGroupPanel),
-    search: activeTab === 'users' ? search : groupSearch,
-    page: 1,
-    paginate: 50,
-  }) as unknown as {
-    usersData: UserData[];
-    loading: boolean;
-    error: boolean;
-  };
-
-  const groupedUsers = useMemo(() => {
-    const groups: Record<string, UserData[]> = {};
-    users.forEach((u) => {
-      const letter = (u.first_name[0] || '').toUpperCase();
-      if (!groups[letter]) groups[letter] = [];
-      groups[letter].push(u);
-    });
-    return groups;
-  }, [users]);
-
-  const searchPlaceholder = useMemo(() => {
-    if (activeTab === 'chats') return 'Sohbet Ara…';
-    if (activeTab === 'groups') return 'Gruplar Ara…';
-    return 'Kişiler Ara…';
-  }, [activeTab]);
-
-  useEffect(() => {
-    if (activeTab !== 'groups') {
-      setShowGroupPanel(false);
-      setGroupSearch('');
-    }
-  }, [activeTab]);
+  const { conversationsData = [] } = useConversationsList({
+    enabled: true,
+    ...(activeTab === 'chats'
+      ? { user_id: Number(currentUserId) }
+      : activeTab === 'groups'
+      ? { type_id: 1 }
+      : {}),
+    paginate: 1,
+    per_page: 10,
+    orderBy: 'desc',
+  });
 
   return (
     <div className="chat-info flex-shrink-0 border">
-      <div className="p-3 border-bottom">
-        <Form.Control
-          type="search"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder={searchPlaceholder}
-        />
+      <div className="d-flex p-2 border-bottom gap-1">
+        <button
+          onClick={() => setActiveTab('chats')}
+          className={`btn btn-sm flex-fill ${activeTab === 'chats' ? 'btn-primary' : 'btn-light'}`}
+        >
+          Sohbetler
+        </button>
+        <button
+          onClick={() => setActiveTab('groups')}
+          className={`btn btn-sm flex-fill ${activeTab === 'groups' ? 'btn-primary' : 'btn-light'}`}
+        >
+          Gruplar
+        </button>
+        <button
+          onClick={() => setActiveTab('users')}
+          className={`btn btn-sm flex-fill ${activeTab === 'users' ? 'btn-primary' : 'btn-light'}`}
+        >
+          Kişiler
+        </button>
       </div>
-      <Tab.Container activeKey={activeTab} onSelect={(k) => setActiveTab(k as 'chats' | 'groups' | 'users')}>
-        <Nav variant="tabs" className="tab-style-6 px-3">
-          <Nav.Item>
-            <Nav.Link eventKey="chats">Sohbetler</Nav.Link>
-          </Nav.Item>
-          <Nav.Item>
-            <Nav.Link eventKey="groups">Gruplar</Nav.Link>
-          </Nav.Item>
-          <Nav.Item>
-            <Nav.Link eventKey="users">Kişiler</Nav.Link>
-          </Nav.Item>
-        </Nav>
-      </Tab.Container>
-      {activeTab === 'groups' ? (
-        <div className="d-flex justify-content-between align-items-center px-3 pt-2 pb-2 border-bottom">
-          <span className="fw-semibold">Grup Sohbetleri</span>
-          <Button size="sm" onClick={() => setShowGroupPanel(true)}>
-            Grup Oluştur
-          </Button>
-        </div>
-      ) : (
-        <div className="small text-muted px-3 pt-2 pb-2 border-bottom">
-          {activeTab === 'chats' && 'Sohbetler'}
-          {activeTab === 'users' && 'Kişiler'}
-        </div>
-      )}
-      {(isConvLoading || isUsersLoading) && (
-        <div className="text-center p-2">
-          <Spinner animation="border" size="sm" />
-        </div>
-      )}
-      {(isConvError || isUsersError) && (
-        <div className="text-danger text-center p-2">Yükleme hatası</div>
-      )}
-      <SimpleBar
-        className={`${activeTab === 'chats'
-            ? 'chat-contacts-tab'
-            : activeTab === 'groups'
-              ? 'chat-groups-tab'
-              : 'chat-users-tab'
-          } list-unstyled mb-0`}
-      >
+      <SimpleBar className="chat-contacts-tab list-unstyled mb-0">
         <ul className="list-unstyled mb-0">
-          {activeTab !== 'users' &&
-            conversations.map((c: ConversationData) => (
-              <li
-                key={c.id}
-                onClick={() => {
-                  setSelectedId(String(c.id));
-                  onSelect(c as unknown as MessageConversation);
-                }}
-                className={`${selectedId === String(c.id) ? 'active' : ''
-                  } ${(c as any).unreadCount ? 'chat-msg-unread' : ''
-                  } ${(c as any).isTyping ? 'chat-msg-typing' : ''
-                  }`}
-              >
-                <div className="d-flex align-items-center">
-                  <span className="avatar avatar-sm avatar-rounded me-2">
-                    <img src={(c as any).avatarUrl || ''} alt="" />
-                  </span>
-                  <div className="flex-fill">
-                    <div className="d-flex justify-content-between">
-                      <span className="fw-semibold">{c.name}</span>
-                      <span className="fs-12 text-muted">
-                        {dayjs((c as any).lastTimestamp || c.created_at).format('HH:mm')}
-                      </span>
-                    </div>
-                    <div className="d-flex justify-content-between align-items-center">
-                      <span className="chat-msg">
-                        {(c as any).isTyping
-                          ? `${(c as any).isTyping} Yazıyor…`
-                          : `${(c as any).lastSender || ''}${(c as any).lastSender ? ': ' : ''}${(c as any).lastMessage || ''}`}
-                      </span>
-                      {(c as any).unreadCount ? (
-                        <span className="badge bg-danger rounded-pill">
-                          {(c as any).unreadCount}
-                        </span>
-                      ) : (
-                        <span className="chat-read-icon">
-                          <i className="ri-check-line" />
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              </li>
-            ))}
-          {activeTab === 'users' &&
-            Object.keys(groupedUsers)
-              .sort()
-              .map((letter) => (
-                <React.Fragment key={letter}>
-                  <li className="px-3 py-1 text-muted fw-semibold">{letter}</li>
-                  {groupedUsers[letter].map((u) => (
-                    <li key={u.id} className="px-3 py-1">
-                      <div className="d-flex align-items-center">
-                        <div className="flex-fill">
-                          <span className="fw-semibold">
-                            {u.first_name} {u.last_name}
-                          </span>
-                        </div>
-                      </div>
-                    </li>
-                  ))}
-                </React.Fragment>
-              ))}
+          {conversationsData.map((c) => (
+            <li
+              key={c.id}
+              onClick={() => onSelect(c)}
+              className="px-3 py-2 border-bottom cursor-pointer"
+            >
+              {c.name}
+            </li>
+          ))}
         </ul>
       </SimpleBar>
-      {activeTab === 'groups' && (
-        <Collapse in={showGroupPanel}>
-          <div className="border-bottom">
-            <div className="d-flex justify-content-between align-items-center px-3 pt-2 pb-2 border-top">
-              <span className="fw-semibold">Gruba Üye Ekleyin</span>
-              <Button variant="link" size="sm" className="p-0" onClick={() => setShowGroupPanel(false)}>
-                <i className="ri-close-line"></i>
-              </Button>
-            </div>
-            <div className="px-3 pb-2">
-              <Form className="d-flex">
-                <Form.Control
-                  type="search"
-                  placeholder="Kişi Ara…"
-                  value={groupSearch}
-                  onChange={(e) => setGroupSearch(e.target.value)}
-                  className="me-2"
-                />
-                <Button variant="primary" type="submit">
-                  <i className="ri-search-line"></i>
-                </Button>
-              </Form>
-            </div>
-            <SimpleBar className="chat-users-tab list-unstyled mb-0" style={{ maxHeight: '200px' }}>
-              <ul className="list-unstyled mb-0">
-                {Object.keys(groupedUsers)
-                  .sort()
-                  .map((letter) => (
-                    <React.Fragment key={letter}>
-                      <li className="px-3 py-1 text-muted fw-semibold">{letter}</li>
-                      {groupedUsers[letter].map((u) => (
-                        <li key={u.id} className="px-3 py-1">
-                          <div className="d-flex align-items-center">
-                            <span className="avatar avatar-sm avatar-rounded me-2">
-                              <img src={u.picture} alt="" />
-                            </span>
-                            <div className="flex-fill">
-                              <span className="fw-semibold">
-                                {u.first_name} {u.last_name}
-                              </span>
-                            </div>
-                          </div>
-                        </li>
-                      ))}
-                    </React.Fragment>
-                  ))}
-              </ul>
-            </SimpleBar>
-          </div>
-        </Collapse>
-      )}
     </div>
   );
 };

--- a/src/components/common/contactPanel/pages/messages/index.tsx
+++ b/src/components/common/contactPanel/pages/messages/index.tsx
@@ -3,42 +3,23 @@ import Conversations from "./conversations";
 import Chat from "./chat";
 
 import { MessageConversation } from "../../../../../types/messages/list";
-interface ChatUser {
-  id: string;
-  name: string;
-  imageUrl: string;
-  status: string;
-  isGroup?: boolean;
-  lastMessage?: string;
-  lastTimestamp?: string;
-}
 
 const MessagesIndex: React.FC<{ currentUserId: string }> = ({ currentUserId }) => {
   const [selectedConversation, setSelectedConversation] = useState<MessageConversation | null>(null);
-  const [activeUser, setActiveUser] = useState<ChatUser | null>(null);
 
   return (
     <div className="main-chart-wrapper d-lg-flex gap-2">
-      <Conversations
-        currentUserId={currentUserId}
-        onSelect={(conv: MessageConversation) => {
-          setSelectedConversation(conv);
-          setActiveUser({
-            id: String(conv.id),
-            name: conv.name,
-            imageUrl: "",
-            status: "online",
-            isGroup: conv.type_id !== 0,
-            lastMessage: "",
-            lastTimestamp: conv.created_at || "",
-          });
-        }}
-      />
-      {selectedConversation && activeUser && (
+      <Conversations currentUserId={currentUserId} onSelect={setSelectedConversation} />
+      {selectedConversation && (
         <Chat
           conversationId={String(selectedConversation.id)}
           currentUserId={currentUserId}
-          user={activeUser}
+          user={{
+            id: String(selectedConversation.id),
+            name: selectedConversation.name,
+            imageUrl: (selectedConversation as any).group_avatar_url || "",
+            status: "online",
+          }}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- simplify MessagesIndex to select conversation and open Chat
- implement a lighter Conversations list
- implement a streamlined Chat panel

## Testing
- `npx tsc -p tsconfig.json`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_685cf88f94c8832c85cc3629d2e4e68f