### PR TITLE
Fix seasons header and total count

### DIFF
--- a/src/components/common/seasons/table.tsx
+++ b/src/components/common/seasons/table.tsx
@@ -6,6 +6,7 @@ import ReusableTable, { ColumnDefinition } from "../ReusableTable";
 import { useSeasonsList } from "../../hooks/season/useSeasonsList";
 import { useSeasonDelete } from "../../hooks/season/useSeasonsDelete";
 import { Season } from "../../../types/seasons/list";
+import Pageheader from "../../page-header/pageheader";
 
 export default function SeasonsListPage() {
     const navigate = useNavigate();
@@ -63,31 +64,31 @@ export default function SeasonsListPage() {
     );
 
     return (
-
-
-        <ReusableTable<Season>
-            pageTitle="Sezon Tipleri"
-            columns={columns}
-            data={seasonsData}
-            loading={loading}
-            showModal={false}
-            showExportButtons
-            tableMode="single"
-            error={error}
-            filters={[]}
-            currentPage={page}
-            totalPages={totalPages}
-            totalItems={totalItems}
-            onAdd={() => navigate("/seasons/crud")}
-            pageSize={paginate}
-            onPageChange={setPage}
-            onPageSizeChange={(newSize) => {
-                setPaginate(newSize);
-                setPage(1);
-            }}
-            exportFileName="seasons"
-            onDeleteRow={(row) => deleteExistingSeason(row.id)}
-        />
+        <div className="container-fluid mt-3">
+            <Pageheader title="Sezon Yönetimi" currentpage="Sezonlar" />
+            <ReusableTable<Season>
+                columns={columns}
+                data={seasonsData}
+                loading={loading}
+                showModal={false}
+                showExportButtons
+                tableMode="single"
+                error={error}
+                filters={[]}
+                currentPage={page}
+                totalPages={totalPages}
+                totalItems={totalItems}
+                onAdd={() => navigate("/seasons/crud")}
+                pageSize={paginate}
+                onPageChange={setPage}
+                onPageSizeChange={(newSize) => {
+                    setPaginate(newSize);
+                    setPage(1);
+                }}
+                exportFileName="seasons"
+                onDeleteRow={(row) => deleteExistingSeason(row.id)}
+            />
+        </div>
 
     );
 }

--- a/src/components/hooks/season/useSeasonsList.tsx
+++ b/src/components/hooks/season/useSeasonsList.tsx
@@ -47,7 +47,8 @@ export function useSeasonsList(params: any) {
     const loading = status === SeasonListStatus.LOADING;
     const seasonsData = data || [];
     const totalPages = meta ? meta.last_page : 1;
-    const totalItems = meta ? meta.total : 0;
+    // Eğer meta bilgisi yoksa toplam kayıt sayısını eldeki veri uzunluğundan hesapla
+    const totalItems = meta ? meta.total : seasonsData.length;
 
     return {
         seasonsData,


### PR DESCRIPTION
## Summary
- show correct page header on seasons list
- compute total item count when API does not return meta

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: cannot find module 'vite' during tsc)*

------
https://chatgpt.com/codex/tasks/task_e_685d176d07a8832c930f8c697db38112