### PR TITLE
Fix newsletter CRUD navigation

### DIFF
--- a/src/components/common/contactPanel/pages/currentNewsletter/crud.tsx
+++ b/src/components/common/contactPanel/pages/currentNewsletter/crud.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { FormikValues, Field } from 'formik';
 import TargetAudienceModal, { AudienceItem } from './TargetAudienceModal';
 
@@ -26,6 +26,8 @@ interface FormData extends FormikValues {
 
 export default function CurrentNewsletterCrud() {
     const navigate = useNavigate();
+    const location = useLocation();
+    const tab = new URLSearchParams(location.search).get('tab') || '1';
 
 
     const { id } = useParams<{ id?: string }>();
@@ -199,7 +201,7 @@ export default function CurrentNewsletterCrud() {
                 payload,
             });
         }
-        navigate(`${import.meta.env.BASE_URL}contact/messages?tab=1`, {
+        navigate(`${import.meta.env.BASE_URL}contact/messages?tab=${tab}`, {
             replace: true,
         });
 
@@ -219,7 +221,7 @@ export default function CurrentNewsletterCrud() {
                 error={combinedError || undefined}
                 onClose={() => {
                     navigate(
-                        `${import.meta.env.BASE_URL}contact/messages?tab=1`,
+                        `${import.meta.env.BASE_URL}contact/messages?tab=${tab}`,
                         {
                             replace: true,
                         }


### PR DESCRIPTION
## Summary
- preserve active tab when returning from newsletter CRUD

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685d3e37eed4832c82fa288302f37b0d