### PR TITLE
Fix study program detail modal link

### DIFF
--- a/src/components/common/pollingManagement/studyPolling/pages/studyProgram/crud.tsx
+++ b/src/components/common/pollingManagement/studyPolling/pages/studyProgram/crud.tsx
@@ -207,6 +207,7 @@ export default function StudyProgramCrud() {
                 tableMode="single"
                 onCloseModal={() => navigate(-1)}
                 showExportButtons={false}
+                modalTitle=""
             />
         );
     }

--- a/src/components/common/pollingManagement/studyPolling/pages/studyProgram/table.tsx
+++ b/src/components/common/pollingManagement/studyPolling/pages/studyProgram/table.tsx
@@ -108,7 +108,7 @@ export default function StudyProgramTable() {
                 <div className="d-flex gap-1 justify-content-center">
                     <Button variant=""
                         className="btn btn-icon btn-sm btn-primary-light rounded-pill"
-                        onClick={() => navigate(`${ROOT}/details/${row.id}`)}>
+                        onClick={() => navigate(`${ROOT}/crud/${row.id}`)}>
                         <i className="ti ti-eye" />
                     </Button>
 


### PR DESCRIPTION
## Summary
- link detail button in the study program table directly to the CRUD modal
- hide default "data" header when opening the student list modal

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_685e839180b4832cbd5afddd5a818a7c