### PR TITLE
Fix newsletter modal title

### DIFF
--- a/src/components/common/contactPanel/pages/currentNewsletter/crud.tsx
+++ b/src/components/common/contactPanel/pages/currentNewsletter/crud.tsx
@@ -211,7 +211,13 @@ export default function CurrentNewsletterCrud() {
         <>
             <ReusableModalForm<FormData>
                 show
-                title={mode === 'add' ? 'Bildirim Ekle' : 'Bülten Detay / Düzenle'}
+                title={
+                    mode === 'add'
+                        ? tab === '1'
+                            ? 'Bülten Ekle'
+                            : 'Bildirim Ekle'
+                        : 'Bülten Detay / Düzenle'
+                }
                 fields={getFields}
                 initialValues={initialValues}
                 onSubmit={handleSubmit}


### PR DESCRIPTION
## Summary
- show `Bülten Ekle` heading when adding a newsletter

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_685fd40c5550832c86feb08fc9828b1c