### PR TITLE
Fix modal navigation based on tab

### DIFF
--- a/src/components/common/contactPanel/pages/currentNewsletter/crud.tsx
+++ b/src/components/common/contactPanel/pages/currentNewsletter/crud.tsx
@@ -27,7 +27,7 @@ interface FormData extends FormikValues {
 export default function CurrentNewsletterCrud() {
     const navigate = useNavigate();
     const location = useLocation();
-    const tab = new URLSearchParams(location.search).get('tab') || '1';
+    const tab = new URLSearchParams(location.search).get('tab') || '0';
 
 
     const { id } = useParams<{ id?: string }>();
@@ -201,7 +201,7 @@ export default function CurrentNewsletterCrud() {
                 payload,
             });
         }
-        navigate(`${import.meta.env.BASE_URL}contact/messages?tab=${tab}`, {
+        navigate(`/contact/messages?tab=${tab}`, {
             replace: true,
         });
 
@@ -226,12 +226,9 @@ export default function CurrentNewsletterCrud() {
                 isLoading={isLoading}
                 error={combinedError || undefined}
                 onClose={() => {
-                    navigate(
-                        `${import.meta.env.BASE_URL}contact/messages?tab=${tab}`,
-                        {
-                            replace: true,
-                        }
-                    );
+                    navigate(`/contact/messages?tab=${tab}`, {
+                        replace: true,
+                    });
 
                 }}
                 autoGoBackOnModalClose

--- a/src/components/common/contactPanel/pages/e-mail/crud.tsx
+++ b/src/components/common/contactPanel/pages/e-mail/crud.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams, useLocation } from 'react-router-dom'
 import { FormikValues } from 'formik'
 
 import ReusableModalForm, { FieldDefinition } from '../../../ReusableModalForm'
@@ -24,6 +24,8 @@ interface FormData extends FormikValues {
 
 export default function EmailCrud() {
     const navigate = useNavigate()
+    const location = useLocation()
+    const tab = new URLSearchParams(location.search).get('tab') || '0'
 
     const { id } = useParams<{ id?: string }>()
     const mode: 'add' | 'update' = id ? 'update' : 'add'
@@ -136,7 +138,7 @@ export default function EmailCrud() {
         } else if (mode === 'update' && id) {
             await updateExistingNotification({ notificationId: Number(id), payload })
         }
-        navigate(`${import.meta.env.BASE_URL}contact/messages?tab=4`, {
+        navigate(`/contact/messages?tab=${tab}`, {
             replace: true,
         })
     }
@@ -159,7 +161,7 @@ export default function EmailCrud() {
                 isLoading={isLoading}
                 error={combinedError || undefined}
                 onClose={() => {
-                    navigate(`${import.meta.env.BASE_URL}contact/messages?tab=4`, {
+                    navigate(`/contact/messages?tab=${tab}`, {
                         replace: true,
                     })
 

--- a/src/components/common/contactPanel/pages/notifications/add.tsx
+++ b/src/components/common/contactPanel/pages/notifications/add.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { FormikValues } from 'formik';
 import ReusableModalForm, { FieldDefinition } from '../../../ReusableModalForm';
 import { useNotificationAdd } from '../../../../hooks/notifications/useAdd';
@@ -21,6 +21,8 @@ interface FormData extends FormikValues {
 
 export default function NotificationAdd() {
     const navigate = useNavigate();
+    const location = useLocation();
+    const tab = new URLSearchParams(location.search).get('tab') || '0';
 
     const { addNewNotification, status, error } = useNotificationAdd();
     const [enabled, setEnabled] = useState({ notifications: false });
@@ -97,7 +99,7 @@ export default function NotificationAdd() {
             send_time: `${values.send_date} ${values.send_time}`,
             group_ids: selectedAudience.map((a) => a.id),
         });
-        navigate(`${import.meta.env.BASE_URL}contact/messages?tab=2`, {
+        navigate(`/contact/messages?tab=${tab}`, {
             replace: true,
         });
     };
@@ -119,7 +121,7 @@ export default function NotificationAdd() {
                 isLoading={isLoading}
                 error={error || undefined}
                 onClose={() => {
-                    navigate(`${import.meta.env.BASE_URL}contact/messages?tab=2`, {
+                    navigate(`/contact/messages?tab=${tab}`, {
                         replace: true,
                     });
 

--- a/src/components/common/contactPanel/pages/notifications/edit.tsx
+++ b/src/components/common/contactPanel/pages/notifications/edit.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { Button } from 'react-bootstrap';
 import { FormikValues } from 'formik';
 import ReusableModalForm, { FieldDefinition } from '../../../ReusableModalForm';
@@ -24,6 +24,8 @@ interface FormData extends FormikValues {
 
 export default function NotificationEdit() {
     const navigate = useNavigate();
+    const location = useLocation();
+    const tab = new URLSearchParams(location.search).get('tab') || '0';
 
     const { id } = useParams<{ id?: string }>();
     const { notification, getNotification, status: detailStatus, error: detailError } = useNotificationDetail();
@@ -141,7 +143,7 @@ export default function NotificationEdit() {
                 },
             });
         }
-        navigate(`${import.meta.env.BASE_URL}contact/messages?tab=2`, {
+        navigate(`/contact/messages?tab=${tab}`, {
             replace: true,
         });
     };
@@ -161,7 +163,7 @@ export default function NotificationEdit() {
                 isLoading={isLoading}
                 error={combinedError || undefined}
                 onClose={() => {
-                    navigate(`${import.meta.env.BASE_URL}contact/messages?tab=2`, {
+                    navigate(`/contact/messages?tab=${tab}`, {
                         replace: true,
                     });
 

--- a/src/components/common/contactPanel/pages/sms/crud.tsx
+++ b/src/components/common/contactPanel/pages/sms/crud.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { FormikValues } from 'formik';
 import TargetAudienceModal, { AudienceItem } from './TargetAudienceModal';
 
@@ -25,6 +25,8 @@ interface FormData extends FormikValues {
 
 export default function SmsCrud() {
     const navigate = useNavigate();
+    const location = useLocation();
+    const tab = new URLSearchParams(location.search).get('tab') || '0';
 
     const { id } = useParams<{ id?: string }>();
     const mode: 'add' | 'edit' = id ? 'edit' : 'add';
@@ -171,7 +173,7 @@ export default function SmsCrud() {
         } else if (mode === 'edit' && id) {
             await updateExistingNotification({ notificationId: Number(id), payload: payload as any });
         }
-        navigate(`${import.meta.env.BASE_URL}contact/messages?tab=3`, {
+        navigate(`/contact/messages?tab=${tab}`, {
             replace: true,
         });
     };
@@ -194,7 +196,7 @@ export default function SmsCrud() {
                 isLoading={isLoading}
                 error={combinedError || undefined}
                 onClose={() => {
-                    navigate(`${import.meta.env.BASE_URL}contact/messages?tab=3`, {
+                    navigate(`/contact/messages?tab=${tab}`, {
                         replace: true,
                     });
 


### PR DESCRIPTION
## Summary
- keep tab context when closing contact modals
- update navigation paths to include the tab

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_685fdb14e1ec832c9025dded655decd5