### PR TITLE
Add contract employee redux slices and hooks

### DIFF
--- a/src/components/hooks/contractEmployees/useAdd.tsx
+++ b/src/components/hooks/contractEmployees/useAdd.tsx
@@ -1,0 +1,21 @@
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { addContractEmployee } from '../../../slices/contractEmployees/add/thunk'
+import { ContractEmployeesAddPayload } from '../../../types/contractEmployees/add'
+
+export function useContractEmployeeAdd() {
+  const dispatch = useDispatch<AppDispatch>()
+  const { data, status, error } = useSelector((state: RootState) => state.contractEmployeeAdd)
+
+  const addNewContractEmployee = useCallback(async (payload: ContractEmployeesAddPayload) => {
+    const resultAction = await dispatch(addContractEmployee(payload))
+    if (addContractEmployee.fulfilled.match(resultAction)) {
+      return resultAction.payload
+    }
+    return null
+  }, [dispatch])
+
+  return { addedContractEmployee: data, status, error, addNewContractEmployee }
+}

--- a/src/components/hooks/contractEmployees/useDelete.tsx
+++ b/src/components/hooks/contractEmployees/useDelete.tsx
@@ -1,0 +1,20 @@
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { deleteContractEmployee } from '../../../slices/contractEmployees/delete/thunk'
+
+export function useContractEmployeeDelete() {
+  const dispatch = useDispatch<AppDispatch>()
+  const { data, status, error } = useSelector((state: RootState) => state.contractEmployeeDelete)
+
+  const deleteExistingContractEmployee = useCallback(async (employeeId: number) => {
+    const resultAction = await dispatch(deleteContractEmployee(employeeId))
+    if (deleteContractEmployee.fulfilled.match(resultAction)) {
+      return resultAction.payload
+    }
+    return null
+  }, [dispatch])
+
+  return { deletedContractEmployee: data, status, error, deleteExistingContractEmployee }
+}

--- a/src/components/hooks/contractEmployees/useDetail.tsx
+++ b/src/components/hooks/contractEmployees/useDetail.tsx
@@ -1,0 +1,20 @@
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { fetchContractEmployee } from '../../../slices/contractEmployees/detail/thunk'
+
+export function useContractEmployeeShow() {
+  const dispatch = useDispatch<AppDispatch>()
+  const { data, status, error } = useSelector((state: RootState) => state.contractEmployeeShow)
+
+  const getContractEmployee = useCallback(async (employeeId: number) => {
+    const resultAction = await dispatch(fetchContractEmployee(employeeId))
+    if (fetchContractEmployee.fulfilled.match(resultAction)) {
+      return resultAction.payload
+    }
+    return null
+  }, [dispatch])
+
+  return { contractEmployee: data, status, error, getContractEmployee }
+}

--- a/src/components/hooks/contractEmployees/useList.tsx
+++ b/src/components/hooks/contractEmployees/useList.tsx
@@ -1,0 +1,68 @@
+import { useState, useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { RootState } from '../../../store/rootReducer'
+import { AppDispatch } from '../../../store'
+import { fetchContractEmployees } from '../../../slices/contractEmployees/list/thunk'
+import { data, meta, ContractEmployeeListArg } from '../../../types/contractEmployees/list'
+import { ContractEmployeesListStatus } from '../../../enums/contractEmployees/list'
+
+export function useContractEmployeesTable(params: ContractEmployeeListArg) {
+  if (params?.enabled === false) {
+    return {
+      contractEmployeesData: [] as data[],
+      loading: false,
+      error: null,
+      page: 1,
+      setPage: () => {},
+      pageSize: 10,
+      setPageSize: () => {},
+      filter: null,
+      setFilter: () => {},
+      totalPages: 1,
+      totalItems: 0
+    }
+  }
+
+  const dispatch = useDispatch<AppDispatch>()
+  const [page, setPage] = useState<number>(params.page || 1)
+  const [pageSize, setPageSize] = useState<number>(params.pageSize || 10)
+  const [filter, setFilter] = useState<any>(null)
+
+  const { data, meta, status, error } = useSelector((state: RootState) => state.contractEmployeeList)
+
+  useEffect(() => {
+    const { enabled = true, ...restParams } = params
+    if (!enabled) return
+
+    const query: ContractEmployeeListArg = {
+      enabled,
+      ...restParams,
+      filter,
+      page,
+      pageSize,
+      per_page: pageSize
+    }
+
+    dispatch(fetchContractEmployees(query))
+  }, [dispatch, filter, page, pageSize, params])
+
+  const loading = status === ContractEmployeesListStatus.LOADING
+  const contractEmployeesData: data[] = data || []
+  const paginationMeta: meta | null = meta
+  const totalPages = paginationMeta ? paginationMeta.last_page : 1
+  const totalItems = paginationMeta ? paginationMeta.total : 0
+
+  return {
+    contractEmployeesData,
+    loading,
+    error,
+    page,
+    setPage,
+    pageSize,
+    setPageSize,
+    filter,
+    setFilter,
+    totalPages,
+    totalItems
+  }
+}

--- a/src/components/hooks/contractEmployees/useUpdate.tsx
+++ b/src/components/hooks/contractEmployees/useUpdate.tsx
@@ -1,0 +1,21 @@
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { updateContractEmployee } from '../../../slices/contractEmployees/update/thunk'
+import { ContractEmployeesUpdatePayload } from '../../../types/contractEmployees/update'
+
+export function useContractEmployeeUpdate() {
+  const dispatch = useDispatch<AppDispatch>()
+  const { data, status, error } = useSelector((state: RootState) => state.contractEmployeeUpdate)
+
+  const updateExistingContractEmployee = useCallback(async (payload: ContractEmployeesUpdatePayload) => {
+    const resultAction = await dispatch(updateContractEmployee(payload))
+    if (updateContractEmployee.fulfilled.match(resultAction)) {
+      return resultAction.payload
+    }
+    return null
+  }, [dispatch])
+
+  return { updatedContractEmployee: data, status, error, updateExistingContractEmployee }
+}

--- a/src/enums/contractEmployees/list.tsx
+++ b/src/enums/contractEmployees/list.tsx
@@ -1,0 +1,8 @@
+export enum ContractEmployeesListStatus {
+  IDLE = 'IDLE',
+  LOADING = 'LOADING',
+  SUCCEEDED = 'SUCCEEDED',
+  FAILED = 'FAILED'
+}
+
+export default ContractEmployeesListStatus;

--- a/src/slices/contractEmployees/add/reducer.tsx
+++ b/src/slices/contractEmployees/add/reducer.tsx
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { addContractEmployee } from './thunk'
+import { ContractEmployeesAddState } from '../../../types/contractEmployees/add'
+import { ContractEmployeesListStatus } from '../../../enums/contractEmployees/list'
+
+const initialState: ContractEmployeesAddState = {
+  data: null,
+  status: ContractEmployeesListStatus.IDLE,
+  error: null
+}
+
+const contractEmployeeAddSlice = createSlice({
+  name: 'contractEmployeeAdd',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(addContractEmployee.pending, state => {
+        state.status = ContractEmployeesListStatus.LOADING
+        state.error = null
+      })
+      .addCase(addContractEmployee.fulfilled, (state, action: PayloadAction<any>) => {
+        state.status = ContractEmployeesListStatus.SUCCEEDED
+        state.data = action.payload
+      })
+      .addCase(addContractEmployee.rejected, (state, action: PayloadAction<any>) => {
+        state.status = ContractEmployeesListStatus.FAILED
+        state.error = action.payload
+      })
+  }
+})
+
+export default contractEmployeeAddSlice.reducer

--- a/src/slices/contractEmployees/add/thunk.tsx
+++ b/src/slices/contractEmployees/add/thunk.tsx
@@ -1,0 +1,17 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { CONTRACT_EMPLOYEES } from '../../../helpers/url_helper'
+import { ContractEmployeesAddPayload } from '../../../types/contractEmployees/add'
+import { data } from '../../../types/contractEmployees/list'
+
+export const addContractEmployee = createAsyncThunk<data, ContractEmployeesAddPayload>(
+  'contractEmployees/addContractEmployee',
+  async (payload, { rejectWithValue }) => {
+    try {
+      const resp = await axiosInstance.post(CONTRACT_EMPLOYEES, payload)
+      return resp.data.data as data
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || 'Add contract employee failed')
+    }
+  }
+)

--- a/src/slices/contractEmployees/delete/reducer.tsx
+++ b/src/slices/contractEmployees/delete/reducer.tsx
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { deleteContractEmployee } from './thunk'
+import { ContractEmployeesDeleteState } from '../../../types/contractEmployees/delete'
+import { ContractEmployeesListStatus } from '../../../enums/contractEmployees/list'
+
+const initialState: ContractEmployeesDeleteState = {
+  data: null,
+  status: ContractEmployeesListStatus.IDLE,
+  error: null
+}
+
+const contractEmployeesDeleteSlice = createSlice({
+  name: 'contractEmployeesDelete',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(deleteContractEmployee.pending, state => {
+        state.status = ContractEmployeesListStatus.LOADING
+        state.error = null
+      })
+      .addCase(deleteContractEmployee.fulfilled, (state, action: PayloadAction<any>) => {
+        state.status = ContractEmployeesListStatus.SUCCEEDED
+        state.data = action.payload
+      })
+      .addCase(deleteContractEmployee.rejected, (state, action: PayloadAction<any>) => {
+        state.status = ContractEmployeesListStatus.FAILED
+        state.error = action.payload
+      })
+  }
+})
+
+export default contractEmployeesDeleteSlice.reducer

--- a/src/slices/contractEmployees/delete/thunk.tsx
+++ b/src/slices/contractEmployees/delete/thunk.tsx
@@ -1,0 +1,16 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { CONTRACT_EMPLOYEES } from '../../../helpers/url_helper'
+import { ContractEmployeesDeleteState } from '../../../types/contractEmployees/delete'
+
+export const deleteContractEmployee = createAsyncThunk<ContractEmployeesDeleteState, number>(
+  'contractEmployees/deleteContractEmployee',
+  async (employeeId, { rejectWithValue }) => {
+    try {
+      const resp = await axiosInstance.delete(`${CONTRACT_EMPLOYEES}/${employeeId}`)
+      return resp.data as ContractEmployeesDeleteState
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || 'Delete contract employee failed')
+    }
+  }
+)

--- a/src/slices/contractEmployees/detail/reducer.tsx
+++ b/src/slices/contractEmployees/detail/reducer.tsx
@@ -1,0 +1,32 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { fetchContractEmployee } from './thunk'
+import { ContractEmployeeShowState } from '../../../types/contractEmployees/detail'
+import { ContractEmployeesListStatus } from '../../../enums/contractEmployees/list'
+
+const initialState: ContractEmployeeShowState = {
+  data: null,
+  status: ContractEmployeesListStatus.IDLE,
+  error: null
+}
+
+const contractEmployeeShowSlice = createSlice({
+  name: 'contractEmployeeShow',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder.addCase(fetchContractEmployee.pending, state => {
+      state.status = ContractEmployeesListStatus.LOADING
+      state.error = null
+    })
+    builder.addCase(fetchContractEmployee.fulfilled, (state, action: PayloadAction<any>) => {
+      state.status = ContractEmployeesListStatus.SUCCEEDED
+      state.data = action.payload
+    })
+    builder.addCase(fetchContractEmployee.rejected, (state, action: PayloadAction<any>) => {
+      state.status = ContractEmployeesListStatus.FAILED
+      state.error = action.payload
+    })
+  }
+})
+
+export default contractEmployeeShowSlice.reducer

--- a/src/slices/contractEmployees/detail/thunk.tsx
+++ b/src/slices/contractEmployees/detail/thunk.tsx
@@ -1,0 +1,16 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { CONTRACT_EMPLOYEES } from '../../../helpers/url_helper'
+import { ContractEmployeeShowState } from '../../../types/contractEmployees/detail'
+
+export const fetchContractEmployee = createAsyncThunk<ContractEmployeeShowState, number>(
+  'contractEmployees/fetchContractEmployee',
+  async (employeeId, { rejectWithValue }) => {
+    try {
+      const response = await axiosInstance.get(`${CONTRACT_EMPLOYEES}/${employeeId}`)
+      return response.data.data as ContractEmployeeShowState
+    } catch (error: any) {
+      return rejectWithValue(error.response?.data?.message || 'Fetch contract employee failed')
+    }
+  }
+)

--- a/src/slices/contractEmployees/list/reducer.tsx
+++ b/src/slices/contractEmployees/list/reducer.tsx
@@ -1,0 +1,44 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { fetchContractEmployees } from './thunk'
+import { ListContractEmployeesResponse } from '../../../types/contractEmployees/list'
+import { ContractEmployeesListStatus } from '../../../enums/contractEmployees/list'
+
+export interface ContractEmployeeListState {
+  data: ListContractEmployeesResponse['data'] | null
+  links: ListContractEmployeesResponse['links'] | null
+  meta: ListContractEmployeesResponse['meta'] | null
+  status: ContractEmployeesListStatus
+  error: string | null
+}
+
+const initialState: ContractEmployeeListState = {
+  data: null,
+  links: null,
+  meta: null,
+  status: ContractEmployeesListStatus.IDLE,
+  error: null
+}
+
+const contractEmployeeListSlice = createSlice({
+  name: 'contractEmployees/list',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder.addCase(fetchContractEmployees.pending, state => {
+      state.status = ContractEmployeesListStatus.LOADING
+      state.error = null
+    })
+    builder.addCase(fetchContractEmployees.fulfilled, (state, action: PayloadAction<ListContractEmployeesResponse>) => {
+      state.status = ContractEmployeesListStatus.SUCCEEDED
+      state.data = action.payload.data
+      state.links = action.payload.links
+      state.meta = action.payload.meta
+    })
+    builder.addCase(fetchContractEmployees.rejected, (state, action: PayloadAction<any>) => {
+      state.status = ContractEmployeesListStatus.FAILED
+      state.error = action.payload || 'Fetch contract employees failed'
+    })
+  }
+})
+
+export default contractEmployeeListSlice.reducer

--- a/src/slices/contractEmployees/list/thunk.tsx
+++ b/src/slices/contractEmployees/list/thunk.tsx
@@ -1,0 +1,24 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { CONTRACT_EMPLOYEES } from '../../../helpers/url_helper'
+import { ListContractEmployeesResponse, ContractEmployeeListArg } from '../../../types/contractEmployees/list'
+
+export const fetchContractEmployees = createAsyncThunk<ListContractEmployeesResponse, ContractEmployeeListArg>(
+  'contractEmployees/fetchContractEmployees',
+  async (queryParams, { rejectWithValue }) => {
+    try {
+      const query = new URLSearchParams()
+      Object.entries(queryParams).forEach(([key, value]) => {
+        if (value !== undefined && value !== null) {
+          query.append(key, String(value))
+        }
+      })
+      const queryString = new URLSearchParams(queryParams).toString()
+      const url = `${CONTRACT_EMPLOYEES}?${queryString}`
+      const resp = await axiosInstance.get(url)
+      return resp.data as ListContractEmployeesResponse
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || 'Fetch contract employees failed')
+    }
+  }
+)

--- a/src/slices/contractEmployees/update/reducer.tsx
+++ b/src/slices/contractEmployees/update/reducer.tsx
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { updateContractEmployee } from './thunk'
+import { ContractEmployeesUpdateState } from '../../../types/contractEmployees/update'
+import { ContractEmployeesListStatus } from '../../../enums/contractEmployees/list'
+
+const initialState: ContractEmployeesUpdateState = {
+  data: null,
+  status: ContractEmployeesListStatus.IDLE,
+  error: null
+}
+
+const contractEmployeesUpdateSlice = createSlice({
+  name: 'contractEmployeesUpdate',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(updateContractEmployee.pending, state => {
+        state.status = ContractEmployeesListStatus.LOADING
+        state.error = null
+      })
+      .addCase(updateContractEmployee.fulfilled, (state, action: PayloadAction<any>) => {
+        state.status = ContractEmployeesListStatus.SUCCEEDED
+        state.data = action.payload
+      })
+      .addCase(updateContractEmployee.rejected, (state, action: PayloadAction<any>) => {
+        state.status = ContractEmployeesListStatus.FAILED
+        state.error = action.payload
+      })
+  }
+})
+
+export default contractEmployeesUpdateSlice.reducer

--- a/src/slices/contractEmployees/update/thunk.tsx
+++ b/src/slices/contractEmployees/update/thunk.tsx
@@ -1,0 +1,17 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { CONTRACT_EMPLOYEES } from '../../../helpers/url_helper'
+import { ContractEmployeesUpdatePayload } from '../../../types/contractEmployees/update'
+import { data } from '../../../types/contractEmployees/list'
+
+export const updateContractEmployee = createAsyncThunk<data, ContractEmployeesUpdatePayload>(
+  'contractEmployees/updateContractEmployee',
+  async ({ employeeId, payload }, { rejectWithValue }) => {
+    try {
+      const resp = await axiosInstance.put(`${CONTRACT_EMPLOYEES}/${employeeId}`, payload)
+      return resp.data.data as data
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || 'Update contract employee failed')
+    }
+  }
+)

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -622,6 +622,12 @@ import userAddReducer from '../slices/user/add/reducer'
 import userUpdateReducer from '../slices/user/update/reducer'
 import userDeleteReducer from '../slices/user/delete/reducer'
 
+import contractEmployeeListSlice from '../slices/contractEmployees/list/reducer'
+import contractEmployeeShowSlice from '../slices/contractEmployees/detail/reducer'
+import contractEmployeeAddSlice from '../slices/contractEmployees/add/reducer'
+import contractEmployeeUpdateSlice from '../slices/contractEmployees/update/reducer'
+import contractEmployeeDeleteSlice from '../slices/contractEmployees/delete/reducer'
+
 import financeNotesSlice from '../slices/financeNotes/list/reducer';
 
 
@@ -740,6 +746,11 @@ const combinedReducer = combineReducers({
   personelUpdate: personelUpdateSlice,
   personelDelete: personelDeleteSlice,
   personelShow: personelShowSlice,
+  contractEmployeeList: contractEmployeeListSlice,
+  contractEmployeeShow: contractEmployeeShowSlice,
+  contractEmployeeAdd: contractEmployeeAddSlice,
+  contractEmployeeUpdate: contractEmployeeUpdateSlice,
+  contractEmployeeDelete: contractEmployeeDeleteSlice,
 
 
   deleteCourse: coursesDeleteSlice,

--- a/src/types/contractEmployees/add.tsx
+++ b/src/types/contractEmployees/add.tsx
@@ -1,0 +1,27 @@
+import { data } from './list'
+import { ContractEmployeesListStatus } from '../../enums/contractEmployees/list'
+
+export interface ContractEmployeesAddPayload {
+  id: number
+  branch: string
+  branch_id: number
+  contract_type_id: number
+  profession_id: number
+  full_name: string
+  contract_type: number
+  weekly_workdays: number
+  weekly_lessons_count: number
+  monthly_count: number
+  salary: string
+  lesson_rate: string
+  question_rate: string
+  daily_rate: string
+  private_lesson_rate: string
+  coaching_rate: string
+}
+
+export interface ContractEmployeesAddState {
+  data: data | null
+  status: ContractEmployeesListStatus
+  error: string | null
+}

--- a/src/types/contractEmployees/delete.tsx
+++ b/src/types/contractEmployees/delete.tsx
@@ -1,0 +1,12 @@
+import { data } from './list'
+import ContractEmployeesListStatus from '../../enums/contractEmployees/list'
+
+export interface ContractEmployeesDeletePayload {
+  id?: number
+}
+
+export interface ContractEmployeesDeleteState {
+  data: data | null
+  status: ContractEmployeesListStatus
+  error: string | null
+}

--- a/src/types/contractEmployees/detail.tsx
+++ b/src/types/contractEmployees/detail.tsx
@@ -1,0 +1,8 @@
+import { data } from './list'
+import ContractEmployeesListStatus from '../../enums/contractEmployees/list'
+
+export interface ContractEmployeeShowState {
+  data: data | null
+  status: ContractEmployeesListStatus
+  error: string | null
+}

--- a/src/types/contractEmployees/list.tsx
+++ b/src/types/contractEmployees/list.tsx
@@ -1,0 +1,48 @@
+export interface data {
+  branch: string
+  branch_id: number
+  contract_type_id: number
+  profession_id: number
+  full_name: string
+  contract_type: number
+  weekly_workdays: number
+  weekly_lessons_count: number
+  monthly_count: number
+  salary: string
+  lesson_rate: string
+  question_rate: string
+  daily_rate: string
+  private_lesson_rate: string
+  coaching_rate: string
+}
+
+export interface meta {
+  current_page: number
+  from: number
+  last_page: number
+  links: {
+    url: string | null
+    label: string
+    active: boolean
+  }[]
+  path: string
+  per_page: number
+  to: number
+  total: number
+}
+
+export interface ListContractEmployeesResponse {
+  data: data[]
+  links: {
+    first: string
+    last: string
+    prev: string | null
+    next: string | null
+  }
+  meta: meta
+}
+
+export interface ContractEmployeeListArg {
+  enabled?: boolean
+  [key: string]: any
+}

--- a/src/types/contractEmployees/update.tsx
+++ b/src/types/contractEmployees/update.tsx
@@ -1,0 +1,29 @@
+import { data } from './list'
+import ContractEmployeesListStatus from '../../enums/contractEmployees/list'
+
+export interface ContractEmployeesUpdatePayload {
+  employeeId: number
+  payload: {
+    branch?: string
+    branch_id?: number
+    contract_type_id?: number
+    profession_id?: number
+    full_name?: string
+    contract_type?: number
+    weekly_workdays?: number
+    weekly_lessons_count?: number
+    monthly_count?: number
+    salary?: string
+    lesson_rate?: string
+    question_rate?: string
+    daily_rate?: string
+    private_lesson_rate?: string
+    coaching_rate?: string
+  }
+}
+
+export interface ContractEmployeesUpdateState {
+  data: data | null
+  status: ContractEmployeesListStatus
+  error: string | null
+}


### PR DESCRIPTION
## Summary
- implement contractEmployees CRUD redux slices, thunks, enums and types
- add hooks for contractEmployees actions
- integrate new slices into root reducer
- restore root reducer without removing existing logic

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_6862980fd4ac832c816b4b3336f79b04