### PR TITLE
Refactor employee earnings modals

### DIFF
--- a/src/components/common/employeeWorkAccruals/pages/accrual/month/crud.tsx
+++ b/src/components/common/employeeWorkAccruals/pages/accrual/month/crud.tsx
@@ -2,53 +2,47 @@ import { useState, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import ReusableTable, { ColumnDefinition } from '../../../../ReusableTable'
 import FilterGroup from '../../../component/organisms/SearchFilters'
-import ReusableModalForm from '../../../../ReusableModalForm'
 import { useEmployeeEarningsTable } from '../../../../../hooks/employeeEarnings/useList'
 
 interface Row { [key: string]: any }
 
 function MonthlyDataModal({ show, row, onClose }: { show: boolean; row: Row | null; onClose: () => void }) {
-    const fields = [
-        {
-            name: 'info',
-            label: '',
-            renderForm: () => (
-                <div className='overflow-x-auto'>
-                    <table className='min-w-full text-sm'>
-                        <thead>
-                            <tr>
-                                <th className='text-left p-2'>Gelir Türü</th>
-                                <th className='text-left p-2'>Sayı</th>
-                                <th className='text-left p-2'>Birim Ücret ₺</th>
-                                <th className='text-left p-2'>Tutar ₺</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {['base', 'lesson', 'question', 'daily', 'coaching', 'private', 'bonus', 'other'].map(k => (
-                                <tr key={k} className='border-t'>
-                                    <td className='p-2'>{k}</td>
-                                    <td className='p-2'>{(row as any)[`${k}_qty`]}</td>
-                                    <td className='p-2'>{(row as any)[`${k}_unit`]}</td>
-                                    <td className='p-2'>{(row as any)[k]}</td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
-            )
-        }
-    ]
+    interface Item {
+        label: string
+        qty: number
+        unit: number
+        total: number
+    }
+
+    const data: Item[] = useMemo(() => {
+        if (!row) return []
+        return ['base', 'lesson', 'question', 'daily', 'coaching', 'private', 'bonus', 'other'].map(k => ({
+            label: k,
+            qty: Number((row as any)[`${k}_qty`] ?? 0),
+            unit: Number((row as any)[`${k}_unit`] ?? 0),
+            total: Number((row as any)[k] ?? 0)
+        }))
+    }, [row])
+
+    const columns: ColumnDefinition<Item>[] = useMemo(
+        () => [
+            { key: 'label', label: 'Gelir Türü', render: r => r.label },
+            { key: 'qty', label: 'Sayı', render: r => r.qty },
+            { key: 'unit', label: 'Birim Ücret ₺', render: r => r.unit },
+            { key: 'total', label: 'Tutar ₺', render: r => r.total }
+        ],
+        []
+    )
+
     return (
-        <ReusableModalForm
-            show={show}
-            title={row?.full_name || ''}
-            fields={fields as any}
-            initialValues={{}}
-            onSubmit={() => onClose()}
-            confirmButtonLabel='Tamam'
-            cancelButtonLabel='Kapat'
-            onClose={onClose}
-            mode='single'
+        <ReusableTable<Item>
+            showModal={show}
+            onCloseModal={onClose}
+            modalTitle={row?.full_name || ''}
+            columns={columns}
+            data={data}
+            tableMode='single'
+            showExportButtons={false}
         />
     )
 }

--- a/src/components/common/employeeWorkAccruals/pages/accrual/month/table.tsx
+++ b/src/components/common/employeeWorkAccruals/pages/accrual/month/table.tsx
@@ -30,52 +30,48 @@ function MonthlyDataModal({
         { key: 'other', label: 'Farklı Ücret', qty: Number(row?.other_qty || 0), unit: Number(row?.other_unit || 0) }
     ])
     const total = useMemo(() => items.reduce((s, i) => s + i.qty * i.unit, 0), [items])
+
+    const columns: ColumnDefinition<typeof items[number]>[] = useMemo(
+        () => [
+            { key: 'label', label: 'Gelir Türü', render: r => r.label },
+            {
+                key: 'qty',
+                label: 'Sayı',
+                render: (r, _o, idx) => (
+                    <input
+                        type='number'
+                        className='form-control w-24'
+                        value={r.qty}
+                        disabled={readOnly}
+                        onChange={e => {
+                            const v = Number(e.target.value)
+                            setItems(arr => arr.map((it, i) => (i === idx ? { ...it, qty: v } : it)))
+                        }}
+                    />
+                )
+            },
+            { key: 'unit', label: 'Birim Ücret ₺', render: r => r.unit.toLocaleString() },
+            { key: 'total', label: 'Tutar ₺', render: r => (r.qty * r.unit).toLocaleString() }
+        ],
+        [readOnly]
+    )
+
+    const tableFooter = (
+        <div className='text-end font-bold p-2'>Genel Toplam ₺ {total.toLocaleString()}</div>
+    )
+
     const fields: FieldDefinition[] = [
         {
             name: 'table',
             label: '',
             renderForm: () => (
-                <div className='overflow-x-auto'>
-                    <table className='min-w-full text-sm'>
-                        <thead>
-                            <tr>
-                                <th className='text-left p-2'>Gelir Türü</th>
-                                <th className='text-left p-2'>Sayı</th>
-                                <th className='text-left p-2'>Birim Ücret ₺</th>
-                                <th className='text-left p-2'>Tutar ₺</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {items.map((it, idx) => (
-                                <tr key={it.key} className='border-t'>
-                                    <td className='p-2'>{it.label}</td>
-                                    <td className='p-2'>
-                                        <input
-                                            type='number'
-                                            className='form-control w-24'
-                                            value={it.qty}
-                                            disabled={readOnly}
-                                            onChange={e => {
-                                                const v = Number(e.target.value)
-                                                setItems(arr => arr.map((r, i) => (i === idx ? { ...r, qty: v } : r)))
-                                            }}
-                                        />
-                                    </td>
-                                    <td className='p-2'>{it.unit.toLocaleString()}</td>
-                                    <td className='p-2'>{(it.qty * it.unit).toLocaleString()}</td>
-                                </tr>
-                            ))}
-                        </tbody>
-                        <tfoot>
-                            <tr className='font-bold border-t'>
-                                <td className='p-2 text-right' colSpan={3}>
-                                    Genel Toplam ₺
-                                </td>
-                                <td className='p-2'>{total.toLocaleString()}</td>
-                            </tr>
-                        </tfoot>
-                    </table>
-                </div>
+                <ReusableTable<typeof items[number]>
+                    tableMode='single'
+                    columns={columns}
+                    data={items}
+                    showExportButtons={false}
+                    customFooter={tableFooter}
+                />
             )
         }
     ]


### PR DESCRIPTION
## Summary
- switch monthly accrual detail modal to `ReusableTable`
- embed `ReusableTable` inside monthly accrual edit modal

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6862c9ef14a8832cbf1422c3d9eb7f3e