### PR TITLE
Fix employee earnings list response

### DIFF
--- a/src/components/hooks/employeeEarnings/useList.tsx
+++ b/src/components/hooks/employeeEarnings/useList.tsx
@@ -5,7 +5,7 @@ import { AppDispatch } from '../../../store'
 import { fetchEmployeeEarnings } from '../../../slices/employeeEarnings/list/thunk'
 import {
   data,
-  meta,
+  PaginationMeta,
   EarningListArg
 } from '../../../types/employeeEarnings/list'
 import { EmployeeEarningsListStatus } from '../../../enums/employeeEarnings/list'
@@ -65,7 +65,7 @@ export function useEmployeeEarningsTable(params: EarningListArg) {
 
   const loading = status === EmployeeEarningsListStatus.LOADING
   const employeeEarningsData: data[] = data || []
-  const paginationMeta: meta | null = meta
+  const paginationMeta: PaginationMeta | null = meta
   const totalPages = paginationMeta ? paginationMeta.last_page : 1
   const totalItems = paginationMeta ? paginationMeta.total : 0
 

--- a/src/slices/employeeEarnings/list/reducer.tsx
+++ b/src/slices/employeeEarnings/list/reducer.tsx
@@ -1,19 +1,17 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { fetchEmployeeEarnings } from './thunk'
-import { ListEmployeeEarningsResponse } from '../../../types/employeeEarnings/list'
+import { ListEmployeeEarningsResponse, PaginationMeta } from '../../../types/employeeEarnings/list'
 import { EmployeeEarningsListStatus } from '../../../enums/employeeEarnings/list'
 
 export interface EmployeeEarningListState {
   data: ListEmployeeEarningsResponse['data'] | null
-  links: ListEmployeeEarningsResponse['links'] | null
-  meta: ListEmployeeEarningsResponse['meta'] | null
+  meta: PaginationMeta | null
   status: EmployeeEarningsListStatus
   error: string | null
 }
 
 const initialState: EmployeeEarningListState = {
   data: null,
-  links: null,
   meta: null,
   status: EmployeeEarningsListStatus.IDLE,
   error: null
@@ -33,8 +31,20 @@ const employeeEarningListSlice = createSlice({
       (state, action: PayloadAction<ListEmployeeEarningsResponse>) => {
         state.status = EmployeeEarningsListStatus.SUCCEEDED
         state.data = action.payload.data
-        state.links = action.payload.links
-        state.meta = action.payload.meta
+        state.meta = {
+          current_page: action.payload.current_page,
+          first_page_url: action.payload.first_page_url,
+          from: action.payload.from,
+          last_page: action.payload.last_page,
+          last_page_url: action.payload.last_page_url,
+          next_page_url: action.payload.next_page_url,
+          path: action.payload.path,
+          per_page: action.payload.per_page,
+          prev_page_url: action.payload.prev_page_url,
+          to: action.payload.to,
+          total: action.payload.total,
+          links: action.payload.links
+        }
       }
     )
     builder.addCase(fetchEmployeeEarnings.rejected, (state, action: PayloadAction<any>) => {

--- a/src/types/employeeEarnings/list.tsx
+++ b/src/types/employeeEarnings/list.tsx
@@ -11,30 +11,41 @@ export interface data {
   platform_id: number | null
 }
 
-export interface meta {
+export interface ILink {
+  url: string | null
+  label: string
+  active: boolean
+}
+
+export interface PaginationMeta {
   current_page: number
+  first_page_url: string
   from: number
   last_page: number
-  links: {
-    url: string | null
-    label: string
-    active: boolean
-  }[]
+  last_page_url: string
+  next_page_url: string | null
   path: string
   per_page: number
+  prev_page_url: string | null
   to: number
   total: number
+  links: ILink[]
 }
 
 export interface ListEmployeeEarningsResponse {
   data: data[]
-  links: {
-    first: string
-    last: string
-    prev: string | null
-    next: string | null
-  }
-  meta: meta
+  current_page: number
+  first_page_url: string
+  from: number
+  last_page: number
+  last_page_url: string
+  links: ILink[]
+  next_page_url: string | null
+  path: string
+  per_page: number
+  prev_page_url: string | null
+  to: number
+  total: number
 }
 
 export interface EarningListArg {


### PR DESCRIPTION
## Summary
- update employee earnings list types with root-level pagination fields
- adapt employee earnings slice and hook for new API response

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6862d0ce190c832caf3bf0f9df4ca754