### PR TITLE
Add monthly employee earnings slice

### DIFF
--- a/src/enums/employeeEarningsMonth/list.tsx
+++ b/src/enums/employeeEarningsMonth/list.tsx
@@ -1,0 +1,8 @@
+export enum EmployeeEarningsMonthListStatus {
+  IDLE = 'IDLE',
+  LOADING = 'LOADING',
+  SUCCEEDED = 'SUCCEEDED',
+  FAILED = 'FAILED',
+}
+
+export default EmployeeEarningsMonthListStatus;

--- a/src/helpers/url_helper.ts
+++ b/src/helpers/url_helper.ts
@@ -174,4 +174,5 @@ export const NOTIFICATIONS = '/notifications';
 export const NOTIFICATIONUSERS = '/notificationusers';
 export const CONTRACT_EMPLOYEES = '/contract-employees';
 export const EMPLOYEE_EARNINGS = '/personel-hakedis';
+export const EMPLOYEE_EARNINGS_MONTH = '/personel-hakedis/ay';
 

--- a/src/slices/employeeEarningsMonth/add/reducer.tsx
+++ b/src/slices/employeeEarningsMonth/add/reducer.tsx
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { addEmployeeEarningsMonth } from './thunk';
+import { EmployeeEarningsMonthAddState } from '../../../types/employeeEarningsMonth/add';
+import EmployeeEarningsMonthListStatus from '../../../enums/employeeEarningsMonth/list';
+
+const initialState: EmployeeEarningsMonthAddState = {
+  data: null,
+  status: EmployeeEarningsMonthListStatus.IDLE,
+  error: null,
+};
+
+const employeeEarningsMonthAddSlice = createSlice({
+  name: 'employeeEarningsMonth/add',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(addEmployeeEarningsMonth.pending, state => {
+        state.status = EmployeeEarningsMonthListStatus.LOADING;
+        state.error = null;
+      })
+      .addCase(addEmployeeEarningsMonth.fulfilled, (state, action: PayloadAction<any>) => {
+        state.status = EmployeeEarningsMonthListStatus.SUCCEEDED;
+        state.data = action.payload;
+      })
+      .addCase(addEmployeeEarningsMonth.rejected, (state, action: PayloadAction<any>) => {
+        state.status = EmployeeEarningsMonthListStatus.FAILED;
+        state.error = action.payload;
+      });
+  },
+});
+
+export default employeeEarningsMonthAddSlice.reducer;

--- a/src/slices/employeeEarningsMonth/add/thunk.tsx
+++ b/src/slices/employeeEarningsMonth/add/thunk.tsx
@@ -1,0 +1,17 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import axiosInstance from '../../../services/axiosClient';
+import { EMPLOYEE_EARNINGS_MONTH } from '../../../helpers/url_helper';
+import { EmployeeEarningsMonthAddPayload } from '../../../types/employeeEarningsMonth/add';
+import { EmployeeMonth } from '../../../types/employeeEarningsMonth/list';
+
+export const addEmployeeEarningsMonth = createAsyncThunk<EmployeeMonth, EmployeeEarningsMonthAddPayload>(
+  'employeeEarningsMonth/add',
+  async (payload, { rejectWithValue }) => {
+    try {
+      const resp = await axiosInstance.post(EMPLOYEE_EARNINGS_MONTH, payload);
+      return resp.data.data as EmployeeMonth;
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || 'Add employee monthly earning failed');
+    }
+  }
+);

--- a/src/slices/employeeEarningsMonth/delete/reducer.tsx
+++ b/src/slices/employeeEarningsMonth/delete/reducer.tsx
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { deleteEmployeeEarningsMonth } from './thunk';
+import { EmployeeEarningsMonthDeleteState } from '../../../types/employeeEarningsMonth/delete';
+import EmployeeEarningsMonthListStatus from '../../../enums/employeeEarningsMonth/list';
+
+const initialState: EmployeeEarningsMonthDeleteState = {
+  data: null,
+  status: EmployeeEarningsMonthListStatus.IDLE,
+  error: null,
+};
+
+const employeeEarningsMonthDeleteSlice = createSlice({
+  name: 'employeeEarningsMonth/delete',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(deleteEmployeeEarningsMonth.pending, state => {
+        state.status = EmployeeEarningsMonthListStatus.LOADING;
+        state.error = null;
+      })
+      .addCase(deleteEmployeeEarningsMonth.fulfilled, (state, action: PayloadAction<any>) => {
+        state.status = EmployeeEarningsMonthListStatus.SUCCEEDED;
+        state.data = action.payload as any;
+      })
+      .addCase(deleteEmployeeEarningsMonth.rejected, (state, action: PayloadAction<any>) => {
+        state.status = EmployeeEarningsMonthListStatus.FAILED;
+        state.error = action.payload;
+      });
+  },
+});
+
+export default employeeEarningsMonthDeleteSlice.reducer;

--- a/src/slices/employeeEarningsMonth/delete/thunk.tsx
+++ b/src/slices/employeeEarningsMonth/delete/thunk.tsx
@@ -1,0 +1,16 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import axiosInstance from '../../../services/axiosClient';
+import { EMPLOYEE_EARNINGS_MONTH } from '../../../helpers/url_helper';
+import { EmployeeEarningsMonthDeleteState } from '../../../types/employeeEarningsMonth/delete';
+
+export const deleteEmployeeEarningsMonth = createAsyncThunk<EmployeeEarningsMonthDeleteState, number>(
+  'employeeEarningsMonth/delete',
+  async (id, { rejectWithValue }) => {
+    try {
+      const resp = await axiosInstance.delete(`${EMPLOYEE_EARNINGS_MONTH}/${id}`);
+      return resp.data as EmployeeEarningsMonthDeleteState;
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || 'Delete employee monthly earning failed');
+    }
+  }
+);

--- a/src/slices/employeeEarningsMonth/detail/reducer.tsx
+++ b/src/slices/employeeEarningsMonth/detail/reducer.tsx
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { fetchEmployeeEarningsMonthDetail } from './thunk';
+import { EmployeeEarningsMonthDetailState } from '../../../types/employeeEarningsMonth/detail';
+import EmployeeEarningsMonthListStatus from '../../../enums/employeeEarningsMonth/list';
+
+const initialState: EmployeeEarningsMonthDetailState = {
+  data: null,
+  status: EmployeeEarningsMonthListStatus.IDLE,
+  error: null,
+};
+
+const employeeEarningsMonthDetailSlice = createSlice({
+  name: 'employeeEarningsMonth/detail',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(fetchEmployeeEarningsMonthDetail.pending, state => {
+        state.status = EmployeeEarningsMonthListStatus.LOADING;
+        state.error = null;
+      })
+      .addCase(fetchEmployeeEarningsMonthDetail.fulfilled, (state, action: PayloadAction<any>) => {
+        state.status = EmployeeEarningsMonthListStatus.SUCCEEDED;
+        state.data = action.payload;
+      })
+      .addCase(fetchEmployeeEarningsMonthDetail.rejected, (state, action: PayloadAction<any>) => {
+        state.status = EmployeeEarningsMonthListStatus.FAILED;
+        state.error = action.payload;
+      });
+  },
+});
+
+export default employeeEarningsMonthDetailSlice.reducer;

--- a/src/slices/employeeEarningsMonth/detail/thunk.tsx
+++ b/src/slices/employeeEarningsMonth/detail/thunk.tsx
@@ -1,0 +1,16 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import axiosInstance from '../../../services/axiosClient';
+import { EMPLOYEE_EARNINGS_MONTH } from '../../../helpers/url_helper';
+import { EmployeeEarningsMonthDetailState } from '../../../types/employeeEarningsMonth/detail';
+
+export const fetchEmployeeEarningsMonthDetail = createAsyncThunk<EmployeeEarningsMonthDetailState['data'], number>(
+  'employeeEarningsMonth/fetchDetail',
+  async (id, { rejectWithValue }) => {
+    try {
+      const resp = await axiosInstance.get(`${EMPLOYEE_EARNINGS_MONTH}/${id}`);
+      return resp.data.data as EmployeeEarningsMonthDetailState['data'];
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || 'Fetch employee monthly earning failed');
+    }
+  }
+);

--- a/src/slices/employeeEarningsMonth/list/reducer.tsx
+++ b/src/slices/employeeEarningsMonth/list/reducer.tsx
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { fetchEmployeeEarningsMonth } from './thunk';
+import { EmployeeEarningsMonthListState } from '../../../types/employeeEarningsMonth/list';
+import EmployeeEarningsMonthListStatus from '../../../enums/employeeEarningsMonth/list';
+
+const initialState: EmployeeEarningsMonthListState = {
+  data: null,
+  status: EmployeeEarningsMonthListStatus.IDLE,
+  error: null,
+};
+
+const employeeEarningsMonthListSlice = createSlice({
+  name: 'employeeEarningsMonth/list',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(fetchEmployeeEarningsMonth.pending, state => {
+        state.status = EmployeeEarningsMonthListStatus.LOADING;
+        state.error = null;
+      })
+      .addCase(fetchEmployeeEarningsMonth.fulfilled, (state, action: PayloadAction<any>) => {
+        state.status = EmployeeEarningsMonthListStatus.SUCCEEDED;
+        state.data = action.payload;
+      })
+      .addCase(fetchEmployeeEarningsMonth.rejected, (state, action: PayloadAction<any>) => {
+        state.status = EmployeeEarningsMonthListStatus.FAILED;
+        state.error = action.payload;
+      });
+  },
+});
+
+export default employeeEarningsMonthListSlice.reducer;

--- a/src/slices/employeeEarningsMonth/list/thunk.tsx
+++ b/src/slices/employeeEarningsMonth/list/thunk.tsx
@@ -1,0 +1,24 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import axiosInstance from '../../../services/axiosClient';
+import { EMPLOYEE_EARNINGS_MONTH } from '../../../helpers/url_helper';
+import { EmployeeEarningsMonthListArgs, EmployeeEarningsMonthListState } from '../../../types/employeeEarningsMonth/list';
+
+export const fetchEmployeeEarningsMonth = createAsyncThunk<EmployeeEarningsMonthListState['data'], EmployeeEarningsMonthListArgs>(
+  'employeeEarningsMonth/fetchList',
+  async (queryParams, { rejectWithValue }) => {
+    try {
+      const query = new URLSearchParams();
+      Object.entries(queryParams).forEach(([key, value]) => {
+        if (key === 'enabled') return;
+        if (value !== undefined && value !== null) {
+          query.append(key, String(value));
+        }
+      });
+      const url = `${EMPLOYEE_EARNINGS_MONTH}?${query.toString()}`;
+      const resp = await axiosInstance.get(url);
+      return resp.data as EmployeeEarningsMonthListState['data'];
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || 'Fetch employee monthly earnings failed');
+    }
+  }
+);

--- a/src/slices/employeeEarningsMonth/update/reducer.tsx
+++ b/src/slices/employeeEarningsMonth/update/reducer.tsx
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { updateEmployeeEarningsMonth } from './thunk';
+import { EmployeeEarningsMonthUpdateState } from '../../../types/employeeEarningsMonth/update';
+import EmployeeEarningsMonthListStatus from '../../../enums/employeeEarningsMonth/list';
+
+const initialState: EmployeeEarningsMonthUpdateState = {
+  data: null,
+  status: EmployeeEarningsMonthListStatus.IDLE,
+  error: null,
+};
+
+const employeeEarningsMonthUpdateSlice = createSlice({
+  name: 'employeeEarningsMonth/update',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(updateEmployeeEarningsMonth.pending, state => {
+        state.status = EmployeeEarningsMonthListStatus.LOADING;
+        state.error = null;
+      })
+      .addCase(updateEmployeeEarningsMonth.fulfilled, (state, action: PayloadAction<any>) => {
+        state.status = EmployeeEarningsMonthListStatus.SUCCEEDED;
+        state.data = action.payload;
+      })
+      .addCase(updateEmployeeEarningsMonth.rejected, (state, action: PayloadAction<any>) => {
+        state.status = EmployeeEarningsMonthListStatus.FAILED;
+        state.error = action.payload;
+      });
+  },
+});
+
+export default employeeEarningsMonthUpdateSlice.reducer;

--- a/src/slices/employeeEarningsMonth/update/thunk.tsx
+++ b/src/slices/employeeEarningsMonth/update/thunk.tsx
@@ -1,0 +1,17 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import axiosInstance from '../../../services/axiosClient';
+import { EMPLOYEE_EARNINGS_MONTH } from '../../../helpers/url_helper';
+import { EmployeeEarningsMonthUpdatePayload } from '../../../types/employeeEarningsMonth/update';
+import { EmployeeMonth } from '../../../types/employeeEarningsMonth/list';
+
+export const updateEmployeeEarningsMonth = createAsyncThunk<EmployeeMonth, EmployeeEarningsMonthUpdatePayload>(
+  'employeeEarningsMonth/update',
+  async ({ id, payload }, { rejectWithValue }) => {
+    try {
+      const resp = await axiosInstance.put(`${EMPLOYEE_EARNINGS_MONTH}/${id}`, payload);
+      return resp.data.data as EmployeeMonth;
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || 'Update employee monthly earning failed');
+    }
+  }
+);

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -634,6 +634,12 @@ import employeeEarningAddSlice from '../slices/employeeEarnings/add/reducer'
 import employeeEarningUpdateSlice from '../slices/employeeEarnings/update/reducer'
 import employeeEarningDeleteSlice from '../slices/employeeEarnings/delete/reducer'
 
+import employeeEarningsMonthListSlice from '../slices/employeeEarningsMonth/list/reducer'
+import employeeEarningsMonthDetailSlice from '../slices/employeeEarningsMonth/detail/reducer'
+import employeeEarningsMonthAddSlice from '../slices/employeeEarningsMonth/add/reducer'
+import employeeEarningsMonthUpdateSlice from '../slices/employeeEarningsMonth/update/reducer'
+import employeeEarningsMonthDeleteSlice from '../slices/employeeEarningsMonth/delete/reducer'
+
 import financeNotesSlice from '../slices/financeNotes/list/reducer';
 
 
@@ -762,6 +768,11 @@ const combinedReducer = combineReducers({
   employeeEarningAdd: employeeEarningAddSlice,
   employeeEarningUpdate: employeeEarningUpdateSlice,
   employeeEarningDelete: employeeEarningDeleteSlice,
+  employeeEarningsMonthList: employeeEarningsMonthListSlice,
+  employeeEarningsMonthDetail: employeeEarningsMonthDetailSlice,
+  employeeEarningsMonthAdd: employeeEarningsMonthAddSlice,
+  employeeEarningsMonthUpdate: employeeEarningsMonthUpdateSlice,
+  employeeEarningsMonthDelete: employeeEarningsMonthDeleteSlice,
 
 
   deleteCourse: coursesDeleteSlice,

--- a/src/types/employeeEarningsMonth/add.tsx
+++ b/src/types/employeeEarningsMonth/add.tsx
@@ -1,0 +1,10 @@
+import { EmployeeMonth } from './list';
+import EmployeeEarningsMonthListStatus from '../../enums/employeeEarningsMonth/list';
+
+export interface EmployeeEarningsMonthAddPayload extends EmployeeMonth {}
+
+export interface EmployeeEarningsMonthAddState {
+  data: EmployeeMonth | null;
+  status: EmployeeEarningsMonthListStatus;
+  error: string | null;
+}

--- a/src/types/employeeEarningsMonth/delete.tsx
+++ b/src/types/employeeEarningsMonth/delete.tsx
@@ -1,0 +1,12 @@
+import { EmployeeMonth } from './list';
+import EmployeeEarningsMonthListStatus from '../../enums/employeeEarningsMonth/list';
+
+export interface EmployeeEarningsMonthDeletePayload {
+  id?: number;
+}
+
+export interface EmployeeEarningsMonthDeleteState {
+  data: EmployeeMonth | null;
+  status: EmployeeEarningsMonthListStatus;
+  error: string | null;
+}

--- a/src/types/employeeEarningsMonth/detail.tsx
+++ b/src/types/employeeEarningsMonth/detail.tsx
@@ -1,0 +1,8 @@
+import { EmployeeMonth } from './list';
+import EmployeeEarningsMonthListStatus from '../../enums/employeeEarningsMonth/list';
+
+export interface EmployeeEarningsMonthDetailState {
+  data: EmployeeMonth | null;
+  status: EmployeeEarningsMonthListStatus;
+  error: string | null;
+}

--- a/src/types/employeeEarningsMonth/list.tsx
+++ b/src/types/employeeEarningsMonth/list.tsx
@@ -1,0 +1,36 @@
+import EmployeeEarningsMonthListStatus from '../../enums/employeeEarningsMonth/list';
+
+export interface EarningItem {
+  id: number;
+  employee_id: number;
+  period: string;
+  income_type: string;
+  quantity: string;
+  unit_price: string;
+  total: string;
+  created_at: string;
+  updated_at: string;
+  platform_id: number | null;
+}
+
+export interface EmployeeMonth {
+  employee_id: number;
+  first_name: string | null;
+  last_name: string | null;
+  branch_id: number | null;
+  profession_id: number | null;
+  branch: string | null;
+  profession: string | null;
+  items: EarningItem[];
+}
+
+export interface EmployeeEarningsMonthListState {
+  data: EmployeeMonth[] | null;
+  status: EmployeeEarningsMonthListStatus;
+  error: string | null;
+}
+
+export interface EmployeeEarningsMonthListArgs {
+  enabled?: boolean;
+  [key: string]: any;
+}

--- a/src/types/employeeEarningsMonth/update.tsx
+++ b/src/types/employeeEarningsMonth/update.tsx
@@ -1,0 +1,13 @@
+import { EmployeeMonth } from './list';
+import EmployeeEarningsMonthListStatus from '../../enums/employeeEarningsMonth/list';
+
+export interface EmployeeEarningsMonthUpdatePayload {
+  id: number;
+  payload: Partial<EmployeeMonth>;
+}
+
+export interface EmployeeEarningsMonthUpdateState {
+  data: EmployeeMonth | null;
+  status: EmployeeEarningsMonthListStatus;
+  error: string | null;
+}


### PR DESCRIPTION
## Summary
- add `EMPLOYEE_EARNINGS_MONTH` helper
- add enum and types for employee monthly earnings
- implement CRUD slices for employee monthly earnings
- register reducers in root reducer

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6862dd3bb5dc832ca7994d450017faf7