### PR TITLE
Add employeeEarningsMonth hooks

### DIFF
--- a/src/components/hooks/employeeEarningsMonth/useAdd.tsx
+++ b/src/components/hooks/employeeEarningsMonth/useAdd.tsx
@@ -1,0 +1,31 @@
+import { useCallback } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { AppDispatch } from "../../../store";
+import { RootState } from "../../../store/rootReducer";
+import { addEmployeeEarningsMonth } from "../../../slices/employeeEarningsMonth/add/thunk";
+import { EmployeeEarningsMonthAddPayload } from "../../../types/employeeEarningsMonth/add";
+
+export function useEmployeeEarningsMonthAdd() {
+  const dispatch = useDispatch<AppDispatch>();
+  const { data, status, error } = useSelector(
+    (state: RootState) => state.employeeEarningsMonthAdd
+  );
+
+  const addNewEmployeeEarningsMonth = useCallback(
+    async (payload: EmployeeEarningsMonthAddPayload) => {
+      const resultAction = await dispatch(addEmployeeEarningsMonth(payload));
+      if (addEmployeeEarningsMonth.fulfilled.match(resultAction)) {
+        return resultAction.payload;
+      }
+      return null;
+    },
+    [dispatch]
+  );
+
+  return {
+    addedEmployeeEarningsMonth: data,
+    status,
+    error,
+    addNewEmployeeEarningsMonth
+  };
+}

--- a/src/components/hooks/employeeEarningsMonth/useDelete.tsx
+++ b/src/components/hooks/employeeEarningsMonth/useDelete.tsx
@@ -1,0 +1,30 @@
+import { useCallback } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { AppDispatch } from "../../../store";
+import { RootState } from "../../../store/rootReducer";
+import { deleteEmployeeEarningsMonth } from "../../../slices/employeeEarningsMonth/delete/thunk";
+
+export function useEmployeeEarningsMonthDelete() {
+  const dispatch = useDispatch<AppDispatch>();
+  const { data, status, error } = useSelector(
+    (state: RootState) => state.employeeEarningsMonthDelete
+  );
+
+  const deleteExistingEmployeeEarningsMonth = useCallback(
+    async (id: number) => {
+      const resultAction = await dispatch(deleteEmployeeEarningsMonth(id));
+      if (deleteEmployeeEarningsMonth.fulfilled.match(resultAction)) {
+        return resultAction.payload;
+      }
+      return null;
+    },
+    [dispatch]
+  );
+
+  return {
+    deletedEmployeeEarningsMonth: data,
+    status,
+    error,
+    deleteExistingEmployeeEarningsMonth
+  };
+}

--- a/src/components/hooks/employeeEarningsMonth/useDetail.tsx
+++ b/src/components/hooks/employeeEarningsMonth/useDetail.tsx
@@ -1,0 +1,30 @@
+import { useCallback } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { AppDispatch } from "../../../store";
+import { RootState } from "../../../store/rootReducer";
+import { fetchEmployeeEarningsMonth } from "../../../slices/employeeEarningsMonth/detail/thunk";
+
+export function useEmployeeEarningsMonthShow() {
+  const dispatch = useDispatch<AppDispatch>();
+  const { data, status, error } = useSelector(
+    (state: RootState) => state.employeeEarningsMonthShow
+  );
+
+  const getEmployeeEarningsMonth = useCallback(
+    async (id: number) => {
+      const resultAction = await dispatch(fetchEmployeeEarningsMonth(id));
+      if (fetchEmployeeEarningsMonth.fulfilled.match(resultAction)) {
+        return resultAction.payload;
+      }
+      return null;
+    },
+    [dispatch]
+  );
+
+  return {
+    employeeEarningsMonth: data,
+    status,
+    error,
+    getEmployeeEarningsMonth
+  };
+}

--- a/src/components/hooks/employeeEarningsMonth/useList.tsx
+++ b/src/components/hooks/employeeEarningsMonth/useList.tsx
@@ -1,0 +1,72 @@
+import { useState, useEffect, useMemo } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "../../../store/rootReducer";
+import { AppDispatch } from "../../../store";
+import { fetchEmployeeEarningsMonthList } from "../../../slices/employeeEarningsMonth/list/thunk";
+import {
+  EmployeeEarningsMonthData,
+  EmployeeEarningsMonthListArgs
+} from "../../../types/employeeEarningsMonth/list";
+import EmployeeEarningsMonthListStatus from "../../../enums/employeeEarningsMonth/list";
+
+export function useEmployeeEarningsMonthList(params: EmployeeEarningsMonthListArgs) {
+  if (params?.enabled === false) {
+    return {
+      employeeEarningsMonthData: [] as EmployeeEarningsMonthData[],
+      loading: false,
+      error: null,
+      page: 1,
+      setPage: () => {},
+      paginate: 10,
+      setPaginate: () => {},
+      filter: null,
+      setFilter: () => {},
+      totalPages: 1,
+      totalItems: 0
+    };
+  }
+
+  const { enabled = true, page: initialPage = 1, paginate: initialPaginate = 10, ...restParams } = params;
+
+  const dispatch = useDispatch<AppDispatch>();
+  const [page, setPage] = useState<number>(initialPage);
+  const [paginate, setPaginate] = useState<number>(initialPaginate);
+  const [filter, setFilter] = useState<any>(null);
+
+  const { data, status, error } = useSelector((state: RootState) => state.employeeEarningsMonthList);
+
+  const serializedRestParams = useMemo(() => JSON.stringify(restParams), [restParams]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const query: EmployeeEarningsMonthListArgs = {
+      enabled,
+      ...restParams,
+      filter,
+      page,
+      paginate
+    };
+
+    dispatch(fetchEmployeeEarningsMonthList(query));
+  }, [dispatch, enabled, serializedRestParams, filter, page, paginate]);
+
+  const loading = status === EmployeeEarningsMonthListStatus.LOADING;
+  const employeeEarningsMonthData: EmployeeEarningsMonthData[] = data || [];
+  const totalPages = 1;
+  const totalItems = employeeEarningsMonthData.length;
+
+  return {
+    employeeEarningsMonthData,
+    loading,
+    error,
+    page,
+    setPage,
+    paginate,
+    setPaginate,
+    filter,
+    setFilter,
+    totalPages,
+    totalItems
+  };
+}

--- a/src/components/hooks/employeeEarningsMonth/useUpdate.tsx
+++ b/src/components/hooks/employeeEarningsMonth/useUpdate.tsx
@@ -1,0 +1,31 @@
+import { useCallback } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { AppDispatch } from "../../../store";
+import { RootState } from "../../../store/rootReducer";
+import { updateEmployeeEarningsMonth } from "../../../slices/employeeEarningsMonth/update/thunk";
+import { EmployeeEarningsMonthUpdatePayload } from "../../../types/employeeEarningsMonth/update";
+
+export function useEmployeeEarningsMonthUpdate() {
+  const dispatch = useDispatch<AppDispatch>();
+  const { data, status, error } = useSelector(
+    (state: RootState) => state.employeeEarningsMonthUpdate
+  );
+
+  const updateExistingEmployeeEarningsMonth = useCallback(
+    async (payload: EmployeeEarningsMonthUpdatePayload) => {
+      const resultAction = await dispatch(updateEmployeeEarningsMonth(payload));
+      if (updateEmployeeEarningsMonth.fulfilled.match(resultAction)) {
+        return resultAction.payload;
+      }
+      return null;
+    },
+    [dispatch]
+  );
+
+  return {
+    updatedEmployeeEarningsMonth: data,
+    status,
+    error,
+    updateExistingEmployeeEarningsMonth
+  };
+}


### PR DESCRIPTION
## Summary
- add missing hooks for employeeEarningsMonth API

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6862e4810350832c979257c8e1391eaa