### PR TITLE
Fix EmployeeEarningsMonth paginator handling

### DIFF
--- a/src/components/common/employeeWorkAccruals/pages/accrual/month/table.tsx
+++ b/src/components/common/employeeWorkAccruals/pages/accrual/month/table.tsx
@@ -204,12 +204,15 @@ export default function EmployeeEarningsMonthTable() {
         const groups = new Map<string, Row>()
 
         employeeEarningsMonthData.forEach(e => {
-            const key = `${e.employee_id}-${e.period}`
+            const empId = e.employee_id ?? e.items?.[0]?.employee_id
+            if (!empId) return
+
+            const key = `${empId}-${e.period}`
             if (!groups.has(key)) {
-                const ce = ceMap.get(e.employee_id)
+                const ce = ceMap.get(empId)
                 const base: Row = {
                     id: key,
-                    employee_id: e.employee_id,
+                    employee_id: empId,
                     period: e.period,
                     bonus: 0,
                     other: 0,
@@ -217,10 +220,10 @@ export default function EmployeeEarningsMonthTable() {
                 }
                 if (ce) {
                     Object.assign(base, {
-                        branch: ce.branch,
+                        branch: ce.branch || '—',
                         branch_id: ce.branch_id,
                         profession_id: ce.profession_id,
-                        profession: profMap.get(ce.profession_id) || ce.profession_id,
+                        profession: profMap.get(ce.profession_id) || ce.profession_id || '—',
                         full_name: ce.full_name,
                         contract_type_text: (ce as any).contract_type_text,
                         weekly_workdays: ce.weekly_workdays,
@@ -231,6 +234,8 @@ export default function EmployeeEarningsMonthTable() {
                         coaching_rate: ce.coaching_rate,
                         salary: ce.salary
                     })
+                } else {
+                    Object.assign(base, { branch: '—', profession: '—' })
                 }
                 base.items = {}
                 groups.set(key, base)

--- a/src/components/hooks/employeeEarningsMonth/useList.tsx
+++ b/src/components/hooks/employeeEarningsMonth/useList.tsx
@@ -6,6 +6,7 @@ import { fetchEmployeeEarningsMonthList } from "../../../slices/employeeEarnings
 import {
   EmployeeEarningsMonthData,
   EmployeeEarningsMonthListArgs,
+  EmployeeEarningsMonthMeta,
 } from "../../../types/employeeEarningsMonth/list";
 import EmployeeEarningsMonthListStatus from "../../../enums/employeeEarningsMonth/list";
 
@@ -70,9 +71,14 @@ export function useEmployeeEarningsMonthList(
   const [paginate, setPaginate] = useState<number>(initialPaginate);
   const [filter, setFilter] = useState<any>(null);
 
-  const { data, status, error } = useSelector(
+  const { rows, meta, status, error } = useSelector(
     (state: RootState) => state.employeeEarningsMonthList
-  );
+  ) as {
+    rows: EmployeeEarningsMonthData[] | null
+    meta: EmployeeEarningsMonthMeta | null
+    status: EmployeeEarningsMonthListStatus
+    error: string | null
+  };
 
   /* -------------------------------------------------------------- */
   /* deterministik dependecy string                                  */
@@ -103,11 +109,10 @@ export function useEmployeeEarningsMonthList(
   /* geriye dönen değerler                                           */
   /* -------------------------------------------------------------- */
   const loading = status === EmployeeEarningsMonthListStatus.LOADING;
-  const employeeEarningsMonthData: EmployeeEarningsMonthData[] = data || [];
-
-  /* API’niz meta döndürüyorsa burada okuyun; örnek olarak sayıyoruz */
-  const totalItems = employeeEarningsMonthData.length;
-  const totalPages = Math.ceil(totalItems / paginate) || 1;
+  const employeeEarningsMonthData: EmployeeEarningsMonthData[] = rows || [];
+  const paginationMeta = meta;
+  const totalItems = paginationMeta ? paginationMeta.total : employeeEarningsMonthData.length;
+  const totalPages = paginationMeta ? paginationMeta.last_page : Math.ceil(totalItems / paginate) || 1;
 
   /* set* fonksiyonları useCallback ile sarmalanabilir (opsiyonel) */
   const memoSetPage = useCallback(setPage, []);

--- a/src/slices/employeeEarningsMonth/list/reducer.tsx
+++ b/src/slices/employeeEarningsMonth/list/reducer.tsx
@@ -1,12 +1,16 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
-import { EmployeeEarningsMonthListState, EmployeeEarningsMonthListResponse } from '../../../types/employeeEarningsMonth/list'
+import {
+  EmployeeEarningsMonthListState,
+  EmployeeEarningsMonthListResponse,
+} from '../../../types/employeeEarningsMonth/list'
 import EmployeeEarningsMonthListStatus from '../../../enums/employeeEarningsMonth/list'
 import { fetchEmployeeEarningsMonthList } from './thunk'
 
 const initialState: EmployeeEarningsMonthListState = {
-  data: null,
+  rows: null,
+  meta: null,
   status: EmployeeEarningsMonthListStatus.IDLE,
-  error: null
+  error: null,
 }
 
 const employeeEarningsMonthListSlice = createSlice({
@@ -22,7 +26,8 @@ const employeeEarningsMonthListSlice = createSlice({
       fetchEmployeeEarningsMonthList.fulfilled,
       (state, action: PayloadAction<EmployeeEarningsMonthListResponse>) => {
         state.status = EmployeeEarningsMonthListStatus.SUCCEEDED
-        state.data = action.payload.data
+        state.rows = action.payload.rows
+        state.meta = action.payload.meta
       }
     )
     builder.addCase(fetchEmployeeEarningsMonthList.rejected, (state, action: PayloadAction<any>) => {

--- a/src/slices/employeeEarningsMonth/list/thunk.tsx
+++ b/src/slices/employeeEarningsMonth/list/thunk.tsx
@@ -1,7 +1,10 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
 import axiosInstance from '../../../services/axiosClient'
 import { EMPLOYEE_EARNINGS_MONTH } from '../../../helpers/url_helper'
-import { EmployeeEarningsMonthListResponse, EmployeeEarningsMonthListArgs } from '../../../types/employeeEarningsMonth/list'
+import {
+  EmployeeEarningsMonthListResponse,
+  EmployeeEarningsMonthListArgs,
+} from '../../../types/employeeEarningsMonth/list'
 
 export const fetchEmployeeEarningsMonthList = createAsyncThunk<EmployeeEarningsMonthListResponse, EmployeeEarningsMonthListArgs>(
   'employeeEarningsMonth/fetchList',
@@ -16,9 +19,36 @@ export const fetchEmployeeEarningsMonthList = createAsyncThunk<EmployeeEarningsM
       })
       const url = `${EMPLOYEE_EARNINGS_MONTH}?${query.toString()}`
       const resp = await axiosInstance.get(url)
-      return resp.data as EmployeeEarningsMonthListResponse
+
+      const res = resp.data
+
+      if (Array.isArray(res?.data)) {
+        return {
+          rows: res.data,
+          meta: {
+            total: res.total ?? res.data.length,
+            last_page: res.last_page ?? 1,
+            current_page: res.current_page ?? 1,
+          },
+        } as EmployeeEarningsMonthListResponse
+      }
+
+      if (Array.isArray(res)) {
+        return {
+          rows: res,
+          meta: { total: res.length, last_page: 1, current_page: 1 },
+        } as EmployeeEarningsMonthListResponse
+      }
+
+      return {
+        rows: [],
+        meta: { total: 0, last_page: 1, current_page: 1 },
+      } as EmployeeEarningsMonthListResponse
     } catch (err: any) {
-      return rejectWithValue(err.response?.data?.message || 'Fetch employee earnings month list failed')
+      return rejectWithValue(
+        err.response?.data?.message ||
+          'Fetch employee earnings month list failed'
+      )
     }
   }
 )

--- a/src/types/employeeEarningsMonth/list.tsx
+++ b/src/types/employeeEarningsMonth/list.tsx
@@ -35,24 +35,20 @@ export interface ILink {
   active: boolean
 }
 
-export interface EmployeeEarningsMonthListResponse {
-  data: EmployeeEarningsMonthData[]
-  current_page: number
-  first_page_url: string
-  from: number
-  last_page: number
-  last_page_url: string
-  links: ILink[]
-  next_page_url: string | null
-  path: string
-  per_page: number
-  prev_page_url: string | null
-  to: number
+export interface EmployeeEarningsMonthMeta {
   total: number
+  last_page: number
+  current_page: number
+}
+
+export interface EmployeeEarningsMonthListResponse {
+  rows: EmployeeEarningsMonthData[]
+  meta: EmployeeEarningsMonthMeta
 }
 
 export interface EmployeeEarningsMonthListState {
-  data: EmployeeEarningsMonthData[] | null
+  rows: EmployeeEarningsMonthData[] | null
+  meta: EmployeeEarningsMonthMeta | null
   status: EmployeeEarningsMonthListStatus
   error: string | null
 }


### PR DESCRIPTION
## Summary
- prefer paginator response when fetching employee earnings month list
- store rows+meta in reducer
- update selector logic in hook
- guard table mapping for missing employee IDs
- handle missing branch/profession gracefully

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68638def735c832c902615738c1db804