### PR TITLE
Update earnings hooks for pagination

### DIFF
--- a/src/components/hooks/employeeEarningsMonth/useList.tsx
+++ b/src/components/hooks/employeeEarningsMonth/useList.tsx
@@ -6,7 +6,7 @@ import { fetchEmployeeEarningsMonthList } from "../../../slices/employeeEarnings
 import {
   EmployeeEarningsMonthData,
   EmployeeEarningsMonthListArgs,
-
+  PaginationMeta,
 } from "../../../types/employeeEarningsMonth/list";
 import EmployeeEarningsMonthListStatus from "../../../enums/employeeEarningsMonth/list";
 
@@ -71,7 +71,7 @@ export function useEmployeeEarningsMonthList(
   const [paginate, setPaginate] = useState<number>(initialPaginate);
   const [filter, setFilter] = useState<any>(null);
 
-  const { data, status, error } = useSelector(
+  const { data, status, error, meta } = useSelector(
     (state: RootState) => state.employeeEarningsMonthList
   );
 
@@ -105,10 +105,9 @@ export function useEmployeeEarningsMonthList(
   /* -------------------------------------------------------------- */
   const loading = status === EmployeeEarningsMonthListStatus.LOADING;
   const employeeEarningsMonthData: EmployeeEarningsMonthData[] = data || [];
-
-  /* API’niz meta döndürüyorsa burada okuyun; örnek olarak sayıyoruz */
-  const totalItems = employeeEarningsMonthData.length;
-  const totalPages = Math.ceil(totalItems / paginate) || 1;
+  const paginationMeta: PaginationMeta | null = meta;
+  const totalPages = paginationMeta ? paginationMeta.last_page : 1;
+  const totalItems = paginationMeta ? paginationMeta.total : 0;
 
   /* set* fonksiyonları useCallback ile sarmalanabilir (opsiyonel) */
   const memoSetPage = useCallback(setPage, []);

--- a/src/components/hooks/employeeEarningsPeriod/useList.tsx
+++ b/src/components/hooks/employeeEarningsPeriod/useList.tsx
@@ -6,9 +6,7 @@ import { fetchEmployeeEarningsPeriodList } from '../../../slices/employeeEarning
 import {
   EmployeeEarningsPeriodData,
   EmployeeEarningsPeriodListArgs,
-  EmployeeEarningsPeriodListResponse,
-  ILink,
-  EmployeeEarningsPeriodItem
+  PaginationMeta
 } from '../../../types/employeeEarningsPeriod/list'
 import EmployeeEarningsPeriodListStatus from '../../../enums/employeeEarningsPeriod/list'
 
@@ -43,7 +41,7 @@ export function useEmployeeEarningsPeriodTable(params: EmployeeEarningsPeriodLis
 
   const { data, status, error, meta } = useSelector(
     (state: RootState) => state.employeeEarningsPeriodList
-  ) as any
+  )
 
   const serializedRestParams = useMemo(
     () => JSON.stringify(restParams),
@@ -67,7 +65,7 @@ export function useEmployeeEarningsPeriodTable(params: EmployeeEarningsPeriodLis
 
   const loading = status === EmployeeEarningsPeriodListStatus.LOADING
   const employeeEarningsPeriodData: EmployeeEarningsPeriodData[] = data || []
-  const paginationMeta = meta as any
+  const paginationMeta: PaginationMeta | null = meta
   const totalPages = paginationMeta ? paginationMeta.last_page : 1
   const totalItems = paginationMeta ? paginationMeta.total : 0
 

--- a/src/slices/employeeEarningsMonth/list/reducer.tsx
+++ b/src/slices/employeeEarningsMonth/list/reducer.tsx
@@ -5,6 +5,7 @@ import { fetchEmployeeEarningsMonthList } from './thunk'
 
 const initialState: EmployeeEarningsMonthListState = {
   data: null,
+  meta: null,
   status: EmployeeEarningsMonthListStatus.IDLE,
   error: null
 }
@@ -23,6 +24,20 @@ const employeeEarningsMonthListSlice = createSlice({
       (state, action: PayloadAction<EmployeeEarningsMonthListResponse>) => {
         state.status = EmployeeEarningsMonthListStatus.SUCCEEDED
         state.data = action.payload.data
+        state.meta = {
+          current_page: action.payload.current_page,
+          first_page_url: action.payload.first_page_url,
+          from: action.payload.from,
+          last_page: action.payload.last_page,
+          last_page_url: action.payload.last_page_url,
+          next_page_url: action.payload.next_page_url,
+          path: action.payload.path,
+          per_page: action.payload.per_page,
+          prev_page_url: action.payload.prev_page_url,
+          to: action.payload.to,
+          total: action.payload.total,
+          links: action.payload.links
+        }
       }
     )
     builder.addCase(fetchEmployeeEarningsMonthList.rejected, (state, action: PayloadAction<any>) => {

--- a/src/slices/employeeEarningsPeriod/list/reducer.tsx
+++ b/src/slices/employeeEarningsPeriod/list/reducer.tsx
@@ -5,6 +5,7 @@ import { fetchEmployeeEarningsPeriodList } from './thunk'
 
 const initialState: EmployeeEarningsPeriodListState = {
   data: null,
+  meta: null,
   status: EmployeeEarningsPeriodListStatus.IDLE,
   error: null
 }
@@ -23,6 +24,20 @@ const employeeEarningsPeriodListSlice = createSlice({
       (state, action: PayloadAction<EmployeeEarningsPeriodListResponse>) => {
         state.status = EmployeeEarningsPeriodListStatus.SUCCEEDED
         state.data = action.payload.data
+        state.meta = {
+          current_page: action.payload.current_page,
+          first_page_url: action.payload.first_page_url,
+          from: action.payload.from,
+          last_page: action.payload.last_page,
+          last_page_url: action.payload.last_page_url,
+          next_page_url: action.payload.next_page_url,
+          path: action.payload.path,
+          per_page: action.payload.per_page,
+          prev_page_url: action.payload.prev_page_url,
+          to: action.payload.to,
+          total: action.payload.total,
+          links: action.payload.links
+        }
       }
     )
     builder.addCase(fetchEmployeeEarningsPeriodList.rejected, (state, action: PayloadAction<any>) => {

--- a/src/types/employeeEarningsMonth/list.tsx
+++ b/src/types/employeeEarningsMonth/list.tsx
@@ -35,6 +35,21 @@ export interface ILink {
   active: boolean
 }
 
+export interface PaginationMeta {
+  current_page: number
+  first_page_url: string
+  from: number
+  last_page: number
+  last_page_url: string
+  next_page_url: string | null
+  path: string
+  per_page: number
+  prev_page_url: string | null
+  to: number
+  total: number
+  links: ILink[]
+}
+
 export interface EmployeeEarningsMonthListResponse {
   data: EmployeeEarningsMonthData[]
   current_page: number
@@ -53,6 +68,7 @@ export interface EmployeeEarningsMonthListResponse {
 
 export interface EmployeeEarningsMonthListState {
   data: EmployeeEarningsMonthData[] | null
+  meta: PaginationMeta | null
   status: EmployeeEarningsMonthListStatus
   error: string | null
 }

--- a/src/types/employeeEarningsPeriod/list.tsx
+++ b/src/types/employeeEarningsPeriod/list.tsx
@@ -30,6 +30,21 @@ export interface ILink {
   active: boolean
 }
 
+export interface PaginationMeta {
+  current_page: number
+  first_page_url: string
+  from: number
+  last_page: number
+  last_page_url: string
+  next_page_url: string | null
+  path: string
+  per_page: number
+  prev_page_url: string | null
+  to: number
+  total: number
+  links: ILink[]
+}
+
 export interface EmployeeEarningsPeriodListResponse {
   data: EmployeeEarningsPeriodData[]
   current_page: number
@@ -48,6 +63,7 @@ export interface EmployeeEarningsPeriodListResponse {
 
 export interface EmployeeEarningsPeriodListState {
   data: EmployeeEarningsPeriodData[] | null
+  meta: PaginationMeta | null
   status: EmployeeEarningsPeriodListStatus
   error: string | null
 }


### PR DESCRIPTION
## Summary
- add `PaginationMeta` types for monthly and period earnings
- store pagination metadata in monthly and period earnings reducers
- expose pagination info from earnings hooks

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686390522ff8832ca5adaed5b13ee7ed