### PR TITLE
Fix EmployeeEarningsMonth list parsing

### DIFF
--- a/src/slices/employeeEarningsMonth/list/reducer.tsx
+++ b/src/slices/employeeEarningsMonth/list/reducer.tsx
@@ -23,21 +23,8 @@ const employeeEarningsMonthListSlice = createSlice({
       fetchEmployeeEarningsMonthList.fulfilled,
       (state, action: PayloadAction<EmployeeEarningsMonthListResponse>) => {
         state.status = EmployeeEarningsMonthListStatus.SUCCEEDED
-        state.data = action.payload.data
-        state.meta = {
-          current_page: action.payload.current_page,
-          first_page_url: action.payload.first_page_url,
-          from: action.payload.from,
-          last_page: action.payload.last_page,
-          last_page_url: action.payload.last_page_url,
-          next_page_url: action.payload.next_page_url,
-          path: action.payload.path,
-          per_page: action.payload.per_page,
-          prev_page_url: action.payload.prev_page_url,
-          to: action.payload.to,
-          total: action.payload.total,
-          links: action.payload.links
-        }
+        state.data = action.payload.rows
+        state.meta = action.payload.meta
       }
     )
     builder.addCase(fetchEmployeeEarningsMonthList.rejected, (state, action: PayloadAction<any>) => {

--- a/src/slices/employeeEarningsMonth/list/thunk.tsx
+++ b/src/slices/employeeEarningsMonth/list/thunk.tsx
@@ -3,22 +3,32 @@ import axiosInstance from '../../../services/axiosClient'
 import { EMPLOYEE_EARNINGS_MONTH } from '../../../helpers/url_helper'
 import { EmployeeEarningsMonthListResponse, EmployeeEarningsMonthListArgs } from '../../../types/employeeEarningsMonth/list'
 
-export const fetchEmployeeEarningsMonthList = createAsyncThunk<EmployeeEarningsMonthListResponse, EmployeeEarningsMonthListArgs>(
-  'employeeEarningsMonth/fetchList',
-  async (queryParams, { rejectWithValue }) => {
-    try {
-      const query = new URLSearchParams()
-      Object.entries(queryParams).forEach(([key, value]) => {
-        if (key === 'enabled') return
-        if (value !== undefined && value !== null) {
-          query.append(key, String(value))
+export const fetchEmployeeEarningsMonthList = createAsyncThunk<
+  EmployeeEarningsMonthListResponse,
+  EmployeeEarningsMonthListArgs
+>('employeeEarningsMonth/fetchList', async (queryParams, { rejectWithValue }) => {
+  try {
+    const query = new URLSearchParams()
+    Object.entries(queryParams).forEach(([key, value]) => {
+      if (key === 'enabled') return
+      if (value !== undefined && value !== null) {
+        query.append(key, String(value))
+      }
+    })
+    const url = `${EMPLOYEE_EARNINGS_MONTH}?${query.toString()}`
+    const res = await axiosInstance.get(url)
+    const rows = Array.isArray(res.data) ? res.data : res.data.data ?? []
+    const meta = Array.isArray(res.data)
+      ? { total: rows.length, last_page: 1, current_page: 1 }
+      : {
+          total: res.data.total,
+          last_page: res.data.last_page,
+          current_page: res.data.current_page
         }
-      })
-      const url = `${EMPLOYEE_EARNINGS_MONTH}?${query.toString()}`
-      const resp = await axiosInstance.get(url)
-      return resp.data as EmployeeEarningsMonthListResponse
-    } catch (err: any) {
-      return rejectWithValue(err.response?.data?.message || 'Fetch employee earnings month list failed')
-    }
+    return { rows, meta }
+  } catch (err: any) {
+    return rejectWithValue(
+      err.response?.data?.message || 'Fetch employee earnings month list failed'
+    )
   }
-)
+})

--- a/src/types/employeeEarningsMonth/list.tsx
+++ b/src/types/employeeEarningsMonth/list.tsx
@@ -14,19 +14,19 @@ export interface EmployeeEarningsMonthItem {
 }
 
 export interface EmployeeEarningsMonthData {
-  period: any
-  total(total: any): unknown
-  income_type: any
-  quantity(quantity: any): unknown
-  unit_price(unit_price: any): unknown
-  employee_id: number
+  employee_id: number | null
+  period: string
+  income_type: string
+  quantity: string
+  unit_price: string
+  total: string
   first_name: string | null
   last_name: string | null
   branch_id: number | null
   profession_id: number | null
-  branch: string | null
-  profession: string | null
-  items: EmployeeEarningsMonthItem[]
+  branch?: string | null
+  profession?: string | null
+  items?: EmployeeEarningsMonthItem[]
 }
 
 export interface ILink {
@@ -36,34 +36,14 @@ export interface ILink {
 }
 
 export interface PaginationMeta {
-  current_page: number
-  first_page_url: string
-  from: number
-  last_page: number
-  last_page_url: string
-  next_page_url: string | null
-  path: string
-  per_page: number
-  prev_page_url: string | null
-  to: number
   total: number
-  links: ILink[]
+  last_page: number
+  current_page: number
 }
 
 export interface EmployeeEarningsMonthListResponse {
-  data: EmployeeEarningsMonthData[]
-  current_page: number
-  first_page_url: string
-  from: number
-  last_page: number
-  last_page_url: string
-  links: ILink[]
-  next_page_url: string | null
-  path: string
-  per_page: number
-  prev_page_url: string | null
-  to: number
-  total: number
+  rows: EmployeeEarningsMonthData[]
+  meta: PaginationMeta
 }
 
 export interface EmployeeEarningsMonthListState {


### PR DESCRIPTION
## Summary
- fix data types for employee earnings month list
- parse list results correctly in thunk
- update reducer to store rows and meta

## Testing
- `npm run lint` *(fails: couldn't find eslint config)*
- `npm run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686393339230832c82f4543fa137a76f