### PR TITLE
Add employee work accrual month pages

### DIFF
--- a/src/components/common/employeeWorkAccruals/pages/accrual/month/MonthlyDetailModal.tsx
+++ b/src/components/common/employeeWorkAccruals/pages/accrual/month/MonthlyDetailModal.tsx
@@ -1,8 +1,7 @@
-import { useState, useMemo } from 'react'
+import { useMemo } from 'react'
 import { Modal, Button, Form } from 'react-bootstrap'
 import ReusableTable, { ColumnDefinition } from '../../../../ReusableTable'
 import { EmployeeEarningsMonthItem } from '../../../../../types/employeeEarningsMonth/list'
-import { saveMonth } from './crud'
 
 interface Props {
   row: any
@@ -20,27 +19,25 @@ const INCOME_TYPES = [
   { key: 'other', label: 'Farklı Ücret' },
 ]
 
-export default function MonthlyDataModal({ row, onClose }: Props) {
+export default function MonthlyDetailModal({ row, onClose }: Props) {
   const year = row.period?.split('-')[0] || new Date().getFullYear()
-  const [period, setPeriod] = useState(row.period || '')
+  const period = row.period
 
-  const [items, setItems] = useState<EmployeeEarningsMonthItem[]>(
-    INCOME_TYPES.map((t) => {
-      const existing = row.items?.find((i: EmployeeEarningsMonthItem) => i.income_type === t.key)
-      return {
-        id: existing?.id || 0,
-        employee_id: row.employee_id,
-        period: period,
-        income_type: t.key,
-        quantity: existing?.quantity || '0',
-        unit_price: (row as any)[`${t.key}_rate`] || existing?.unit_price || '0',
-        total: existing?.total || '0',
-        created_at: '',
-        updated_at: '',
-        platform_id: null,
-      }
-    })
-  )
+  const items: EmployeeEarningsMonthItem[] = INCOME_TYPES.map((t) => {
+    const existing = row.items?.find((i: EmployeeEarningsMonthItem) => i.income_type === t.key)
+    return {
+      id: existing?.id || 0,
+      employee_id: row.employee_id,
+      period: period,
+      income_type: t.key,
+      quantity: existing?.quantity || '0',
+      unit_price: (row as any)[`${t.key}_rate`] || existing?.unit_price || '0',
+      total: existing?.total || '0',
+      created_at: '',
+      updated_at: '',
+      platform_id: null,
+    }
+  })
 
   const columns: ColumnDefinition<EmployeeEarningsMonthItem>[] = [
     { key: 'income_type', label: 'Gelir Türü', render: (r) => INCOME_TYPES.find((t) => t.key === r.income_type)?.label },
@@ -48,18 +45,7 @@ export default function MonthlyDataModal({ row, onClose }: Props) {
     {
       key: 'quantity',
       label: 'Sayı',
-      render: (r, _open, idx) => (
-        <Form.Control
-          type='number'
-          size='sm'
-          disabled={r.income_type === 'salary'}
-          value={r.quantity}
-          onChange={(e) => {
-            const val = e.target.value
-            setItems((prev) => prev.map((it, i) => (i === idx ? { ...it, quantity: val } : it)))
-          }}
-        />
-      ),
+      render: (r) => <Form.Control type='number' size='sm' disabled value={r.quantity} />,
     },
     {
       key: 'total',
@@ -70,28 +56,11 @@ export default function MonthlyDataModal({ row, onClose }: Props) {
 
   const total = useMemo(() => items.reduce((sum, i) => sum + Number(i.quantity) * Number(i.unit_price), 0), [items])
 
-  async function handleSave() {
-    await saveMonth({ employee_id: row.employee_id, period, items })
-    onClose()
-  }
-
   return (
     <Modal show centered onHide={onClose}>
       <Modal.Header closeButton>
         <Modal.Title>
-          Personel Adı: {row.full_name}&nbsp;&nbsp; Dönem:
-          <select
-            className='ms-2 border rounded'
-            value={period}
-            onChange={(e) => setPeriod(e.target.value)}
-          >
-            {Array.from({ length: 12 }).map((_, i) => {
-              const m = String(i + 1).padStart(2, '0')
-              return (
-                <option key={m} value={`${year}-${m}`}>{`${year}-${m}`}</option>
-              )
-            })}
-          </select>
+          Personel Adı: {row.full_name}&nbsp;&nbsp; Dönem: {period}
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>
@@ -109,8 +78,7 @@ export default function MonthlyDataModal({ row, onClose }: Props) {
         <div className='text-right mt-4 font-bold'>Genel Toplam ₺ {total.toFixed(2)}</div>
       </Modal.Body>
       <Modal.Footer>
-        <Button variant='outline-secondary' onClick={onClose}>İptal</Button>
-        <Button variant='primary' onClick={handleSave}>Kaydet</Button>
+        <Button variant='outline-secondary' onClick={onClose}>Kapat</Button>
       </Modal.Footer>
     </Modal>
   )

--- a/src/components/common/employeeWorkAccruals/pages/accrual/month/crud.tsx
+++ b/src/components/common/employeeWorkAccruals/pages/accrual/month/crud.tsx
@@ -1,0 +1,16 @@
+import axiosInstance from '../../../../services/axiosClient'
+import { EMPLOYEE_EARNINGS_MONTH } from '../../../../helpers/url_helper'
+import { EmployeeEarningsMonthListResponse } from '../../../../types/employeeEarningsMonth/list'
+
+export async function getMonth(params: { employee_id: number; period: string }) {
+  const query = new URLSearchParams()
+  query.append('employee_id', String(params.employee_id))
+  query.append('period', params.period)
+  const res = await axiosInstance.get(`${EMPLOYEE_EARNINGS_MONTH}?${query.toString()}`)
+  return res.data as EmployeeEarningsMonthListResponse
+}
+
+export async function saveMonth(payload: any) {
+  const res = await axiosInstance.post(EMPLOYEE_EARNINGS_MONTH, payload)
+  return res.data
+}

--- a/src/components/common/employeeWorkAccruals/pages/accrual/month/table.tsx
+++ b/src/components/common/employeeWorkAccruals/pages/accrual/month/table.tsx
@@ -1,0 +1,104 @@
+import { useState, useEffect, useMemo } from 'react'
+import ReusableTable, { ColumnDefinition } from '../../../../ReusableTable'
+import { useEmployeeEarningsMonthList } from '../../../../../hooks/employeeEarningsMonth/useList'
+import { useContractEmployeesTable } from '../../../../../hooks/contractEmployees/useList'
+import MonthlyDataModal from './MonthlyDataModal'
+import MonthlyDetailModal from './MonthlyDetailModal'
+
+export default function EmployeeEarningsMonthTable() {
+  const currentMonth = new Date().toISOString().slice(0, 7)
+  const { employeeEarningsMonthData, loading: earningsLoading } = useEmployeeEarningsMonthList({ period: currentMonth })
+  const { contractEmployeesData, loading: contractLoading } = useContractEmployeesTable({ page: 1, pageSize: 9999 })
+
+  const loading = earningsLoading || contractLoading
+
+  const [entryRow, setEntryRow] = useState<any | null>(null)
+  const [detailRow, setDetailRow] = useState<any | null>(null)
+
+  const data = useMemo(() => {
+    return (contractEmployeesData || []).map((c) => {
+      const e = (employeeEarningsMonthData || []).find((x) => x.employee_id === (c as any).id)
+      return { ...c, ...e }
+    })
+  }, [contractEmployeesData, employeeEarningsMonthData])
+
+  const columns: ColumnDefinition<any>[] = [
+    { key: 'branch', label: 'Şube' },
+    {
+      key: 'profession_id',
+      label: 'Meslek/Branş',
+      render: (r) => (r as any).profession || String(r.profession_id),
+    },
+    { key: 'full_name', label: 'Adı Soyadı' },
+    {
+      key: 'entry',
+      label: 'Aylık Veri Girişi',
+      render: (r) => (
+        <button
+          className='btn btn-primary rounded-pill px-3'
+          onClick={() => setEntryRow(r)}
+        >
+          Aylık Veri Girişi
+        </button>
+      ),
+    },
+    {
+      key: 'contract_type',
+      label: 'Sözleşme Türü',
+      render: (r) => (r as any).contract_type_text || String(r.contract_type),
+    },
+    { key: 'weekly_workdays', label: 'Haftalık İş Günü' },
+    { key: 'salary', label: 'Maaş' },
+    { key: 'lesson_rate', label: 'Ders Ücreti' },
+    { key: 'question_rate', label: 'Soru Çözüm Ders Ücreti' },
+    {
+      key: 'question_qty',
+      label: 'Soru Çözüm Ders Sayısı',
+      render: (r) => {
+        const item = r.items?.find((i: any) => i.income_type === 'question')
+        return item ? item.quantity : '-'
+      },
+    },
+    { key: 'daily_rate', label: 'Gün Bazlı Ücret' },
+    { key: 'private_lesson_rate', label: 'Özel Ders Ücreti' },
+    { key: 'coaching_rate', label: 'Koçluk Ücreti' },
+    {
+      key: 'bonus',
+      label: 'Prim',
+      render: (r) => {
+        const item = r.items?.find((i: any) => i.income_type === 'bonus')
+        return item ? item.total : '-'
+      },
+    },
+    {
+      key: 'other',
+      label: 'Farklı Ücret',
+      render: (r) => {
+        const item = r.items?.find((i: any) => i.income_type === 'other')
+        return item ? item.total : '-'
+      },
+    },
+    {
+      key: 'total',
+      label: 'Toplam Ücret',
+      render: (r) => (r.items ? r.items.reduce((s: number, i: any) => s + Number(i.total), 0) : 0),
+    },
+    {
+      key: 'actions',
+      label: 'İşlemler',
+      render: (r) => (
+        <button className='btn btn-icon' onClick={() => setDetailRow(r)}>
+          <i className='ti ti-eye' />
+        </button>
+      ),
+    },
+  ]
+
+  return (
+    <div className='p-4'>
+      <ReusableTable<any> columns={columns} data={data} loading={loading} error={null} tableMode='single' />
+      {entryRow && <MonthlyDataModal row={entryRow} onClose={() => setEntryRow(null)} />}
+      {detailRow && <MonthlyDetailModal row={detailRow} onClose={() => setDetailRow(null)} />}
+    </div>
+  )
+}

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -437,6 +437,12 @@ const EmployeeWorkAccrualsTable = lazy(
       "../components/common/employeeWorkAccruals/pages/contract/table"
     )
 );
+const EmployeeEarningsMonthTable = lazy(
+  () =>
+    import(
+      "../components/common/employeeWorkAccruals/pages/accrual/month/table"
+    )
+);
 
 //ödev takip
 //index
@@ -2376,6 +2382,11 @@ export const Routedata = [
     id: 6711,
     path: `${import.meta.env.BASE_URL}employee-work-accruals/contract`,
     element: <EmployeeWorkAccrualsTable />,
+  },
+  {
+    id: 6712,
+    path: `${import.meta.env.BASE_URL}employee-work-accruals/month`,
+    element: <EmployeeEarningsMonthTable />,
   },
 
 


### PR DESCRIPTION
## Summary
- implement monthly accrual table and modals
- add crud helpers
- wire EmployeeEarningsMonthTable route

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6863b44416a8832c9e6c979247ce534f