### PR TITLE
Implement monthly accrual save API

### DIFF
--- a/src/components/common/employeeWorkAccruals/pages/accrual/month/crud.tsx
+++ b/src/components/common/employeeWorkAccruals/pages/accrual/month/crud.tsx
@@ -1,4 +1,5 @@
 import axiosInstance from '../../../../../../services/axiosClient'
+import axios from 'axios'
 import { EMPLOYEE_EARNINGS_MONTH } from '../../../../../../helpers/url_helper'
 import { EmployeeEarningsMonthListResponse } from '../../../../../../types/employeeEarningsMonth/list'
 
@@ -10,7 +11,25 @@ export async function getMonth(params: { employee_id: number; period: string }) 
     return res.data as EmployeeEarningsMonthListResponse
 }
 
-export async function saveMonth(payload: any) {
-    const res = await axiosInstance.post(EMPLOYEE_EARNINGS_MONTH, payload)
+const client = axios.create({
+    baseURL: import.meta.env.VITE_API_URL,
+    headers: {
+        Authorization: `Bearer ${localStorage.getItem('token')}`,
+        'Content-Type': 'application/json',
+    },
+})
+
+export async function saveMonth({ employee_id, period, items }: { employee_id: number; period: string; items: any[] }) {
+    const body = {
+        items: items.map((i) => ({
+            employee_id,
+            period,
+            income_type: i.income_type,
+            quantity: +i.quantity,
+            unit_price: +i.unit_price,
+            total: +i.quantity * +i.unit_price,
+        })),
+    }
+    const res = await client.post('/personel-hakedis/kaydet', body)
     return res.data
 }


### PR DESCRIPTION
## Summary
- create axios client for month accrual save
- post monthly accrual data to `/personel-hakedis/kaydet`

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6863ca4f70e8832cb22d92f13a946358