### PR TITLE
Fix MonthlyDataModal save payload

### DIFF
--- a/src/components/common/employeeWorkAccruals/pages/accrual/month/crud.tsx
+++ b/src/components/common/employeeWorkAccruals/pages/accrual/month/crud.tsx
@@ -19,17 +19,7 @@ const client = axios.create({
     },
 })
 
-export async function saveMonth({ employee_id, period, items }: { employee_id: number; period: string; items: any[] }) {
-    const body = {
-        items: items.map((i) => ({
-            employee_id,
-            period,
-            income_type: i.income_type,
-            quantity: +i.quantity,
-            unit_price: +i.unit_price,
-            total: +i.quantity * +i.unit_price,
-        })),
-    }
+export async function saveMonth(body: { employee_id: number; period: string; items: any[] }) {
     const res = await client.post('/personel-hakedis/kaydet', body)
     return res.data
 }


### PR DESCRIPTION
## Summary
- sync period in rows when select changes
- validate and convert items before saving
- fetch list after saving month data
- simplify saveMonth API call

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6863cc89dff8832cb055879e49268297