### PR TITLE
Add period accrual table and routing

### DIFF
--- a/src/components/common/employeeWorkAccruals/pages/accrual/period/crud.tsx
+++ b/src/components/common/employeeWorkAccruals/pages/accrual/period/crud.tsx
@@ -1,0 +1,25 @@
+import axiosInstance from '../../../../../../services/axiosClient'
+import axios from 'axios'
+import { EMPLOYEE_EARNINGS_PERIOD } from '../../../../../../helpers/url_helper'
+import { EmployeeEarningsPeriodListResponse } from '../../../../../../types/employeeEarningsPeriod/list'
+
+export async function getPeriod(params: { employee_id: number; period: string }) {
+    const query = new URLSearchParams()
+    query.append('employee_id', String(params.employee_id))
+    query.append('period', params.period)
+    const res = await axiosInstance.get(`${EMPLOYEE_EARNINGS_PERIOD}?${query.toString()}`)
+    return res.data as EmployeeEarningsPeriodListResponse
+}
+
+const client = axios.create({
+    baseURL: import.meta.env.VITE_API_URL,
+    headers: {
+        Authorization: `Bearer ${localStorage.getItem('token')}`,
+        'Content-Type': 'application/json',
+    },
+})
+
+export async function savePeriod(body: { employee_id: number; period: string; items: any[] }) {
+    const res = await client.post('/personel-hakedis/kaydet', body)
+    return res.data
+}

--- a/src/components/common/employeeWorkAccruals/pages/accrual/period/table.tsx
+++ b/src/components/common/employeeWorkAccruals/pages/accrual/period/table.tsx
@@ -1,0 +1,157 @@
+import { useState, useMemo } from 'react'
+import { Button } from 'react-bootstrap'
+import { useNavigate } from 'react-router-dom'
+import ReusableTable, { ColumnDefinition } from '../../../../ReusableTable'
+import FilterGroup, { FilterDefinition } from '../../../component/organisms/SearchFilters'
+import { useEmployeeEarningsPeriodTable } from '../../../../../hooks/employeeEarningsPeriod/useList'
+import { useContractEmployeesTable } from '../../../../../hooks/contractEmployees/useList'
+import MonthlyDetailModal from './MonthlyDetailModal'
+
+export default function EmployeeEarningsPeriodTable() {
+  const navigate = useNavigate()
+  const currentMonth = new Date().toISOString().slice(0, 7)
+
+  const [period, setPeriod] = useState(currentMonth)
+  const [employeeId, setEmployeeId] = useState('')
+
+  const { employeeEarningsPeriodData, loading: earningsLoading } =
+    useEmployeeEarningsPeriodTable({
+      period,
+      employee_id: employeeId ? Number(employeeId) : undefined,
+    })
+  const { contractEmployeesData, loading: contractLoading } =
+    useContractEmployeesTable({ page: 1, pageSize: 9999 })
+
+  const loading = earningsLoading || contractLoading
+
+  const [detailRow, setDetailRow] = useState<any | null>(null)
+
+  const employeeOptions = useMemo(
+    () =>
+      (contractEmployeesData || []).map((c: any) => ({
+        value: String(c.id),
+        label: c.full_name,
+      })),
+    [contractEmployeesData]
+  )
+
+  const monthOptions = useMemo(() => {
+    const year = new Date().getFullYear()
+    return Array.from({ length: 12 }).map((_, i) => {
+      const m = String(i + 1).padStart(2, '0')
+      return { value: `${year}-${m}`, label: `${year}-${m}` }
+    })
+  }, [])
+
+  const filteredContracts = useMemo(
+    () =>
+      (contractEmployeesData || []).filter(
+        (c: any) => !employeeId || String(c.id) === employeeId
+      ),
+    [contractEmployeesData, employeeId]
+  )
+
+  const data = useMemo(() => {
+    return filteredContracts.map((c) => {
+      const e = (employeeEarningsPeriodData || []).find(
+        (x) => x.employee_id === (c as any).id
+      )
+      return { ...c, ...e }
+    })
+  }, [filteredContracts, employeeEarningsPeriodData])
+
+  const filters: FilterDefinition[] = useMemo(
+    () => [
+      {
+        key: 'employee_id',
+        label: 'Personel',
+        type: 'select',
+        value: employeeId,
+        options: employeeOptions,
+        onChange: setEmployeeId,
+      },
+      {
+        key: 'period',
+        label: 'Dönem',
+        type: 'select',
+        value: period,
+        options: monthOptions,
+        onChange: setPeriod,
+      },
+    ],
+    [employeeId, period, employeeOptions, monthOptions]
+  )
+
+  const columns: ColumnDefinition<any>[] = [
+    { key: 'branch', label: 'Şube' },
+    {
+      key: 'profession_id',
+      label: 'Meslek/Branş',
+      render: (r) => (r as any).profession || String(r.profession_id),
+    },
+    { key: 'full_name', label: 'Adı Soyadı' },
+    {
+      key: 'contract_type',
+      label: 'Sözleşme Türü',
+      render: (r) => (r as any).contract_type_text || String(r.contract_type),
+    },
+    { key: 'weekly_workdays', label: 'Haftalık İş Günü' },
+    { key: 'salary', label: 'Maaş' },
+    { key: 'lesson_rate', label: 'Ders Ücreti' },
+    { key: 'question_rate', label: 'Soru Çözüm Ders Ücreti' },
+    {
+      key: 'question_qty',
+      label: 'Soru Çözüm Ders Sayısı',
+      render: (r) => {
+        const item = r.items?.find((i: any) => i.income_type === 'question')
+        return item ? item.quantity : '-'
+      },
+    },
+    { key: 'daily_rate', label: 'Gün Bazlı Ücret' },
+    { key: 'private_lesson_rate', label: 'Özel Ders Ücreti' },
+    { key: 'coaching_rate', label: 'Koçluk Ücreti' },
+    {
+      key: 'bonus',
+      label: 'Prim',
+      render: (r) => {
+        const item = r.items?.find((i: any) => i.income_type === 'bonus')
+        return item ? item.total : '-'
+      },
+    },
+    {
+      key: 'other',
+      label: 'Farklı Ücret',
+      render: (r) => {
+        const item = r.items?.find((i: any) => i.income_type === 'other')
+        return item ? item.total : '-'
+      },
+    },
+    {
+      key: 'total',
+      label: 'Toplam Ücret',
+      render: (r) => (r.items ? r.items.reduce((s: number, i: any) => s + Number(i.total), 0) : 0),
+    },
+    {
+      key: 'actions',
+      label: 'İşlemler',
+      render: (r) => (
+        <Button
+          variant='primary-light'
+          size='sm'
+          className='btn-icon rounded-pill'
+          onClick={() => setDetailRow(r)}
+        >
+          <i className='ti ti-eye'></i>
+        </Button>
+      ),
+    },
+  ]
+
+  return (
+    <div className='p-4'>
+      <FilterGroup filters={filters} navigate={navigate} columnsPerRow={2} />
+      <ReusableTable<any> columns={columns} data={data} loading={loading} error={null} tableMode='single' />
+      {detailRow && <MonthlyDetailModal row={detailRow} onClose={() => setDetailRow(null)} />}
+    </div>
+  )
+}

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -443,6 +443,12 @@ const EmployeeEarningsMonthTable = lazy(
       "../components/common/employeeWorkAccruals/pages/accrual/month/table"
     )
 );
+const EmployeeEarningsPeriodTable = lazy(
+  () =>
+    import(
+      "../components/common/employeeWorkAccruals/pages/accrual/period/table"
+    )
+)
 
 //ödev takip
 //index
@@ -2387,6 +2393,11 @@ export const Routedata = [
     id: 6712,
     path: `${import.meta.env.BASE_URL}employee-work-accruals/month`,
     element: <EmployeeEarningsMonthTable />,
+  },
+  {
+    id: 6713,
+    path: `${import.meta.env.BASE_URL}employee-work-accruals/period`,
+    element: <EmployeeEarningsPeriodTable />,
   },
 
 


### PR DESCRIPTION
## Summary
- implement period accrual CRUD helpers
- implement Period table page derived from month table, minus data entry column
- register new period table in routing data

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6863d62cecdc832ca7f80a2e63063db2