### PR TITLE
Add accrual index page

### DIFF
--- a/src/components/common/employeeWorkAccruals/pages/accrual/index.tsx
+++ b/src/components/common/employeeWorkAccruals/pages/accrual/index.tsx
@@ -1,0 +1,62 @@
+import React, { useState, useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import Pageheader from '../../../../page-header/pageheader';
+import TabsContainer from '../../component/organisms/TabsContainer';
+
+import EmployeeEarningsMonthTable from './month/table';
+import EmployeeEarningsPeriodTable from './period/table';
+
+const EmployeeAccrualIndex: React.FC = () => {
+    const tabs = [
+        {
+            label: 'Aylık',
+            content: <EmployeeEarningsMonthTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+        {
+            label: 'Dönem',
+            content: <EmployeeEarningsPeriodTable />,
+            activeBgColor: '#5C67F7',
+            activeTextColor: '#FFFFFF',
+            passiveBgColor: '#5C67F726',
+            passiveTextColor: '#5C67F7',
+        },
+    ];
+
+    const location = useLocation();
+    const navigate = useNavigate();
+
+    const getTabFromSearch = () => {
+        const params = new URLSearchParams(location.search);
+        const tab = params.get('tab');
+        return tab ? parseInt(tab, 10) : 0;
+    };
+
+    const [activeIdx, setActiveIdx] = useState<number>(getTabFromSearch());
+
+    useEffect(() => {
+        setActiveIdx(getTabFromSearch());
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [location.search]);
+
+    return (
+        <div>
+            <Pageheader title="Çalışma Hakediş" currentpage={tabs[activeIdx].label} />
+            <TabsContainer
+                tabs={tabs}
+                selectedIndex={activeIdx}
+                onTabChange={(parentIdx) => {
+                    setActiveIdx(parentIdx);
+                    const params = new URLSearchParams(location.search);
+                    params.set('tab', parentIdx.toString());
+                    navigate(`${location.pathname}?${params.toString()}`, { replace: true });
+                }}
+            />
+        </div>
+    );
+};
+
+export default EmployeeAccrualIndex;

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -449,6 +449,9 @@ const EmployeeEarningsPeriodTable = lazy(
       "../components/common/employeeWorkAccruals/pages/accrual/period/table"
     )
 )
+const EmployeeAccrualIndex = lazy(
+  () => import("../components/common/employeeWorkAccruals/pages/accrual")
+);
 
 //ödev takip
 //index
@@ -2398,6 +2401,11 @@ export const Routedata = [
     id: 6713,
     path: `${import.meta.env.BASE_URL}employee-work-accruals/period`,
     element: <EmployeeEarningsPeriodTable />,
+  },
+  {
+    id: 6714,
+    path: `${import.meta.env.BASE_URL}employee-work-accruals`,
+    element: <EmployeeAccrualIndex />,
   },
 
 


### PR DESCRIPTION
## Summary
- implement `EmployeeAccrualIndex` page with tab layout
- lazy load new index component
- route `/employee-work-accruals` to new index page

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6863d9c6ed24832ca5106e9d0141a85f