### PR TITLE
Fix nested tab default

### DIFF
--- a/src/components/common/employeeWorkAccruals/pages/accrual/index.tsx
+++ b/src/components/common/employeeWorkAccruals/pages/accrual/index.tsx
@@ -32,14 +32,14 @@ const EmployeeAccrualIndex: React.FC = () => {
     ];
 
     /* -------------------------------------------------------------
-       URL (?tab=0/1) -> aktif sekme senkronizasyonu
+       URL (?accrualTab=0/1) -> aktif sekme senkronizasyonu
        ------------------------------------------------------------- */
     const location = useLocation();
     const navigate = useNavigate();
 
     const getTabFromSearch = () => {
         const params = new URLSearchParams(location.search);
-        const tab = params.get('tab');
+        const tab = params.get('accrualTab');
         return tab ? parseInt(tab, 10) : 0;
     };
 
@@ -62,7 +62,7 @@ const EmployeeAccrualIndex: React.FC = () => {
 
                     /* sekme değiştiğinde URL query’sini güncelle */
                     const params = new URLSearchParams(location.search);
-                    params.set('tab', parentIdx.toString());
+                    params.set('accrualTab', parentIdx.toString());
                     navigate(`${location.pathname}?${params.toString()}`, {
                         replace: true,
                     });


### PR DESCRIPTION
## Summary
- avoid nested tab parameter conflicts by using separate query parameters

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_6863f5472ff4832cace85d2373e5848e