### PR TITLE
Add employeePayments module

### DIFF
--- a/src/components/hooks/employeePayments/useAdd.tsx
+++ b/src/components/hooks/employeePayments/useAdd.tsx
@@ -1,0 +1,21 @@
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { addEmployeePayment } from '../../../slices/employeePayments/add/thunk'
+import { EmployeePaymentAddPayload } from '../../../types/employeePayments/add'
+
+export function useEmployeePaymentAdd() {
+  const dispatch = useDispatch<AppDispatch>()
+  const { data, status, error } = useSelector((state: RootState) => state.employeePaymentAdd)
+
+  const addNewEmployeePayment = useCallback(async (payload: EmployeePaymentAddPayload) => {
+    const resultAction = await dispatch(addEmployeePayment(payload))
+    if (addEmployeePayment.fulfilled.match(resultAction)) {
+      return resultAction.payload
+    }
+    return null
+  }, [dispatch])
+
+  return { addedEmployeePayment: data, status, error, addNewEmployeePayment }
+}

--- a/src/components/hooks/employeePayments/useDelete.tsx
+++ b/src/components/hooks/employeePayments/useDelete.tsx
@@ -1,0 +1,20 @@
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { deleteEmployeePayment } from '../../../slices/employeePayments/delete/thunk'
+
+export function useEmployeePaymentDelete() {
+  const dispatch = useDispatch<AppDispatch>()
+  const { data, status, error } = useSelector((state: RootState) => state.employeePaymentDelete)
+
+  const deleteExistingEmployeePayment = useCallback(async (id: number) => {
+    const resultAction = await dispatch(deleteEmployeePayment(id))
+    if (deleteEmployeePayment.fulfilled.match(resultAction)) {
+      return resultAction.payload
+    }
+    return null
+  }, [dispatch])
+
+  return { deletedEmployeePayment: data, status, error, deleteExistingEmployeePayment }
+}

--- a/src/components/hooks/employeePayments/useDetail.tsx
+++ b/src/components/hooks/employeePayments/useDetail.tsx
@@ -1,0 +1,20 @@
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { fetchEmployeePayment } from '../../../slices/employeePayments/detail/thunk'
+
+export function useEmployeePaymentShow() {
+  const dispatch = useDispatch<AppDispatch>()
+  const { data, status, error } = useSelector((state: RootState) => state.employeePaymentShow)
+
+  const getEmployeePayment = useCallback(async (id: number) => {
+    const resultAction = await dispatch(fetchEmployeePayment(id))
+    if (fetchEmployeePayment.fulfilled.match(resultAction)) {
+      return resultAction.payload
+    }
+    return null
+  }, [dispatch])
+
+  return { employeePayment: data, status, error, getEmployeePayment }
+}

--- a/src/components/hooks/employeePayments/useList.tsx
+++ b/src/components/hooks/employeePayments/useList.tsx
@@ -1,0 +1,81 @@
+import { useState, useEffect, useMemo } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { RootState } from '../../../store/rootReducer'
+import { AppDispatch } from '../../../store'
+import { fetchEmployeePayments } from '../../../slices/employeePayments/list/thunk'
+import { EmployeePaymentData, PaginationMeta, EmployeePaymentListArg } from '../../../types/employeePayments/list'
+import EmployeePaymentListStatus from '../../../enums/employeePayments/list'
+
+export function useEmployeePaymentList(params: EmployeePaymentListArg) {
+  if (params?.enabled === false) {
+    return {
+      employeePaymentData: [] as EmployeePaymentData[],
+      loading: false,
+      error: null,
+      page: 1,
+      setPage: () => {},
+      pageSize: 10,
+      setPageSize: () => {},
+      filter: null,
+      setFilter: () => {},
+      totalPages: 1,
+      totalItems: 0
+    }
+  }
+
+  const {
+    enabled = true,
+    page: initialPage = 1,
+    pageSize: initialPageSize = 10,
+    ...restParams
+  } = params
+
+  const dispatch = useDispatch<AppDispatch>()
+  const [page, setPage] = useState<number>(initialPage)
+  const [pageSize, setPageSize] = useState<number>(initialPageSize)
+  const [filter, setFilter] = useState<any>(null)
+
+  const { data, meta, status, error } = useSelector(
+    (state: RootState) => state.employeePaymentList
+  )
+
+  const serializedRestParams = useMemo(
+    () => JSON.stringify(restParams),
+    [restParams]
+  )
+
+  useEffect(() => {
+    if (!enabled) return
+
+    const query: EmployeePaymentListArg = {
+      enabled,
+      ...restParams,
+      filter,
+      page,
+      pageSize,
+      per_page: pageSize
+    }
+
+    dispatch(fetchEmployeePayments(query))
+  }, [dispatch, enabled, serializedRestParams, filter, page, pageSize])
+
+  const loading = status === EmployeePaymentListStatus.LOADING
+  const employeePaymentData: EmployeePaymentData[] = data || []
+  const paginationMeta: PaginationMeta | null = meta
+  const totalPages = paginationMeta ? paginationMeta.last_page : 1
+  const totalItems = paginationMeta ? paginationMeta.total : 0
+
+  return {
+    employeePaymentData,
+    loading,
+    error,
+    page,
+    setPage,
+    pageSize,
+    setPageSize,
+    filter,
+    setFilter,
+    totalPages,
+    totalItems
+  }
+}

--- a/src/components/hooks/employeePayments/useUpdate.tsx
+++ b/src/components/hooks/employeePayments/useUpdate.tsx
@@ -1,0 +1,21 @@
+import { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch } from '../../../store'
+import { RootState } from '../../../store/rootReducer'
+import { updateEmployeePayment } from '../../../slices/employeePayments/update/thunk'
+import { EmployeePaymentUpdatePayload } from '../../../types/employeePayments/update'
+
+export function useEmployeePaymentUpdate() {
+  const dispatch = useDispatch<AppDispatch>()
+  const { data, status, error } = useSelector((state: RootState) => state.employeePaymentUpdate)
+
+  const updateExistingEmployeePayment = useCallback(async (payload: EmployeePaymentUpdatePayload) => {
+    const resultAction = await dispatch(updateEmployeePayment(payload))
+    if (updateEmployeePayment.fulfilled.match(resultAction)) {
+      return resultAction.payload
+    }
+    return null
+  }, [dispatch])
+
+  return { updatedEmployeePayment: data, status, error, updateExistingEmployeePayment }
+}

--- a/src/enums/employeePayments/list.tsx
+++ b/src/enums/employeePayments/list.tsx
@@ -1,0 +1,8 @@
+export enum EmployeePaymentListStatus {
+  IDLE = 'IDLE',
+  LOADING = 'LOADING',
+  SUCCEEDED = 'SUCCEEDED',
+  FAILED = 'FAILED'
+}
+
+export default EmployeePaymentListStatus;

--- a/src/helpers/url_helper.ts
+++ b/src/helpers/url_helper.ts
@@ -176,4 +176,5 @@ export const CONTRACT_EMPLOYEES = '/contract-employees';
 export const EMPLOYEE_EARNINGS = '/personel-hakedis';
 export const EMPLOYEE_EARNINGS_MONTH = '/personel-hakedis/ay';
 export const EMPLOYEE_EARNINGS_PERIOD = '/personel-hakedis/donem';
+export const EMPLOYEE_PAYMENTS = '/employee-payments';
 

--- a/src/slices/employeePayments/add/reducer.tsx
+++ b/src/slices/employeePayments/add/reducer.tsx
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { addEmployeePayment } from './thunk'
+import { EmployeePaymentAddState } from '../../../types/employeePayments/add'
+import EmployeePaymentListStatus from '../../../enums/employeePayments/list'
+
+const initialState: EmployeePaymentAddState = {
+  data: null,
+  status: EmployeePaymentListStatus.IDLE,
+  error: null
+}
+
+const employeePaymentAddSlice = createSlice({
+  name: 'employeePaymentAdd',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(addEmployeePayment.pending, state => {
+        state.status = EmployeePaymentListStatus.LOADING
+        state.error = null
+      })
+      .addCase(addEmployeePayment.fulfilled, (state, action: PayloadAction<any>) => {
+        state.status = EmployeePaymentListStatus.SUCCEEDED
+        state.data = action.payload
+      })
+      .addCase(addEmployeePayment.rejected, (state, action: PayloadAction<any>) => {
+        state.status = EmployeePaymentListStatus.FAILED
+        state.error = action.payload
+      })
+  }
+})
+
+export default employeePaymentAddSlice.reducer

--- a/src/slices/employeePayments/add/thunk.tsx
+++ b/src/slices/employeePayments/add/thunk.tsx
@@ -1,0 +1,17 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { EMPLOYEE_PAYMENTS } from '../../../helpers/url_helper'
+import { EmployeePaymentAddPayload } from '../../../types/employeePayments/add'
+import { EmployeePaymentItem } from '../../../types/employeePayments/list'
+
+export const addEmployeePayment = createAsyncThunk<EmployeePaymentItem, EmployeePaymentAddPayload>(
+  'employeePayments/addEmployeePayment',
+  async (payload, { rejectWithValue }) => {
+    try {
+      const resp = await axiosInstance.post(EMPLOYEE_PAYMENTS, payload)
+      return resp.data.data as EmployeePaymentItem
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || 'Add employee payment failed')
+    }
+  }
+)

--- a/src/slices/employeePayments/delete/reducer.tsx
+++ b/src/slices/employeePayments/delete/reducer.tsx
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { deleteEmployeePayment } from './thunk'
+import { EmployeePaymentDeleteState } from '../../../types/employeePayments/delete'
+import EmployeePaymentListStatus from '../../../enums/employeePayments/list'
+
+const initialState: EmployeePaymentDeleteState = {
+  data: null,
+  status: EmployeePaymentListStatus.IDLE,
+  error: null
+}
+
+const employeePaymentDeleteSlice = createSlice({
+  name: 'employeePaymentDelete',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(deleteEmployeePayment.pending, state => {
+        state.status = EmployeePaymentListStatus.LOADING
+        state.error = null
+      })
+      .addCase(deleteEmployeePayment.fulfilled, (state, action: PayloadAction<any>) => {
+        state.status = EmployeePaymentListStatus.SUCCEEDED
+        state.data = action.payload
+      })
+      .addCase(deleteEmployeePayment.rejected, (state, action: PayloadAction<any>) => {
+        state.status = EmployeePaymentListStatus.FAILED
+        state.error = action.payload
+      })
+  }
+})
+
+export default employeePaymentDeleteSlice.reducer

--- a/src/slices/employeePayments/delete/thunk.tsx
+++ b/src/slices/employeePayments/delete/thunk.tsx
@@ -1,0 +1,16 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { EMPLOYEE_PAYMENTS } from '../../../helpers/url_helper'
+import { EmployeePaymentDeleteState } from '../../../types/employeePayments/delete'
+
+export const deleteEmployeePayment = createAsyncThunk<EmployeePaymentDeleteState, number>(
+  'employeePayments/deleteEmployeePayment',
+  async (id, { rejectWithValue }) => {
+    try {
+      const resp = await axiosInstance.delete(`${EMPLOYEE_PAYMENTS}/${id}`)
+      return resp.data as EmployeePaymentDeleteState
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || 'Delete employee payment failed')
+    }
+  }
+)

--- a/src/slices/employeePayments/detail/reducer.tsx
+++ b/src/slices/employeePayments/detail/reducer.tsx
@@ -1,0 +1,32 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { fetchEmployeePayment } from './thunk'
+import { EmployeePaymentShowState } from '../../../types/employeePayments/detail'
+import EmployeePaymentListStatus from '../../../enums/employeePayments/list'
+
+const initialState: EmployeePaymentShowState = {
+  data: null,
+  status: EmployeePaymentListStatus.IDLE,
+  error: null
+}
+
+const employeePaymentShowSlice = createSlice({
+  name: 'employeePaymentShow',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder.addCase(fetchEmployeePayment.pending, state => {
+      state.status = EmployeePaymentListStatus.LOADING
+      state.error = null
+    })
+    builder.addCase(fetchEmployeePayment.fulfilled, (state, action: PayloadAction<any>) => {
+      state.status = EmployeePaymentListStatus.SUCCEEDED
+      state.data = action.payload
+    })
+    builder.addCase(fetchEmployeePayment.rejected, (state, action: PayloadAction<any>) => {
+      state.status = EmployeePaymentListStatus.FAILED
+      state.error = action.payload
+    })
+  }
+})
+
+export default employeePaymentShowSlice.reducer

--- a/src/slices/employeePayments/detail/thunk.tsx
+++ b/src/slices/employeePayments/detail/thunk.tsx
@@ -1,0 +1,16 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { EMPLOYEE_PAYMENTS } from '../../../helpers/url_helper'
+import { EmployeePaymentShowState } from '../../../types/employeePayments/detail'
+
+export const fetchEmployeePayment = createAsyncThunk<EmployeePaymentShowState, number>(
+  'employeePayments/fetchEmployeePayment',
+  async (id, { rejectWithValue }) => {
+    try {
+      const response = await axiosInstance.get(`${EMPLOYEE_PAYMENTS}/${id}`)
+      return response.data.data as EmployeePaymentShowState
+    } catch (error: any) {
+      return rejectWithValue(error.response?.data?.message || 'Fetch employee payment failed')
+    }
+  }
+)

--- a/src/slices/employeePayments/list/reducer.tsx
+++ b/src/slices/employeePayments/list/reducer.tsx
@@ -1,0 +1,50 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { fetchEmployeePayments } from './thunk'
+import { EmployeePaymentListState, EmployeePaymentListResponse } from '../../../types/employeePayments/list'
+import EmployeePaymentListStatus from '../../../enums/employeePayments/list'
+
+const initialState: EmployeePaymentListState = {
+  data: null,
+  meta: null,
+  status: EmployeePaymentListStatus.IDLE,
+  error: null
+}
+
+const employeePaymentListSlice = createSlice({
+  name: 'employeePaymentList',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder.addCase(fetchEmployeePayments.pending, state => {
+      state.status = EmployeePaymentListStatus.LOADING
+      state.error = null
+    })
+    builder.addCase(
+      fetchEmployeePayments.fulfilled,
+      (state, action: PayloadAction<EmployeePaymentListResponse>) => {
+        state.status = EmployeePaymentListStatus.SUCCEEDED
+        state.data = action.payload.data
+        state.meta = {
+          current_page: action.payload.current_page,
+          first_page_url: action.payload.first_page_url,
+          from: action.payload.from,
+          last_page: action.payload.last_page,
+          last_page_url: action.payload.last_page_url,
+          next_page_url: action.payload.next_page_url,
+          path: action.payload.path,
+          per_page: action.payload.per_page,
+          prev_page_url: action.payload.prev_page_url,
+          to: action.payload.to,
+          total: action.payload.total,
+          links: action.payload.links
+        }
+      }
+    )
+    builder.addCase(fetchEmployeePayments.rejected, (state, action: PayloadAction<any>) => {
+      state.status = EmployeePaymentListStatus.FAILED
+      state.error = action.payload || 'Fetch employee payments failed'
+    })
+  }
+})
+
+export default employeePaymentListSlice.reducer

--- a/src/slices/employeePayments/list/thunk.tsx
+++ b/src/slices/employeePayments/list/thunk.tsx
@@ -1,0 +1,24 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { EMPLOYEE_PAYMENTS } from '../../../helpers/url_helper'
+import { EmployeePaymentListResponse, EmployeePaymentListArg } from '../../../types/employeePayments/list'
+
+export const fetchEmployeePayments = createAsyncThunk<EmployeePaymentListResponse, EmployeePaymentListArg>(
+  'employeePayments/fetchEmployeePayments',
+  async (queryParams, { rejectWithValue }) => {
+    try {
+      const query = new URLSearchParams()
+      Object.entries(queryParams).forEach(([key, value]) => {
+        if (key === 'enabled') return
+        if (value !== undefined && value !== null) {
+          query.append(key, String(value))
+        }
+      })
+      const url = `${EMPLOYEE_PAYMENTS}?${query.toString()}`
+      const resp = await axiosInstance.get(url)
+      return resp.data as EmployeePaymentListResponse
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || 'Fetch employee payments failed')
+    }
+  }
+)

--- a/src/slices/employeePayments/update/reducer.tsx
+++ b/src/slices/employeePayments/update/reducer.tsx
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { updateEmployeePayment } from './thunk'
+import { EmployeePaymentUpdateState } from '../../../types/employeePayments/update'
+import EmployeePaymentListStatus from '../../../enums/employeePayments/list'
+
+const initialState: EmployeePaymentUpdateState = {
+  data: null,
+  status: EmployeePaymentListStatus.IDLE,
+  error: null
+}
+
+const employeePaymentUpdateSlice = createSlice({
+  name: 'employeePaymentUpdate',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(updateEmployeePayment.pending, state => {
+        state.status = EmployeePaymentListStatus.LOADING
+        state.error = null
+      })
+      .addCase(updateEmployeePayment.fulfilled, (state, action: PayloadAction<any>) => {
+        state.status = EmployeePaymentListStatus.SUCCEEDED
+        state.data = action.payload
+      })
+      .addCase(updateEmployeePayment.rejected, (state, action: PayloadAction<any>) => {
+        state.status = EmployeePaymentListStatus.FAILED
+        state.error = action.payload
+      })
+  }
+})
+
+export default employeePaymentUpdateSlice.reducer

--- a/src/slices/employeePayments/update/thunk.tsx
+++ b/src/slices/employeePayments/update/thunk.tsx
@@ -1,0 +1,17 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import axiosInstance from '../../../services/axiosClient'
+import { EMPLOYEE_PAYMENTS } from '../../../helpers/url_helper'
+import { EmployeePaymentUpdatePayload } from '../../../types/employeePayments/update'
+import { EmployeePaymentItem } from '../../../types/employeePayments/list'
+
+export const updateEmployeePayment = createAsyncThunk<EmployeePaymentItem, EmployeePaymentUpdatePayload>(
+  'employeePayments/updateEmployeePayment',
+  async ({ id, payload }, { rejectWithValue }) => {
+    try {
+      const resp = await axiosInstance.put(`${EMPLOYEE_PAYMENTS}/${id}`, payload)
+      return resp.data.data as EmployeePaymentItem
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || 'Update employee payment failed')
+    }
+  }
+)

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -646,6 +646,12 @@ import employeeEarningsPeriodDeleteSlice from '../slices/employeeEarningsPeriod/
 
 import financeNotesSlice from '../slices/financeNotes/list/reducer';
 
+import employeePaymentListReducer from '../slices/employeePayments/list/reducer'
+import employeePaymentAddReducer from '../slices/employeePayments/add/reducer'
+import employeePaymentUpdateReducer from '../slices/employeePayments/update/reducer'
+import employeePaymentDeleteReducer from '../slices/employeePayments/delete/reducer'
+import employeePaymentShowReducer from '../slices/employeePayments/detail/reducer'
+
 
 const combinedReducer = combineReducers({
   login: loginReducer,
@@ -782,6 +788,12 @@ const combinedReducer = combineReducers({
   employeeEarningsPeriodAdd: employeeEarningsPeriodAddSlice,
   employeeEarningsPeriodUpdate: employeeEarningsPeriodUpdateSlice,
   employeeEarningsPeriodDelete: employeeEarningsPeriodDeleteSlice,
+
+  employeePaymentList: employeePaymentListReducer,
+  employeePaymentAdd: employeePaymentAddReducer,
+  employeePaymentUpdate: employeePaymentUpdateReducer,
+  employeePaymentDelete: employeePaymentDeleteReducer,
+  employeePaymentShow: employeePaymentShowReducer,
 
 
   deleteCourse: coursesDeleteSlice,

--- a/src/types/employeePayments/add.tsx
+++ b/src/types/employeePayments/add.tsx
@@ -1,0 +1,21 @@
+import { EmployeePaymentItem } from './list'
+import EmployeePaymentListStatus from '../../enums/employeePayments/list'
+
+export interface EmployeePaymentAddPayload {
+  id: number
+  employee_id: number
+  period: string
+  payment_type: string
+  payment_date: string
+  payment_method: string
+  bank_name: string
+  amount: string
+  created_at: string
+  updated_at: string
+}
+
+export interface EmployeePaymentAddState {
+  data: EmployeePaymentItem | null
+  status: EmployeePaymentListStatus
+  error: string | null
+}

--- a/src/types/employeePayments/delete.tsx
+++ b/src/types/employeePayments/delete.tsx
@@ -1,0 +1,12 @@
+import { EmployeePaymentItem } from './list'
+import EmployeePaymentListStatus from '../../enums/employeePayments/list'
+
+export interface EmployeePaymentDeletePayload {
+  id?: number
+}
+
+export interface EmployeePaymentDeleteState {
+  data: EmployeePaymentItem | null
+  status: EmployeePaymentListStatus
+  error: string | null
+}

--- a/src/types/employeePayments/detail.tsx
+++ b/src/types/employeePayments/detail.tsx
@@ -1,0 +1,8 @@
+import { EmployeePaymentItem } from './list'
+import EmployeePaymentListStatus from '../../enums/employeePayments/list'
+
+export interface EmployeePaymentShowState {
+  data: EmployeePaymentItem | null
+  status: EmployeePaymentListStatus
+  error: string | null
+}

--- a/src/types/employeePayments/list.tsx
+++ b/src/types/employeePayments/list.tsx
@@ -1,0 +1,109 @@
+import EmployeePaymentListStatus from '../../enums/employeePayments/list'
+
+export interface EmployeePaymentItem {
+  id: number
+  employee_id: number
+  period: string
+  payment_type: string
+  payment_date: string
+  payment_method: string
+  bank_name: string
+  amount: string
+  created_at: string
+  updated_at: string
+}
+
+export interface ContractEmployee {
+  id: number
+  employee_id: number
+  branch_id: number
+  contract_type_id: number
+  profession_id: number
+  weekly_workdays: number
+  weekly_lessons_count: number
+  monthly_count: number
+  salary: string
+  lesson_rate: string
+  question_rate: string
+  daily_rate: string
+  private_lesson_rate: string
+  coaching_rate: string
+  platform_id: number
+  created_at: string | null
+  updated_at: string | null
+  contract_type: any
+}
+
+export interface Employee {
+  id: number
+  full_name: string
+  identification_no: string
+  birth_day: string
+  type_id: number
+  email: string
+  phone_number: string
+  address: string
+  gender_id: number
+  status: number
+  created_at: string | null
+  updated_at: string | null
+  platform_id: number
+  branch: any
+  contract_employee: ContractEmployee | null
+}
+
+export interface EmployeePaymentData {
+  employee_id: number
+  employee: Employee | null
+  total_amount: number
+  items: EmployeePaymentItem[]
+}
+
+export interface ILink {
+  url: string | null
+  label: string
+  active: boolean
+}
+
+export interface PaginationMeta {
+  current_page: number
+  first_page_url: string
+  from: number
+  last_page: number
+  last_page_url: string
+  next_page_url: string | null
+  path: string
+  per_page: number
+  prev_page_url: string | null
+  to: number
+  total: number
+  links: ILink[]
+}
+
+export interface EmployeePaymentListResponse {
+  data: EmployeePaymentData[]
+  current_page: number
+  first_page_url: string
+  from: number
+  last_page: number
+  last_page_url: string
+  links: ILink[]
+  next_page_url: string | null
+  path: string
+  per_page: number
+  prev_page_url: string | null
+  to: number
+  total: number
+}
+
+export interface EmployeePaymentListState {
+  data: EmployeePaymentData[] | null
+  meta: PaginationMeta | null
+  status: EmployeePaymentListStatus
+  error: string | null
+}
+
+export interface EmployeePaymentListArg {
+  enabled?: boolean
+  [key: string]: any
+}

--- a/src/types/employeePayments/update.tsx
+++ b/src/types/employeePayments/update.tsx
@@ -1,0 +1,23 @@
+import { EmployeePaymentItem } from './list'
+import EmployeePaymentListStatus from '../../enums/employeePayments/list'
+
+export interface EmployeePaymentUpdatePayload {
+  id: number
+  payload: {
+    employee_id?: number
+    period?: string
+    payment_type?: string
+    payment_date?: string
+    payment_method?: string
+    bank_name?: string
+    amount?: string
+    created_at?: string
+    updated_at?: string
+  }
+}
+
+export interface EmployeePaymentUpdateState {
+  data: EmployeePaymentItem | null
+  status: EmployeePaymentListStatus
+  error: string | null
+}


### PR DESCRIPTION
## Summary
- add enum and types for employeePayments
- implement Redux slices and thunks for CRUD operations
- provide React hooks for employeePayments features
- expose API constant for employee payments
- register reducers in rootReducer

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6864e98f2f38832cb9a8ae767ad4ddc9