### PR TITLE
Add personnel payments period table

### DIFF
--- a/src/components/common/employeeWorkAccruals/pages/payments/period/crud.tsx
+++ b/src/components/common/employeeWorkAccruals/pages/payments/period/crud.tsx
@@ -1,0 +1,60 @@
+import { Modal, Button, Table } from 'antd'
+import type { ColumnsType } from 'antd/es/table'
+import dayjs from 'dayjs'
+import type { EmployeePaymentData, EmployeePaymentItem } from '../../../../../../types/employeePayments/list'
+
+interface Props {
+  row: EmployeePaymentData
+  onClose: () => void
+}
+
+const currency = new Intl.NumberFormat('tr-TR', { style: 'currency', currency: 'TRY' })
+
+export default function PaymentDetailModal({ row, onClose }: Props) {
+  const items: EmployeePaymentItem[] = row.items
+
+  const columns: ColumnsType<EmployeePaymentItem> = [
+    { title: 'Ödeme Türü', dataIndex: 'payment_type', key: 'payment_type' },
+    {
+      title: 'Ödeme Tarihi',
+      dataIndex: 'payment_date',
+      key: 'payment_date',
+      render: (v: string) => (v ? dayjs(v).format('YYYY-MM-DD') : '-')
+    },
+    { title: 'Ödeme Yöntemi', dataIndex: 'payment_method', key: 'payment_method' },
+    { title: 'Banka/Kurum Adı', dataIndex: 'bank_name', key: 'bank_name' },
+    {
+      title: 'Ödenen Tutar (₺)',
+      dataIndex: 'amount',
+      key: 'amount',
+      align: 'right' as const,
+      render: (v: string) => currency.format(Number(v || 0))
+    }
+  ]
+
+  const total = items.reduce((s, i) => s + Number(i.amount || 0), 0)
+
+  return (
+    <Modal
+      open
+      title='Personel Ödeme Detay'
+      onCancel={onClose}
+      footer={[<Button key='close' onClick={onClose}>Kapat</Button>]}
+      getContainer={() => document.body}
+    >
+      <div className='mb-4 font-bold'>
+        Personel Ad: {row.employee?.full_name}&nbsp;&nbsp; Dönem:{' '}
+        {dayjs(row.items[0]?.period).format('YYYY MMM')}
+      </div>
+      <Table<EmployeePaymentItem>
+        columns={columns}
+        dataSource={items}
+        pagination={false}
+        rowKey={r => String(r.id)}
+      />
+      <div style={{ textAlign: 'right', fontWeight: 'bold', marginTop: 16 }}>
+        Toplam Ödenen {currency.format(total)}
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/common/employeeWorkAccruals/pages/payments/period/table.tsx
+++ b/src/components/common/employeeWorkAccruals/pages/payments/period/table.tsx
@@ -1,0 +1,169 @@
+import { useState, useMemo } from 'react'
+import { Table, Button, DatePicker, Select } from 'antd'
+import type { ColumnsType } from 'antd/es/table'
+import dayjs from 'dayjs'
+import { useEmployeePaymentList } from '../../../../../hooks/employeePayments/useList'
+import { useContractEmployeesTable } from '../../../../../hooks/contractEmployees/useList'
+import type { EmployeePaymentData } from '../../../../../../types/employeePayments/list'
+import PaymentDetailModal from './crud'
+
+const currency = new Intl.NumberFormat('tr-TR', { style: 'currency', currency: 'TRY' })
+
+function getAmount(row: EmployeePaymentData, type: string) {
+  const item = row.items.find(i => i.payment_type === type)
+  return item ? Number(item.amount) : 0
+}
+
+export default function PersonnelPaymentsPeriodTable() {
+  const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState(10)
+  const [employeeId, setEmployeeId] = useState<string | undefined>()
+  const [period, setPeriod] = useState(dayjs().format('YYYY-MM'))
+  const [detailRow, setDetailRow] = useState<EmployeePaymentData | null>(null)
+
+  const {
+    employeePaymentData = [],
+    loading,
+    totalItems
+  } = useEmployeePaymentList({
+    page,
+    pageSize,
+    employee_id: employeeId ? Number(employeeId) : undefined,
+    period,
+    type: 'donem'
+  })
+
+  const { contractEmployeesData } = useContractEmployeesTable({ page: 1, pageSize: 9999 })
+
+  const employeeOptions = useMemo(
+    () => (contractEmployeesData || []).map(c => ({ value: String((c as any).id), label: (c as any).full_name })),
+    [contractEmployeesData]
+  )
+
+  const columns: ColumnsType<EmployeePaymentData> = useMemo(
+    () => [
+      {
+        title: 'Okul Seviyesi',
+        key: 'branch',
+        render: (r: EmployeePaymentData) => r.employee?.branch?.name || '-'
+      },
+      {
+        title: 'Meslek / Branş',
+        key: 'profession',
+        render: (r: EmployeePaymentData) => r.employee?.contract_employee?.profession_id ?? '-'
+      },
+      {
+        title: 'Adı Soyadı',
+        key: 'full_name',
+        render: (r: EmployeePaymentData) => r.employee?.full_name || '-'
+      },
+      {
+        title: 'Sözleşme Türü',
+        key: 'contract_type',
+        render: (r: EmployeePaymentData) => r.employee?.contract_employee?.contract_type?.name || '-'
+      },
+      {
+        title: 'Toplam Ücret (₺)',
+        dataIndex: 'total_amount',
+        key: 'total',
+        align: 'right' as const,
+        render: (v: any) => currency.format(Number(v || 0))
+      },
+      {
+        title: 'Nakit Avans',
+        key: 'cash_advance',
+        align: 'right' as const,
+        render: (r: EmployeePaymentData) => currency.format(getAmount(r, 'Nakit Avans'))
+      },
+      {
+        title: 'Banka Avans',
+        key: 'bank_advance',
+        align: 'right' as const,
+        render: (r: EmployeePaymentData) => currency.format(getAmount(r, 'Banka Avans'))
+      },
+      {
+        title: 'Banka Maaş',
+        key: 'bank_salary',
+        align: 'right' as const,
+        render: (r: EmployeePaymentData) => currency.format(getAmount(r, 'Banka Maaş'))
+      },
+      {
+        title: 'Nakit',
+        key: 'cash',
+        align: 'right' as const,
+        render: (r: EmployeePaymentData) => currency.format(getAmount(r, 'Nakit'))
+      },
+      {
+        title: 'İşlemler',
+        key: 'actions',
+        render: (_: any, r: EmployeePaymentData) => (
+          <Button type='link' onClick={() => setDetailRow(r)}>
+            Detay
+          </Button>
+        )
+      }
+    ],
+    []
+  )
+
+  const total = useMemo(
+    () => employeePaymentData.reduce((s, r) => s + Number(r.total_amount || 0), 0),
+    [employeePaymentData]
+  )
+
+  return (
+    <div className='p-4'>
+      <div className='flex gap-4 mb-4'>
+        <Select
+          placeholder='Personel'
+          options={employeeOptions}
+          allowClear
+          value={employeeId}
+          onChange={v => {
+            setEmployeeId(v)
+            setPage(1)
+          }}
+          style={{ width: 200 }}
+        />
+        <DatePicker
+          picker='month'
+          format='YYYY MMM'
+          value={dayjs(period)}
+          onChange={d => {
+            setPeriod(d ? d.format('YYYY-MM') : dayjs().format('YYYY-MM'))
+            setPage(1)
+          }}
+          allowClear={false}
+        />
+      </div>
+      <Table<EmployeePaymentData>
+        rowKey={r => String(r.employee_id)}
+        columns={columns}
+        dataSource={employeePaymentData}
+        loading={loading}
+        pagination={{
+          current: page,
+          pageSize,
+          total: totalItems,
+          showSizeChanger: true,
+          onChange: (p, s) => {
+            setPage(p)
+            setPageSize(s)
+          }
+        }}
+        summary={() => (
+          <Table.Summary.Row>
+            <Table.Summary.Cell index={0} colSpan={4}>
+              <div style={{ textAlign: 'right', fontWeight: 'bold' }}>Toplam</div>
+            </Table.Summary.Cell>
+            <Table.Summary.Cell index={4} align='right' style={{ fontWeight: 'bold' }}>
+              {currency.format(total)}
+            </Table.Summary.Cell>
+            <Table.Summary.Cell index={5} colSpan={5} />
+          </Table.Summary.Row>
+        )}
+      />
+      {detailRow && <PaymentDetailModal row={detailRow} onClose={() => setDetailRow(null)} />}
+    </div>
+  )
+}

--- a/src/route/routingdata.tsx
+++ b/src/route/routingdata.tsx
@@ -579,6 +579,9 @@ const OnlineExamPage = lazy(
 const PersonnelPaymentsMonthTable = lazy(
   () => import("../components/common/employeeWorkAccruals/pages/payments/month/table")
 );
+const PersonnelPaymentsPeriodTable = lazy(
+  () => import("../components/common/employeeWorkAccruals/pages/payments/period/table")
+);
 
 
 
@@ -2473,6 +2476,11 @@ export const Routedata = [
     id: 6716,
     path: `${import.meta.env.BASE_URL}employee-payments/month`,
     element: <PersonnelPaymentsMonthTable />,
+  },
+  {
+    id: 6717,
+    path: `${import.meta.env.BASE_URL}employee-payments/period`,
+    element: <PersonnelPaymentsPeriodTable />,
   },
 
 ];


### PR DESCRIPTION
## Summary
- add payments period table with Ant Design table, filters, and total summary
- add payment detail modal for period view
- **add routing data for the new period payments table**

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68650641f000832cb6b28d0821789691