### PR TITLE
Fix undefined items error in payment table

### DIFF
--- a/src/components/common/employeeWorkAccruals/pages/payments/month/table.tsx
+++ b/src/components/common/employeeWorkAccruals/pages/payments/month/table.tsx
@@ -12,6 +12,7 @@ import PaymentDetailModal from './crud'
 const currency = new Intl.NumberFormat('tr-TR', { style: 'currency', currency: 'TRY' })
 
 function getAmounts(row: EmployeePaymentData, types: string[]) {
+    if (!Array.isArray(row.items)) return 0
     return row.items
         .filter(i => types.includes(i.payment_type))
         .reduce((s, i) => s + Number(i.amount), 0)


### PR DESCRIPTION
## Summary
- avoid `filter` crash if `items` is missing in `PersonnelPaymentsMonthTable`

## Testing
- `npm run lint` *(fails: ESLint config not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865230cfd90832cbc41857127ffa86b