### PR TITLE
Fix payment modal crash on missing items

### DIFF
--- a/src/components/common/employeeWorkAccruals/pages/payments/month/crud.tsx
+++ b/src/components/common/employeeWorkAccruals/pages/payments/month/crud.tsx
@@ -11,7 +11,7 @@ interface Props {
 const currency = new Intl.NumberFormat('tr-TR', { style: 'currency', currency: 'TRY' })
 
 export default function PaymentDetailModal({ row, onClose }: Props) {
-    const items: EmployeePaymentItem[] = row.items
+    const items: EmployeePaymentItem[] = row.items || []
 
     const columns: ColumnDefinition<EmployeePaymentItem>[] = [
         { key: 'payment_type', label: 'Ödeme Türü' },
@@ -35,7 +35,7 @@ export default function PaymentDetailModal({ row, onClose }: Props) {
         <Modal show centered onHide={onClose}>
             <Modal.Header closeButton>
                 <Modal.Title>
-                    Personel Ad: {row.employee?.full_name}&nbsp;&nbsp; Dönem: {dayjs(row.items[0]?.period).format('YYYY MMM')}
+                    Personel Ad: {row.employee?.full_name}&nbsp;&nbsp; Dönem: {dayjs(row.items?.[0]?.period).format('YYYY MMM')}
                 </Modal.Title>
             </Modal.Header>
             <Modal.Body>

--- a/src/components/common/employeeWorkAccruals/pages/payments/month/monthlyDataEntry.tsx
+++ b/src/components/common/employeeWorkAccruals/pages/payments/month/monthlyDataEntry.tsx
@@ -48,12 +48,12 @@ export default function MonthlyDataEntry({ row, filter, onClose }: Props) {
     const { updateExistingEmployeePayment } = useEmployeePaymentUpdate()
 
     const [period, setPeriod] = useState(
-        row.items[0]?.period ?? dayjs().format('YYYY-MM'),
+        row.items?.[0]?.period ?? dayjs().format('YYYY-MM'),
     )
     const [items, setItems] = useState<Item[]>(
         TYPES.map((t) => {
             const ex =
-                row.items.find(
+                row.items?.find(
                     (i: EmployeePaymentItem) => i.payment_type === t,
                 ) ?? null
             return {

--- a/src/components/common/employeeWorkAccruals/pages/payments/period/crud.tsx
+++ b/src/components/common/employeeWorkAccruals/pages/payments/period/crud.tsx
@@ -11,7 +11,7 @@ interface Props {
 const currency = new Intl.NumberFormat('tr-TR', { style: 'currency', currency: 'TRY' })
 
 export default function PaymentDetailModal({ row, onClose }: Props) {
-  const items: EmployeePaymentItem[] = row.items
+  const items: EmployeePaymentItem[] = row.items || []
 
   const columns: ColumnDefinition<EmployeePaymentItem>[] = [
     { key: 'payment_type', label: 'Ödeme Türü' },
@@ -37,9 +37,9 @@ export default function PaymentDetailModal({ row, onClose }: Props) {
         <Modal.Title>Personel Ödeme Detay</Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        <div className='mb-2 fw-bold'>
-          Personel Ad: {row.employee?.full_name}&nbsp;&nbsp; Dönem: {dayjs(row.items[0]?.period).format('YYYY MMM')}
-        </div>
+          <div className='mb-2 fw-bold'>
+            Personel Ad: {row.employee?.full_name}&nbsp;&nbsp; Dönem: {dayjs(row.items?.[0]?.period).format('YYYY MMM')}
+          </div>
         <ReusableTable<EmployeePaymentItem>
           tableMode='single'
           columns={columns}

--- a/src/components/common/employeeWorkAccruals/pages/payments/period/table.tsx
+++ b/src/components/common/employeeWorkAccruals/pages/payments/period/table.tsx
@@ -12,7 +12,7 @@ import PaymentDetailModal from './crud'
 const currency = new Intl.NumberFormat('tr-TR', { style: 'currency', currency: 'TRY' })
 
 function getAmount(row: EmployeePaymentData, type: string) {
-  const item = row.items.find(i => i.payment_type === type)
+  const item = row.items?.find(i => i.payment_type === type)
   return item ? Number(item.amount) : 0
 }
 


### PR DESCRIPTION
## Summary
- guard against empty `row.items` when editing monthly payments
- avoid errors in monthly payment modal for missing items
- handle undefined item arrays in period payment views

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6865249784dc832c81e8d5c3e7497de6